### PR TITLE
Fix ignored body in setDashboardItemProperty

### DIFF
--- a/src/version2/dashboards.ts
+++ b/src/version2/dashboards.ts
@@ -493,6 +493,10 @@ export class Dashboards {
     const config: RequestConfig = {
       url: `/rest/api/2/dashboard/${parameters.dashboardId}/items/${parameters.itemId}/properties/${parameters.propertyKey}`,
       method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: parameters.body,
     };
 
     return this.client.sendRequest(config, callback);

--- a/src/version3/dashboards.ts
+++ b/src/version3/dashboards.ts
@@ -492,6 +492,10 @@ export class Dashboards {
     const config: RequestConfig = {
       url: `/rest/api/3/dashboard/${parameters.dashboardId}/items/${parameters.itemId}/properties/${parameters.propertyKey}`,
       method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: parameters.body,
     };
 
     return this.client.sendRequest(config, callback);


### PR DESCRIPTION
This fixes a bug where the body is ignored and not sent in `dashboards.setDashboardItemProperty()`.
I also added the `Content-Type: application/json` header to avoid receiving a 415 response from Jira.

API docs: [Set dashboard item property](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-dashboards/#api-rest-api-3-dashboard-dashboardid-items-itemid-properties-propertykey-put)