### PR TITLE
Add support for passing along accountID when adding watcher to Jira issue

### DIFF
--- a/src/version2/issueWatchers.ts
+++ b/src/version2/issueWatchers.ts
@@ -92,6 +92,10 @@ export class IssueWatchers {
     const config: RequestConfig = {
       url: `/rest/api/2/issue/${parameters.issueIdOrKey}/watchers`,
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: parameters.accountId,
     };
 
     return this.client.sendRequest(config, callback);

--- a/src/version2/parameters/addWatcher.ts
+++ b/src/version2/parameters/addWatcher.ts
@@ -1,4 +1,7 @@
 export interface AddWatcher {
   /** The ID or key of the issue. */
   issueIdOrKey: string;
+
+  /** Account id for specific user. */
+  accountId?: string;
 }

--- a/src/version3/issueWatchers.ts
+++ b/src/version3/issueWatchers.ts
@@ -141,6 +141,10 @@ export class IssueWatchers {
     const config: RequestConfig = {
       url: `/rest/api/3/issue/${parameters.issueIdOrKey}/watchers`,
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: parameters.accountId,
     };
 
     return this.client.sendRequest(config, callback);

--- a/src/version3/parameters/addWatcher.ts
+++ b/src/version3/parameters/addWatcher.ts
@@ -1,4 +1,7 @@
 export interface AddWatcher {
   /** The ID or key of the issue. */
   issueIdOrKey: string;
+
+  /** Account id for specific user. */
+  accountId?: string;
 }


### PR DESCRIPTION
## Problem
- The only functionality in `jira.js` to add a watcher to an issue is by using the current user. Their API does however offer the functionality to pass along an optional `accountID` to assign someone else as watched based on their Jira ID. This is a crucial functionality for my usage.


## Change
- Added `accountId` property to `addWatcher`
- Added `application/json` as header to make API call work. 415 status code gets returned if this doesn't get added.

## How to test
- Manually tested this against our own hosted Jira solution. Both for regression, as well as for adding a custom user.