### PR TITLE
Added custom headers as client's configuration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ docs
 coverage
 
 .DS_Store
+lsp/
+.idea/

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,9 @@ export interface Config {
   host: string;
   timeout?: number;
   strictGDPR?: boolean;
+  headers?: {
+    [key: string]: number | string | boolean;
+  };
   authentication?: {
     jwt?: {
       iss: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,8 +178,12 @@ export class Client {
   private requestInstance: AxiosInstance;
 
   constructor(private readonly config: Config) {
-    const headers = config.hasOwnProperty('strictGDPR') &&
-      { 'x-atlassian-force-account-id': config.strictGDPR };
+
+    const headers = config.headers || {};
+
+    if (config.hasOwnProperty('strictGDPR')) {
+      headers['x-atlassian-force-account-id'] = !!config.strictGDPR;
+    }
 
     this.requestInstance = axios.create({
       baseURL: config.host,


### PR DESCRIPTION
Sometimes we may need to use some custom headers like e.g. `X-Atlassian-Token:no-check`.
I added this option to `Client` class and `Config` interface.
Thank you.