### PR TITLE
Wrong types for projectId

### DIFF
--- a/src/version2/models/version.ts
+++ b/src/version2/models/version.ts
@@ -59,7 +59,7 @@ export interface Version {
    * The ID of the project to which this version is attached. Required when creating a version. Not applicable when
    * updating a version.
    */
-  projectId: number;
+  projectId: string | number;
   /**
    * The URL of the self link to the version to which all unfixed issues are moved when a version is released. Not
    * applicable when creating a version. Optional when updating a version.

--- a/src/version2/parameters/addActorUsers.ts
+++ b/src/version2/parameters/addActorUsers.ts
@@ -2,7 +2,7 @@ import { ActorsMap } from '../models';
 
 export interface AddActorUsers extends ActorsMap {
   /** The project ID or project key (case-sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The ID of the project role. Use [Get all project roles](#api-rest-api-2-role-get) to get a list of project role
    * IDs.

--- a/src/version2/parameters/archiveProject.ts
+++ b/src/version2/parameters/archiveProject.ts
@@ -1,4 +1,4 @@
 export interface ArchiveProject {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/createProjectAvatar.ts
+++ b/src/version2/parameters/createProjectAvatar.ts
@@ -1,8 +1,16 @@
 export interface CreateProjectAvatar {
   /** The ID or (case-sensitive) key of the project. */
   projectIdOrKey: string | number;
-  avatar: any;
   /** The X coordinate of the top-left corner of the crop region. */
   x?: number;
   /** The Y coordinate of the top-left corner of the crop region. */
   y?: number;
+  /**
+   * The length of each side of the crop region.
+   *
+   * @default 0
+   */
+  size?: number;
+  mimeType: string;
+  avatar: Buffer | ArrayBuffer | Uint8Array | any;
+}

--- a/src/version2/parameters/createProjectAvatar.ts
+++ b/src/version2/parameters/createProjectAvatar.ts
@@ -1,16 +1,8 @@
 export interface CreateProjectAvatar {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
+  avatar: any;
   /** The X coordinate of the top-left corner of the crop region. */
   x?: number;
   /** The Y coordinate of the top-left corner of the crop region. */
   y?: number;
-  /**
-   * The length of each side of the crop region.
-   *
-   * @default 0
-   */
-  size?: number;
-  mimeType: string;
-  avatar: Buffer | ArrayBuffer | Uint8Array;
-}

--- a/src/version2/parameters/deleteActor.ts
+++ b/src/version2/parameters/deleteActor.ts
@@ -1,6 +1,6 @@
 export interface DeleteActor {
   /** The project ID or project key (case-sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The ID of the project role. Use [Get all project roles](#api-rest-api-2-role-get) to get a list of project role
    * IDs.

--- a/src/version2/parameters/deleteProject.ts
+++ b/src/version2/parameters/deleteProject.ts
@@ -1,6 +1,6 @@
 export interface DeleteProject {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** Whether this project is placed in the Jira recycle bin where it will be available for restoration. */
   enableUndo?: boolean;
 }

