### PR TITLE
ci: make the schema audit dispatchable

### DIFF
--- a/.github/workflows/schema-audit.yaml
+++ b/.github/workflows/schema-audit.yaml
@@ -1,0 +1,36 @@
+name: 🔬 Schema audit
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: live-tests
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: 🔬 Schemas against the live API
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: 🔄 Checkout sources
+        uses: actions/checkout@v7
+      - name: ⚙️ Use Node.js 22.x
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.x
+      - name: 📦 Install pnpm
+        uses: pnpm/action-setup@v6
+      - name: 📌 Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: 📝 Creating `.env` file
+        run: |
+          touch .env
+          echo JIRA_BASE_URL=${{ secrets.HOST }} >> .env
+          echo JIRA_EMAIL=${{ secrets.EMAIL }} >> .env
+          echo JIRA_API_TOKEN=${{ secrets.API_TOKEN }} >> .env
+      - name: 🔬 Audit schemas against the live API
+        run: pnpm run audit:schemas


### PR DESCRIPTION
GitHub only offers `workflow_dispatch` for workflows that exist on the default branch — dispatching `schema-audit.yaml` from `feature/v6` currently answers `HTTP 404: workflow not found on the default branch`.

This adds the workflow to `master` so the button appears. The audit itself is then run against the branch under test:

    gh workflow run schema-audit.yaml --ref feature/v6

The `schedule` trigger is deliberately left out here: a nightly run from `master` would execute against 5.x, where `audit:schemas` does not exist. The `feature/v6` copy keeps its cron and takes over when v6 merges.