### PR TITLE
fix: `searchForIssuesUsingJqlEnhancedSearch` & `searchForIssuesUsingJqlEnhancedSearchPost` url

### DIFF
--- a/src/version2/issueSearch.ts
+++ b/src/version2/issueSearch.ts
@@ -401,7 +401,7 @@ export class IssueSearch {
     callback?: Callback<T>,
   ): Promise<void | T> {
     const config: RequestConfig = {
-      url: '/rest/api/2/search/jql',
+      url: '/rest/api/2/search',
       method: 'GET',
       params: {
         jql: parameters.jql,
@@ -462,7 +462,7 @@ export class IssueSearch {
     callback?: Callback<T>,
   ): Promise<void | T> {
     const config: RequestConfig = {
-      url: '/rest/api/2/search/jql',
+      url: '/rest/api/2/search',
       method: 'POST',
       data: {
         // todo add deprecation notice


### PR DESCRIPTION
Remove `/jql` from the URL of `searchForIssuesUsingJqlEnhancedSearch` and `searchForIssuesUsingJqlEnhancedSearchPost`, it doesn't exist on v2 Jira instances.

```
response: {
    code: 'ERR_BAD_REQUEST',
    message: 'Request failed with status code 404',
    data: {
      message: 'null for uri: https://issues.redhat.com/rest/api/2/search/jql?jql=Project+%3D+RHEL&fields=id,issuetype,status,components,summary,assignee,priority',
      'status-code': 404
    },
    status: 404,
    statusText: 'Not Found'
  }
```