--- a/src/version2/parameters/deleteProjectAsynchronously.ts
+++ b/src/version2/parameters/deleteProjectAsynchronously.ts
@@ -1,4 +1,4 @@
 export interface DeleteProjectAsynchronously {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/deleteProjectAvatar.ts
+++ b/src/version2/parameters/deleteProjectAvatar.ts
@@ -1,6 +1,6 @@
 export interface DeleteProjectAvatar {
   /** The project ID or (case-sensitive) key. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The ID of the avatar. */
   id: number;
 }

--- a/src/version2/parameters/deleteProjectProperty.ts
+++ b/src/version2/parameters/deleteProjectProperty.ts
@@ -1,6 +1,6 @@
 export interface DeleteProjectProperty {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The project property key. Use [Get project property keys](#api-rest-api-2-project-projectIdOrKey-properties-get) to
    * get a list of all project property keys.

--- a/src/version2/parameters/getAllProjectAvatars.ts
+++ b/src/version2/parameters/getAllProjectAvatars.ts
@@ -1,4 +1,4 @@
 export interface GetAllProjectAvatars {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/getAllStatuses.ts
+++ b/src/version2/parameters/getAllStatuses.ts
@@ -1,4 +1,4 @@
 export interface GetAllStatuses {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/getFeaturesForProject.ts
+++ b/src/version2/parameters/getFeaturesForProject.ts
@@ -1,4 +1,4 @@
 export interface GetFeaturesForProject {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/getFieldConfigurationSchemeProjectMapping.ts
+++ b/src/version2/parameters/getFieldConfigurationSchemeProjectMapping.ts
@@ -7,5 +7,5 @@ export interface GetFieldConfigurationSchemeProjectMapping {
    * The list of project IDs. To include multiple projects, separate IDs with ampersand:
    * `projectId=10000&projectId=10001`.
    */
-  projectId: number[];
+  projectId: (string | number)[];
 }

--- a/src/version2/parameters/getHierarchy.ts
+++ b/src/version2/parameters/getHierarchy.ts
@@ -1,4 +1,4 @@
 export interface GetHierarchy {
   /** The ID of the project. */
-  projectId: number;
+  projectId: string | number;
 }

--- a/src/version2/parameters/getIssueTypeSchemeForProjects.ts
+++ b/src/version2/parameters/getIssueTypeSchemeForProjects.ts
@@ -7,5 +7,5 @@ export interface GetIssueTypeSchemeForProjects {
    * The list of project IDs. To include multiple project IDs, provide an ampersand-separated list. For example,
    * `projectId=10000&projectId=10001`.
    */
-  projectId: number[];
+  projectId: (string | number)[];
 }

--- a/src/version2/parameters/getIssueTypeScreenSchemeProjectAssociations.ts
+++ b/src/version2/parameters/getIssueTypeScreenSchemeProjectAssociations.ts
@@ -7,5 +7,5 @@ export interface GetIssueTypeScreenSchemeProjectAssociations {
    * The list of project IDs. To include multiple projects, separate IDs with ampersand:
    * `projectId=10000&projectId=10001`.
    */
-  projectId: number[];
+  projectId: (string | number)[];
 }

--- a/src/version2/parameters/getIssueTypesForProject.ts
+++ b/src/version2/parameters/getIssueTypesForProject.ts
@@ -1,6 +1,6 @@
 export interface GetIssueTypesForProject {
   /** The ID of the project. */
-  projectId: number;
+  projectId: string | number;
   /**
    * The level of the issue type to filter by. Use:
    *

--- a/src/version2/parameters/getProjectComponents.ts
+++ b/src/version2/parameters/getProjectComponents.ts
@@ -1,4 +1,4 @@
 export interface GetProjectComponents {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/getProjectComponentsPaginated.ts
+++ b/src/version2/parameters/getProjectComponentsPaginated.ts
@@ -1,6 +1,6 @@
 export interface GetProjectComponentsPaginated {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The index of the first item to return in a page of results (page offset). */
   startAt?: number;
   /** The maximum number of items to return per page. */

--- a/src/version2/parameters/getProjectEmail.ts
+++ b/src/version2/parameters/getProjectEmail.ts
@@ -1,4 +1,4 @@
 export interface GetProjectEmail {
   /** The project ID. */
-  projectId: number;
+  projectId: string | number;
 }

--- a/src/version2/parameters/getProjectProperty.ts
+++ b/src/version2/parameters/getProjectProperty.ts
@@ -1,6 +1,6 @@
 export interface GetProjectProperty {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The project property key. Use [Get project property keys](#api-rest-api-2-project-projectIdOrKey-properties-get) to
    * get a list of all project property keys.

--- a/src/version2/parameters/getProjectPropertyKeys.ts
+++ b/src/version2/parameters/getProjectPropertyKeys.ts
@@ -1,4 +1,4 @@
 export interface GetProjectPropertyKeys {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/getProjectRole.ts
+++ b/src/version2/parameters/getProjectRole.ts
@@ -1,6 +1,6 @@
 export interface GetProjectRole {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The ID of the project role. Use [Get all project roles](#api-rest-api-2-role-get) to get a list of project role
    * IDs.

--- a/src/version2/parameters/getProjectRoleDetails.ts
+++ b/src/version2/parameters/getProjectRoleDetails.ts
@@ -1,6 +1,6 @@
 export interface GetProjectRoleDetails {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** Whether the roles should be filtered to include only those the user is assigned to. */
   currentMember?: boolean;
   excludeConnectAddons?: boolean;

--- a/src/version2/parameters/getProjectRoles.ts
+++ b/src/version2/parameters/getProjectRoles.ts
@@ -1,4 +1,4 @@
 export interface GetProjectRoles {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/getProjectVersions.ts
+++ b/src/version2/parameters/getProjectVersions.ts
@@ -1,6 +1,6 @@
 export interface GetProjectVersions {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * Use [expand](https://developer.atlassian.com/cloud/jira/platform/rest/v2/intro/#expansion) to include additional
    * information in the response. This parameter accepts `operations`, which returns actions that can be performed on

--- a/src/version2/parameters/getProjectVersionsPaginated.ts
+++ b/src/version2/parameters/getProjectVersionsPaginated.ts
@@ -1,6 +1,6 @@
 export interface GetProjectVersionsPaginated {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The index of the first item to return in a page of results (page offset). */
   startAt?: number;
   /** The maximum number of items to return per page. */

--- a/src/version2/parameters/getWorkflowSchemeProjectAssociations.ts
+++ b/src/version2/parameters/getWorkflowSchemeProjectAssociations.ts
@@ -3,5 +3,5 @@ export interface GetWorkflowSchemeProjectAssociations {
    * The ID of a project to return the workflow schemes for. To include multiple projects, provide an ampersand-Jim:
    * oneseparated list. For example, `projectId=10000&projectId=10001`.
    */
-  projectId: number[];
+  projectId: (string | number)[];
 }

--- a/src/version2/parameters/restore.ts
+++ b/src/version2/parameters/restore.ts
@@ -1,4 +1,4 @@
 export interface Restore {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/setActors.ts
+++ b/src/version2/parameters/setActors.ts
@@ -2,7 +2,7 @@ import { ProjectRoleActorsUpdate } from '../models';
 
 export interface SetActors extends ProjectRoleActorsUpdate {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The ID of the project role. Use [Get all project roles](#api-rest-api-2-role-get) to get a list of project role
    * IDs.

--- a/src/version2/parameters/setProjectProperty.ts
+++ b/src/version2/parameters/setProjectProperty.ts
@@ -1,6 +1,6 @@
 export interface SetProjectProperty {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The key of the project property. The maximum length is 255 characters. */
   propertyKey: string;
   propertyValue: any;

--- a/src/version2/parameters/toggleFeatureForProject.ts
+++ b/src/version2/parameters/toggleFeatureForProject.ts
@@ -2,7 +2,7 @@ import { ProjectFeatureToggleRequest } from '../models';
 
 export interface ToggleFeatureForProject extends ProjectFeatureToggleRequest {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The key of the feature. */
   featureKey: string;
 }

--- a/src/version2/parameters/updateProject.ts
+++ b/src/version2/parameters/updateProject.ts
@@ -2,7 +2,7 @@ import { UpdateProjectDetails } from '../models';
 
 export interface UpdateProject extends UpdateProjectDetails {
   /** The project ID or project key (case-sensitive). */
-  projectIdOrKey: number | string;
+  projectIdOrKey: string | number;
   /**
    * The [project
    * type](https://confluence.atlassian.com/x/GwiiLQ#Jiraapplicationsoverview-Productfeaturesandprojecttypes), which

--- a/src/version2/parameters/updateProjectAvatar.ts
+++ b/src/version2/parameters/updateProjectAvatar.ts
@@ -2,5 +2,5 @@ import { Avatar } from '../models';
 
 export interface UpdateProjectAvatar extends Avatar {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version2/parameters/updateProjectEmail.ts
+++ b/src/version2/parameters/updateProjectEmail.ts
@@ -2,5 +2,5 @@ import { ProjectEmailAddress } from '../models';
 
 export interface UpdateProjectEmail extends ProjectEmailAddress {
   /** The project ID. */
-  projectId: number;
+  projectId: string | number;
 }

--- a/src/version3/parameters/addActorUsers.ts
+++ b/src/version3/parameters/addActorUsers.ts
@@ -2,7 +2,7 @@ import { ActorsMap } from '../models';
 
 export interface AddActorUsers extends ActorsMap {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The ID of the project role. Use [Get all project roles](#api-rest-api-3-role-get) to get a list of project role
    * IDs.

--- a/src/version3/parameters/archiveProject.ts
+++ b/src/version3/parameters/archiveProject.ts
@@ -1,4 +1,4 @@
 export interface ArchiveProject {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/createProjectAvatar.ts
+++ b/src/version3/parameters/createProjectAvatar.ts
@@ -1,6 +1,7 @@
 export interface CreateProjectAvatar {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
+  avatar: any;
   /** The X coordinate of the top-left corner of the crop region. */
   x?: number;
   /** The Y coordinate of the top-left corner of the crop region. */

--- a/src/version3/parameters/createProjectAvatar.ts
+++ b/src/version3/parameters/createProjectAvatar.ts
@@ -1,7 +1,6 @@
 export interface CreateProjectAvatar {
   /** The ID or (case-sensitive) key of the project. */
   projectIdOrKey: string | number;
-  avatar: any;
   /** The X coordinate of the top-left corner of the crop region. */
   x?: number;
   /** The Y coordinate of the top-left corner of the crop region. */

--- a/src/version3/parameters/deleteActor.ts
+++ b/src/version3/parameters/deleteActor.ts
@@ -1,6 +1,6 @@
 export interface DeleteActor {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The ID of the project role. Use [Get all project roles](#api-rest-api-3-role-get) to get a list of project role
    * IDs.

--- a/src/version3/parameters/deleteProject.ts
+++ b/src/version3/parameters/deleteProject.ts
@@ -1,6 +1,6 @@
 export interface DeleteProject {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** Whether this project is placed in the Jira recycle bin where it will be available for restoration. */
   enableUndo?: boolean;
 }

--- a/src/version3/parameters/deleteProjectAsynchronously.ts
+++ b/src/version3/parameters/deleteProjectAsynchronously.ts
@@ -1,4 +1,4 @@
 export interface DeleteProjectAsynchronously {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/deleteProjectAvatar.ts
+++ b/src/version3/parameters/deleteProjectAvatar.ts
@@ -1,6 +1,6 @@
 export interface DeleteProjectAvatar {
   /** The project ID or (case-sensitive) key. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The ID of the avatar. */
   id: number;
 }

--- a/src/version3/parameters/deleteProjectProperty.ts
+++ b/src/version3/parameters/deleteProjectProperty.ts
@@ -1,6 +1,6 @@
 export interface DeleteProjectProperty {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The project property key. Use [Get project property keys](#api-rest-api-3-project-projectIdOrKey-properties-get) to
    * get a list of all project property keys.

--- a/src/version3/parameters/getAllProjectAvatars.ts
+++ b/src/version3/parameters/getAllProjectAvatars.ts
@@ -1,4 +1,4 @@
 export interface GetAllProjectAvatars {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/getAllStatuses.ts
+++ b/src/version3/parameters/getAllStatuses.ts
@@ -1,4 +1,4 @@
 export interface GetAllStatuses {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/getFeaturesForProject.ts
+++ b/src/version3/parameters/getFeaturesForProject.ts
@@ -1,4 +1,4 @@
 export interface GetFeaturesForProject {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/getFieldConfigurationSchemeProjectMapping.ts
+++ b/src/version3/parameters/getFieldConfigurationSchemeProjectMapping.ts
@@ -7,5 +7,5 @@ export interface GetFieldConfigurationSchemeProjectMapping {
    * The list of project IDs. To include multiple projects, separate IDs with ampersand:
    * `projectId=10000&projectId=10001`.
    */
-  projectId: number[];
+  projectId: (string | number)[];
 }

--- a/src/version3/parameters/getHierarchy.ts
+++ b/src/version3/parameters/getHierarchy.ts
@@ -1,4 +1,4 @@
 export interface GetHierarchy {
   /** The ID of the project. */
-  projectId: number;
+  projectId: string | number;
 }

--- a/src/version3/parameters/getIssueTypeSchemeForProjects.ts
+++ b/src/version3/parameters/getIssueTypeSchemeForProjects.ts
@@ -7,5 +7,5 @@ export interface GetIssueTypeSchemeForProjects {
    * The list of project IDs. To include multiple project IDs, provide an ampersand-separated list. For example,
    * `projectId=10000&projectId=10001`.
    */
-  projectId: number[];
+  projectId: (string | number)[];
 }

--- a/src/version3/parameters/getIssueTypeScreenSchemeProjectAssociations.ts
+++ b/src/version3/parameters/getIssueTypeScreenSchemeProjectAssociations.ts
@@ -7,5 +7,5 @@ export interface GetIssueTypeScreenSchemeProjectAssociations {
    * The list of project IDs. To include multiple projects, separate IDs with ampersand:
    * `projectId=10000&projectId=10001`.
    */
-  projectId: number[];
+  projectId: (string | number)[];
 }

--- a/src/version3/parameters/getIssueTypesForProject.ts
+++ b/src/version3/parameters/getIssueTypesForProject.ts
@@ -1,6 +1,6 @@
 export interface GetIssueTypesForProject {
   /** The ID of the project. */
-  projectId: number;
+  projectId: string | number;
   /**
    * The level of the issue type to filter by. Use:
    *

--- a/src/version3/parameters/getProjectComponents.ts
+++ b/src/version3/parameters/getProjectComponents.ts
@@ -1,6 +1,6 @@
 export interface GetProjectComponents {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The source of the components to return. Can be `jira` (default), `compass` or `auto`. When `auto` is specified, the
    * API will return connected Compass components if the project is opted into Compass, otherwise it will return Jira

--- a/src/version3/parameters/getProjectComponentsPaginated.ts
+++ b/src/version3/parameters/getProjectComponentsPaginated.ts
@@ -1,6 +1,6 @@
 export interface GetProjectComponentsPaginated {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The index of the first item to return in a page of results (page offset). */
   startAt?: number;
   /** The maximum number of items to return per page. */

--- a/src/version3/parameters/getProjectEmail.ts
+++ b/src/version3/parameters/getProjectEmail.ts
@@ -1,4 +1,4 @@
 export interface GetProjectEmail {
   /** The project ID. */
-  projectId: number;
+  projectId: string | number;
 }

--- a/src/version3/parameters/getProjectProperty.ts
+++ b/src/version3/parameters/getProjectProperty.ts
@@ -1,6 +1,6 @@
 export interface GetProjectProperty {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The project property key. Use [Get project property keys](#api-rest-api-3-project-projectIdOrKey-properties-get) to
    * get a list of all project property keys.

--- a/src/version3/parameters/getProjectPropertyKeys.ts
+++ b/src/version3/parameters/getProjectPropertyKeys.ts
@@ -1,4 +1,4 @@
 export interface GetProjectPropertyKeys {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/getProjectRole.ts
+++ b/src/version3/parameters/getProjectRole.ts
@@ -1,6 +1,6 @@
 export interface GetProjectRole {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The ID of the project role. Use [Get all project roles](#api-rest-api-3-role-get) to get a list of project role
    * IDs.

--- a/src/version3/parameters/getProjectRoleDetails.ts
+++ b/src/version3/parameters/getProjectRoleDetails.ts
@@ -1,6 +1,6 @@
 export interface GetProjectRoleDetails {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** Whether the roles should be filtered to include only those the user is assigned to. */
   currentMember?: boolean;
   excludeConnectAddons?: boolean;

--- a/src/version3/parameters/getProjectRoles.ts
+++ b/src/version3/parameters/getProjectRoles.ts
@@ -1,4 +1,4 @@
 export interface GetProjectRoles {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/getProjectVersions.ts
+++ b/src/version3/parameters/getProjectVersions.ts
@@ -1,6 +1,6 @@
 export interface GetProjectVersions {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * Use [expand](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#expansion) to include additional
    * information in the response. This parameter accepts `operations`, which returns actions that can be performed on

--- a/src/version3/parameters/getProjectVersionsPaginated.ts
+++ b/src/version3/parameters/getProjectVersionsPaginated.ts
@@ -1,6 +1,6 @@
 export interface GetProjectVersionsPaginated {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The index of the first item to return in a page of results (page offset). */
   startAt?: number;
   /** The maximum number of items to return per page. */

--- a/src/version3/parameters/getWorkflowSchemeProjectAssociations.ts
+++ b/src/version3/parameters/getWorkflowSchemeProjectAssociations.ts
@@ -3,5 +3,5 @@ export interface GetWorkflowSchemeProjectAssociations {
    * The ID of a project to return the workflow schemes for. To include multiple projects, provide an ampersand-Jim:
    * oneseparated list. For example, `projectId=10000&projectId=10001`.
    */
-  projectId: number[];
+  projectId: (string | number)[];
 }

--- a/src/version3/parameters/restore.ts
+++ b/src/version3/parameters/restore.ts
@@ -1,4 +1,4 @@
 export interface Restore {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/setActors.ts
+++ b/src/version3/parameters/setActors.ts
@@ -2,7 +2,7 @@ import { ProjectRoleActorsUpdate } from '../models';
 
 export interface SetActors extends ProjectRoleActorsUpdate {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /**
    * The ID of the project role. Use [Get all project roles](#api-rest-api-3-role-get) to get a list of project role
    * IDs.

--- a/src/version3/parameters/setProjectProperty.ts
+++ b/src/version3/parameters/setProjectProperty.ts
@@ -1,6 +1,6 @@
 export interface SetProjectProperty {
   /** The project ID or project key (case sensitive). */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The key of the project property. The maximum length is 255 characters. */
   propertyKey: string;
   propertyValue: any;

--- a/src/version3/parameters/toggleFeatureForProject.ts
+++ b/src/version3/parameters/toggleFeatureForProject.ts
@@ -2,7 +2,7 @@ import { ProjectFeatureToggleRequest } from '../models';
 
 export interface ToggleFeatureForProject extends ProjectFeatureToggleRequest {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
   /** The key of the feature. */
   featureKey: string;
 }

--- a/src/version3/parameters/updateProject.ts
+++ b/src/version3/parameters/updateProject.ts
@@ -2,7 +2,7 @@ import { UpdateProjectDetails } from '../models';
 
 export interface UpdateProject extends UpdateProjectDetails {
   /** The project ID or project key (case-sensitive). */
-  projectIdOrKey: number | string;
+  projectIdOrKey: string | number;
   projectTypeKey?: string;
   projectTemplateKey?: string;
   /**

--- a/src/version3/parameters/updateProjectAvatar.ts
+++ b/src/version3/parameters/updateProjectAvatar.ts
@@ -2,5 +2,5 @@ import { Avatar } from '../models';
 
 export interface UpdateProjectAvatar extends Avatar {
   /** The ID or (case-sensitive) key of the project. */
-  projectIdOrKey: string;
+  projectIdOrKey: string | number;
 }

--- a/src/version3/parameters/updateProjectEmail.ts
+++ b/src/version3/parameters/updateProjectEmail.ts
@@ -2,5 +2,5 @@ import { ProjectEmailAddress } from '../models';
 
 export interface UpdateProjectEmail extends ProjectEmailAddress {
   /** The project ID. */
-  projectId: number;
+  projectId: string | number;
 }


### PR DESCRIPTION
Fixes #352.

1. Support `number` for `projectIdOrKey`
2. Support `string` for `projectId`
  - `projectId` is `int64` on Jira API, which the API support both number and number string.
3. Fixed discrepancy in v2 `createProjectAvatar.ts` to accept `any` for `avatar`.
  - I copied the definition from v3.