### PR TITLE
fix(bugfix): SendCustomHeaderForAddAttachmentApi as per the jira api …

### DIFF
--- a/src/version2/issueAttachments.ts
+++ b/src/version2/issueAttachments.ts
@@ -312,6 +312,7 @@ export class IssueAttachments {
       url: `/rest/api/2/issue/${parameters.issueIdOrKey}/attachments`,
       method: 'POST',
       headers: {
+        'X-Atlassian-Token': 'no-check',
         'Content-Type': 'multipart/form-data',
         ...formData.getHeaders?.(),
       },

--- a/src/version3/issueAttachments.ts
+++ b/src/version3/issueAttachments.ts
@@ -312,6 +312,7 @@ export class IssueAttachments {
       url: `/rest/api/3/issue/${parameters.issueIdOrKey}/attachments`,
       method: 'POST',
       headers: {
+        'X-Atlassian-Token': 'no-check',
         'Content-Type': 'multipart/form-data',
         ...formData.getHeaders?.(),
       },


### PR DESCRIPTION
As per the JIRA Api doc,
We need to pass a custom header for Attachment api. (adding a new attachment to an issue)
https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post

`'X-Atlassian-Token': 'no-check'`

Issue: Without this header, currently the post request received error like `XSRF check failed`

Similar issues reported: https://ecosystem.atlassian.net/browse/ACJIRA-317

Please review the PR.
Thanks