### PR TITLE
Fix updateComment payload

### DIFF
--- a/src/version2/issueComments.ts
+++ b/src/version2/issueComments.ts
@@ -244,7 +244,9 @@ export class IssueComments {
       params: {
         expand: parameters.expand,
       },
-      data: parameters.body,
+      data: {
+        body: parameters.body,
+      },
     };
 
     return this.client.sendRequest(config, callback);

--- a/src/version3/issueComments.ts
+++ b/src/version3/issueComments.ts
@@ -245,7 +245,9 @@ export class IssueComments {
         notifyUsers: parameters.notifyUsers,
         expand: parameters.expand,
       },
-      data: parameters.body,
+      data: {
+        body: parameters.body,
+      },
     };
 
     return this.client.sendRequest(config, callback);

--- a/tests/integration/version2/issueComments.test.ts
+++ b/tests/integration/version2/issueComments.test.ts
@@ -1,0 +1,54 @@
+import {
+  cleanupEnvironment,
+  getVersion2Client,
+  prepareEnvironment,
+} from '../utils';
+import { Constants } from '../constants';
+
+describe('IssueAttachments', () => {
+  beforeAll(async () => {
+    await prepareEnvironment();
+  });
+
+  afterAll(async () => {
+    await cleanupEnvironment();
+  });
+
+  it('should update comment', async () => {
+    const client = getVersion2Client({ noCheckAtlassianToken: true });
+
+    const issue = await client.issues.createIssue({
+      fields: {
+        summary: 'Issue with comments',
+        project: {
+          key: Constants.testProjectKey,
+        },
+        issuetype: {
+          name: 'Task',
+        },
+      },
+    });
+
+    expect(issue).toBeDefined();
+
+    const comment = await client.issueComments.addComment({
+      issueIdOrKey: issue.key,
+      body: 'this is a comment',
+    });
+
+    expect(comment).toBeDefined();
+
+    const updatedComment = await client.issueComments.updateComment({
+      issueIdOrKey: issue.key,
+      id: comment.id,
+      body: 'updated comment',
+    });
+
+    expect(updatedComment).toBeDefined();
+    expect(updatedComment.id).toEqual(comment.id);
+
+    await client.issues.deleteIssue({
+      issueIdOrKey: issue.key,
+    });
+  });
+});

--- a/tests/integration/version3/issueComments.test.ts
+++ b/tests/integration/version3/issueComments.test.ts
@@ -1,0 +1,54 @@
+import {
+  cleanupEnvironment,
+  getVersion3Client,
+  prepareEnvironment,
+} from '../utils';
+import { Constants } from '../constants';
+
+describe('IssueAttachments', () => {
+  beforeAll(async () => {
+    await prepareEnvironment();
+  });
+
+  afterAll(async () => {
+    await cleanupEnvironment();
+  });
+
+  it('should update comment', async () => {
+    const client = getVersion3Client({ noCheckAtlassianToken: true });
+
+    const issue = await client.issues.createIssue({
+      fields: {
+        summary: 'Issue with comments',
+        project: {
+          key: Constants.testProjectKey,
+        },
+        issuetype: {
+          name: 'Task',
+        },
+      },
+    });
+
+    expect(issue).toBeDefined();
+
+    const comment = await client.issueComments.addComment({
+      issueIdOrKey: issue.key,
+      body: 'this is a comment',
+    });
+
+    expect(comment).toBeDefined();
+
+    const updatedComment = await client.issueComments.updateComment({
+      issueIdOrKey: issue.key,
+      id: comment.id,
+      body: 'updated comment',
+    });
+
+    expect(updatedComment).toBeDefined();
+    expect(updatedComment.id).toEqual(comment.id);
+
+    await client.issues.deleteIssue({
+      issueIdOrKey: issue.key,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #183 

Payload is currently set to send the body as a string, this causes
payload to be encoded as form-data not json. Passing a json object
solves this and avoids the 405 error from the API.

Added a couple integration tests, but did not have a place to run against, will check results of workflows to see if fixes are needed.