### PR TITLE
Respect the configured expiry time in JWT authentication

### DIFF
--- a/src/services/authenticationService/authentications/createJWTAuthentication.ts
+++ b/src/services/authenticationService/authentications/createJWTAuthentication.ts
@@ -11,7 +11,7 @@ export function createJWTAuthentication(
   const { method, url } = requestData;
 
   const now = Math.floor(Date.now() / 1000);
-  const expire = now + 180;
+  const expire = now + (authenticationData.expiryTimeSeconds ?? 180);
 
   const request = jwt.fromMethodAndUrl(method, url);
   const tokenData = {


### PR DESCRIPTION
Previously the `expiryTimeSeconds` was not respected.