### PR TITLE
Fix changelog typings in issueBean.ts (both v2 and v3)

### DIFF
--- a/src/version2/models/issueBean.ts
+++ b/src/version2/models/issueBean.ts
@@ -28,7 +28,7 @@ export interface IssueBean {
   /** The metadata for the fields on the issue that can be amended. */
   editmeta?: IssueUpdateMetadata[];
   /** Details of changelogs associated with the issue. */
-  changelog?: PageOfChangelogs[];
+  changelog?: PageOfChangelogs;
   /** The versions of each field on the issue. */
   versionedRepresentations?: {};
   fieldsToInclude?: IncludedFields;

--- a/src/version3/models/issueBean.ts
+++ b/src/version3/models/issueBean.ts
@@ -28,7 +28,7 @@ export interface IssueBean {
   /** The metadata for the fields on the issue that can be amended. */
   editmeta?: IssueUpdateMetadata[];
   /** Details of changelogs associated with the issue. */
-  changelog?: PageOfChangelogs[];
+  changelog?: PageOfChangelogs;
   /** The versions of each field on the issue. */
   versionedRepresentations?: {};
   fieldsToInclude?: IncludedFields;


### PR DESCRIPTION
I've encountered this issue while was using 'searchForIssuesUsingJql` API: the typing does not match returned data. 

After consulting [the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-get), it turns out it is indeed wrong: `IssueBean.changelog` should not be an array.