### PR TITLE
fix: restore the scripts the docs workflow calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,12 @@
     "check:browser:e2e": "node scripts/checkBrowser.ts",
     "test": "vitest run",
     "test:live": "vitest run --config vitest.config.live.ts",
-    "audit:schemas": "node scripts/schemaAudit.ts"
+    "audit:schemas": "node scripts/schemaAudit.ts",
+    "docs:api": "typedoc && node scripts/trim-api-sidebar.ts",
+    "docs:dev": "pnpm run docs:api && vitepress dev docs",
+    "docs:build": "pnpm run docs:api && vitepress build docs",
+    "docs:preview": "vitepress preview docs",
+    "docs:og": "node scripts/build-og-image.ts"
   },
   "dependencies": {
     "zod": "^4.4.3"


### PR DESCRIPTION
The v6 branch lost the `docs:*` scripts while keeping everything they drive — `typedoc.json`, `docs/`, `scripts/trim-api-sidebar.ts`, `scripts/build-og-image.ts` and all four devDependencies (`typedoc`, `typedoc-plugin-markdown`, `typedoc-vitepress-theme`, `vitepress`).

Nothing could catch it before the merge: `docs.yml` only runs on a push to `master`, so it first failed on the release commit itself with `ERR_PNPM_NO_SCRIPT: Missing script: docs:build`, and the Pages deploy was skipped. The site is still serving the 5.x reference.

The entries invoke `node` rather than `tsx`, matching `check:browser` and `audit:schemas`; Node strips the types itself and both scripts stay within what it handles.

Verified by running `docs:build` end to end: typedoc emitted 6290 markdown pages, `trim-api-sidebar` dropped 6 models/parameters subgroups and wrote a 94 KB sidebar, and vitepress rendered 18947 files into `docs/.vitepress/dist` with a sitemap. Exit 0.