### PR TITLE
Remove tslib as a dependency as it's not called anywhere in the codebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.2",
-        "form-data": "^4.0.0",
-        "tslib": "^2.6.3"
+        "form-data": "^4.0.0"
       },
       "devDependencies": {
         "@swc-node/register": "^1.9.2",
@@ -6142,6 +6141,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   },
   "dependencies": {
     "axios": "^1.7.2",
-    "form-data": "^4.0.0",
-    "tslib": "^2.6.3"
+    "form-data": "^4.0.0"
   }
 }


### PR DESCRIPTION
I see it's a devDependency of the `@swc-node` packages imported but not sure why it's listed here as a dependency as I wasn't able to see any uses of it in the codebase.

While packaging a lambda we have that uses your library (thank you for this ❤️ ), we came across this breaking as we strip out the devDependencies from our lambda packaging to have a smaller deployment artifact.