### PR TITLE
addComment V3 support simple string body

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,10 @@
 {
-  "plugins": [
-    "prettier-plugin-jsdoc"
-  ]
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-jsdoc"],
+  "printWidth": 120,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
 }

--- a/src/version3/issueComments.ts
+++ b/src/version3/issueComments.ts
@@ -24,7 +24,7 @@ export class IssueComments {
    */
   async getCommentsByIds<T = Models.PageComment>(
     parameters: Parameters.GetCommentsByIds,
-    callback: Callback<T>
+    callback: Callback<T>,
   ): Promise<void>;
   /**
    * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#pagination) list of
@@ -77,7 +77,7 @@ export class IssueComments {
    */
   async getComments<T = Models.PageOfComments>(
     parameters: Parameters.GetComments | string,
-    callback: Callback<T>
+    callback: Callback<T>,
   ): Promise<void>;
   /**
    * Returns all comments for an issue.
@@ -96,7 +96,7 @@ export class IssueComments {
    */
   async getComments<T = Models.PageOfComments>(
     parameters: Parameters.GetComments | string,
-    callback?: never
+    callback?: never,
   ): Promise<T>;
   async getComments<T = Models.PageOfComments>(
     parameters: Parameters.GetComments | string,
@@ -145,7 +145,23 @@ export class IssueComments {
    */
   async addComment<T = Models.Comment>(parameters: Parameters.AddComment, callback?: never): Promise<T>;
   async addComment<T = Models.Comment>(parameters: Parameters.AddComment, callback?: Callback<T>): Promise<void | T> {
-    // todo add simple comment structure (string)
+    const getBody = (body: Parameters.AddComment['body']): Models.Document | undefined => {
+      if (typeof body === 'string') {
+        return {
+          type: 'doc',
+          version: 1,
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: body }],
+            },
+          ],
+        };
+      }
+
+      return body;
+    };
+    const body = getBody(parameters.body);
 
     const config: RequestConfig = {
       url: `/rest/api/3/issue/${parameters.issueIdOrKey}/comment`,
@@ -157,7 +173,7 @@ export class IssueComments {
         self: parameters.self,
         id: parameters.id,
         author: parameters.author,
-        body: parameters.body,
+        body,
         renderedBody: parameters.renderedBody,
         updateAuthor: parameters.updateAuthor,
         created: parameters.created,

--- a/src/version3/issueComments.ts
+++ b/src/version3/issueComments.ts
@@ -145,23 +145,16 @@ export class IssueComments {
    */
   async addComment<T = Models.Comment>(parameters: Parameters.AddComment, callback?: never): Promise<T>;
   async addComment<T = Models.Comment>(parameters: Parameters.AddComment, callback?: Callback<T>): Promise<void | T> {
-    const getBody = (body: Parameters.AddComment['body']): Models.Document | undefined => {
-      if (typeof body === 'string') {
-        return {
-          type: 'doc',
-          version: 1,
-          content: [
-            {
-              type: 'paragraph',
-              content: [{ type: 'text', text: body }],
-            },
-          ],
-        };
-      }
-
-      return body;
-    };
-    const body = getBody(parameters.body);
+    const body = typeof parameters.body === 'string' ? {
+      type: 'doc',
+      version: 1,
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: parameters.body }],
+        },
+      ],
+    } : parameters.body;
 
     const config: RequestConfig = {
       url: `/rest/api/3/issue/${parameters.issueIdOrKey}/comment`,

--- a/src/version3/parameters/addComment.ts
+++ b/src/version3/parameters/addComment.ts
@@ -1,6 +1,6 @@
-import { Comment } from '../models';
+import { Comment, Document } from '../models';
 
-export interface AddComment extends Comment {
+export interface AddComment extends Omit<Comment, 'body'> {
   /** The ID or key of the issue. */
   issueIdOrKey: string;
   /**
@@ -9,4 +9,5 @@ export interface AddComment extends Comment {
    * rendered in HTML.
    */
   expand?: string;
+  body?: string | Document;
 }

--- a/src/version3/parameters/addComment.ts
+++ b/src/version3/parameters/addComment.ts
@@ -9,5 +9,9 @@ export interface AddComment extends Omit<Comment, 'body'> {
    * rendered in HTML.
    */
   expand?: string;
+  /**
+   * The comment text in [Atlassian Document
+   * Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/).
+   */
   body?: string | Document;
 }

--- a/tests/unit/version3/issueComments.test.ts
+++ b/tests/unit/version3/issueComments.test.ts
@@ -39,3 +39,40 @@ test('addComment should accept follow parameters', t => {
     visibility: undefined,
   });
 });
+
+test('addComment should accept body string and convert to simple Document', t => {
+  const client = new Version3Client({
+    host: 'http://localhost',
+    newErrorHandling: true,
+  });
+  const sendRequestStub = sinon.stub(client, 'sendRequest');
+
+  client.issueComments.addComment({
+    issueIdOrKey: 'key',
+    body: 'Comment',
+  });
+
+  t.truthy(sendRequestStub.calledOnce);
+
+  const callArgument = sendRequestStub.getCall(0).args[0];
+
+  t.is(callArgument.url, '/rest/api/3/issue/key/comment');
+  t.deepEqual(callArgument.data, {
+    author: undefined,
+    body: {
+      type: 'doc',
+      version: 1,
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Comment' }] }],
+    },
+    created: undefined,
+    id: undefined,
+    jsdAuthorCanSeeRequest: undefined,
+    jsdPublic: undefined,
+    properties: undefined,
+    renderedBody: undefined,
+    self: undefined,
+    updateAuthor: undefined,
+    updated: undefined,
+    visibility: undefined,
+  });
+});


### PR DESCRIPTION
I was implementing adding a comment to an issue with api V3 and stumbled on this todo
https://github.com/MrRefactoring/jira.js/blob/5d9a19bafd6d53744498da2780f3fb0ed7aca668/src/version3/issueComments.ts#L147-L150

Since I basically implemented the same thing in my project, I figured I'd take a stab at it directly here.

I had to tweak .prettierrc to match closer the .editorconfig file because the linter was complaining a lot about some choices Prettier made.
I still had an indentation issue with a ternary, but worked around the problem by making a function instead