### PR TITLE
fix: the API reference builds without warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,12 @@
 
   The default is `'warn'` because the shapes Jira sends vary with things a library cannot see — tenant locale, whether a feature is enabled, team-managed versus company-managed projects, an enum Atlassian grew without notice. None of those are your bug, and none should stop your program. Use `'throw'` in a test suite, where a mismatch is the thing under test.
 * **`SchemaMismatchError` reports structurally.** It carries `report` — endpoint, field paths, expected and received *types* — and no longer carries the response body. The body used to end up in every log line and error tracker that saw the error, carrying issue summaries, display names and custom field contents with it.
-* **A v5 → v6 codemod** ships in the package at `tools/codemod/v5-to-v6.ts`. It rewrites client construction, authentication and imports, and leaves a `TODO(jira.js@6)` wherever a human has to decide.
+* **A v5 → v6 codemod** ships in the package. It rewrites client construction, authentication and imports, and leaves a `TODO(jira.js@6)` wherever a human has to decide — read every one of them.
+
+  ```bash
+  npx jscodeshift -t node_modules/jira.js/tools/codemod/v5-to-v6.ts \
+    --parser ts --extensions ts,tsx,js,jsx src/
+  ```
 * **First-class OAuth 2.0 (3LO)**, with automatic refresh before expiry, one retry on `401`, cloud id resolution and rotated-refresh-token callbacks.
 * **A browser build.** The package is browser-safe throughout, verified in CI both statically and by loading the built bundle in Chromium.
 

--- a/src/core/createClient.ts
+++ b/src/core/createClient.ts
@@ -54,7 +54,7 @@ function describeValue(value: unknown): string {
  * `path` is a zod issue path, so every segment is an object key or an array index, and anything no longer there is
  * simply skipped — the walk describes a body that was just parsed, not an arbitrary structure.
  */
-function takeKeys(body: unknown, path: readonly PropertyKey[], keys: readonly PropertyKey[]): Record<string, string> {
+function takeKeyTypes(body: unknown, path: readonly PropertyKey[], keys: readonly PropertyKey[]): Record<string, string> {
   let target = body;
 
   for (const segment of path) {
@@ -167,7 +167,7 @@ async function getAuthHeaders(auth: Auth): Promise<Record<string, string>> {
  * Prefer `createV1Client` / `createV2Client` from `confluence.js` unless you want the flat functions and a smaller
  * bundle.
  *
- * @stable
+ * @public
  */
 export function createClient(config: ClientConfig | Client): Client {
   if (isClient(config)) return config;
@@ -337,7 +337,7 @@ export function createClient(config: ClientConfig | Client): Client {
                 endpoint,
                 path: finding.path.join('.'),
                 keys: finding.keys.map(key => String(key)),
-                types: takeKeys(data, finding.path, finding.keys),
+                types: takeKeyTypes(data, finding.path, finding.keys),
               });
             }
 

--- a/src/core/errors/apiError.ts
+++ b/src/core/errors/apiError.ts
@@ -11,7 +11,7 @@ export interface ApiErrorOptions {
  * The subclasses below cover the statuses worth branching on. Catch this one to catch them all, or a subclass — or use
  * the predicates, which survive a duplicated install of this package.
  *
- * @stable
+ * @public
  */
 export class ApiError extends Error {
   readonly [ERROR_KINDS]: readonly ErrorKind[] = ['api'];
@@ -39,7 +39,7 @@ export class ApiError extends Error {
 /**
  * 401 — the credentials are missing, expired or rejected.
  *
- * @stable
+ * @public
  */
 export class AuthError extends ApiError {
   override readonly [ERROR_KINDS]: readonly ErrorKind[] = ['api', 'auth'];
@@ -66,7 +66,7 @@ export class AuthError extends ApiError {
  * endpoints want classic ones (`read:confluence-content.all`). An app that holds only one family gets this error from
  * the other.
  *
- * @stable
+ * @public
  */
 export class ScopeError extends AuthError {
   override readonly [ERROR_KINDS]: readonly ErrorKind[] = ['api', 'auth', 'scope'];
@@ -84,7 +84,7 @@ export class ScopeError extends AuthError {
 /**
  * 403 — authenticated, but not allowed. Usually a Confluence permission rather than a scope.
  *
- * @stable
+ * @public
  */
 export class ForbiddenError extends ApiError {
   override readonly [ERROR_KINDS]: readonly ErrorKind[] = ['api', 'forbidden'];
@@ -104,7 +104,7 @@ export class ForbiddenError extends ApiError {
  *
  * Confluence returns 404 for both, deliberately: telling the two apart would leak the existence of restricted content.
  *
- * @stable
+ * @public
  */
 export class NotFoundError extends ApiError {
   override readonly [ERROR_KINDS]: readonly ErrorKind[] = ['api', 'notFound'];
@@ -130,7 +130,7 @@ export interface RateLimitErrorOptions extends ApiErrorOptions {
  * `retryAfterMs` carries Atlassian's own advice when the response included `Retry-After`. It is not retried for you:
  * the right response to a rate limit is to slow the whole client down, which only your code can decide.
  *
- * @stable
+ * @public
  */
 export class RateLimitError extends ApiError {
   override readonly [ERROR_KINDS]: readonly ErrorKind[] = ['api', 'rateLimit'];
@@ -152,7 +152,7 @@ export class RateLimitError extends ApiError {
 /**
  * 5xx — Confluence failed on its own side.
  *
- * @stable
+ * @public
  */
 export class ServerError extends ApiError {
   override readonly [ERROR_KINDS]: readonly ErrorKind[] = ['api', 'server'];

--- a/src/core/errors/networkError.ts
+++ b/src/core/errors/networkError.ts
@@ -6,7 +6,7 @@ import { ERROR_KINDS, hasErrorKind, type ErrorKind } from './kinds.js';
  * `fetch` reports these as a bare `TypeError` whose real reason is buried in `cause`. Wrapping them means a caller can
  * catch every failure of this client uniformly, and `transient` says whether retrying stands a chance.
  *
- * @stable
+ * @public
  */
 export class NetworkError extends Error {
   readonly [ERROR_KINDS]: readonly ErrorKind[] = ['network'];

--- a/src/core/errors/oauthError.ts
+++ b/src/core/errors/oauthError.ts
@@ -38,7 +38,7 @@ function readErrorFields(body: unknown): { error?: string; errorDescription?: st
  * Deliberately not an `ApiError`: it does not come from the Confluence API, and a caller retrying Confluence calls
  * should not treat "your refresh token is dead" as the same class of problem as "that page is missing".
  *
- * @stable
+ * @public
  */
 export class OAuthError extends Error {
   readonly [ERROR_KINDS]: readonly ErrorKind[] = ['oauth'];
@@ -53,7 +53,7 @@ export class OAuthError extends Error {
    */
   readonly error?: string;
   readonly errorDescription?: string;
-  /** Whether the only way forward is a fresh authorization. Read it through {@link isReauthorizationRequired}. */
+  /** Whether the only way forward is a fresh authorization. Read it through {@link core/errors/predicates!isReauthorizationRequired}. */
   readonly reauthorizationRequired: boolean;
 
   constructor(message: string, options?: OAuthErrorOptions) {
@@ -82,7 +82,7 @@ export class OAuthError extends Error {
  * Thrown at construction time where possible, so a mistake surfaces before the first request rather than as a puzzling
  * 401.
  *
- * @stable
+ * @public
  */
 export class ConfigError extends Error {
   readonly [ERROR_KINDS]: readonly ErrorKind[] = ['config'];

--- a/src/core/errors/predicates.ts
+++ b/src/core/errors/predicates.ts
@@ -18,7 +18,7 @@ import { hasErrorKind } from './kinds.js';
  * Prefer these predicates to `instanceof` in library code and in anything that might load two copies of this package:
  * they check a branded marker instead of the prototype chain.
  *
- * @stable
+ * @public
  */
 export function isApiError(value: unknown): value is ApiError {
   return hasErrorKind(value, 'api');
@@ -27,7 +27,7 @@ export function isApiError(value: unknown): value is ApiError {
 /**
  * 401 — credentials missing, expired or rejected.
  *
- * @stable
+ * @public
  */
 export function isAuthError(value: unknown): value is AuthError {
   return hasErrorKind(value, 'auth');
@@ -36,7 +36,7 @@ export function isAuthError(value: unknown): value is AuthError {
 /**
  * 403 — authenticated but not permitted.
  *
- * @stable
+ * @public
  */
 export function isForbiddenError(value: unknown): value is ForbiddenError {
   return hasErrorKind(value, 'forbidden');
@@ -45,7 +45,7 @@ export function isForbiddenError(value: unknown): value is ForbiddenError {
 /**
  * 404 — absent, or invisible to you.
  *
- * @stable
+ * @public
  */
 export function isNotFoundError(value: unknown): value is NotFoundError {
   return hasErrorKind(value, 'notFound');
@@ -54,7 +54,7 @@ export function isNotFoundError(value: unknown): value is NotFoundError {
 /**
  * 429 — rate limited. Read `retryAfterMs` for Atlassian's own advice.
  *
- * @stable
+ * @public
  */
 export function isRateLimitError(value: unknown): value is RateLimitError {
   return hasErrorKind(value, 'rateLimit');
@@ -63,7 +63,7 @@ export function isRateLimitError(value: unknown): value is RateLimitError {
 /**
  * 5xx — Confluence failed on its side.
  *
- * @stable
+ * @public
  */
 export function isServerError(value: unknown): value is ServerError {
   return hasErrorKind(value, 'server');
@@ -72,7 +72,7 @@ export function isServerError(value: unknown): value is ServerError {
 /**
  * No HTTP response at all — DNS, TLS, socket, timeout.
  *
- * @stable
+ * @public
  */
 export function isNetworkError(value: unknown): value is NetworkError {
   return hasErrorKind(value, 'network');
@@ -81,7 +81,7 @@ export function isNetworkError(value: unknown): value is NetworkError {
 /**
  * An OAuth 2.0 failure: token exchange, refresh, or cloud-id resolution.
  *
- * @stable
+ * @public
  */
 export function isOAuthError(value: unknown): value is OAuthError {
   return hasErrorKind(value, 'oauth');
@@ -90,7 +90,7 @@ export function isOAuthError(value: unknown): value is OAuthError {
 /**
  * The client configuration cannot work.
  *
- * @stable
+ * @public
  */
 export function isConfigError(value: unknown): value is ConfigError {
   return hasErrorKind(value, 'config');
@@ -99,7 +99,7 @@ export function isConfigError(value: unknown): value is ConfigError {
 /**
  * A 2xx response that is not JSON where the endpoint promised JSON.
  *
- * @stable
+ * @public
  */
 export function isSchemaMismatchError(value: unknown): value is SchemaMismatchError {
   return hasErrorKind(value, 'schemaMismatch');
@@ -115,7 +115,7 @@ export function isSchemaMismatchError(value: unknown): value is SchemaMismatchEr
  * `access_denied`, the same code a declining user produces — and sending people through consent over a bad environment
  * variable would loop them forever. That case answers `false` here and surfaces as a plain {@link isOAuthError}.
  *
- * @stable
+ * @public
  */
 export function isReauthorizationRequired(value: unknown): value is OAuthError {
   return isOAuthError(value) && value.reauthorizationRequired;
@@ -127,7 +127,7 @@ export function isReauthorizationRequired(value: unknown): value is OAuthError {
  * Distinct from {@link isAuthError} because the remedy is different: refreshing cannot help, the app needs the scope
  * added and the user has to consent again. Confluence reports it as a 401 with `Unauthorized; scope does not match`.
  *
- * @stable
+ * @public
  */
 export function isScopeError(value: unknown): value is ScopeError {
   return hasErrorKind(value, 'scope');

--- a/src/core/errors/schemaMismatchError.ts
+++ b/src/core/errors/schemaMismatchError.ts
@@ -17,7 +17,7 @@ import type { SchemaMismatchReport } from '../schemaMismatch.js';
  *
  * Distinct from `ApiError`, which means the request itself failed.
  *
- * @stable
+ * @public
  */
 export class SchemaMismatchError extends Error {
   readonly [ERROR_KINDS]: readonly ErrorKind[] = ['schemaMismatch'];

--- a/src/core/oauth/helpers.ts
+++ b/src/core/oauth/helpers.ts
@@ -57,7 +57,7 @@ async function requestJson<T>(url: string, init: RequestInit): Promise<T> {
  *
  * `state` is yours to generate and to verify when the callback comes back — it is what stops CSRF on the redirect.
  *
- * @stable
+ * @public
  */
 export function generateAuthorizationUrl(params: {
   clientId: string;
@@ -83,7 +83,7 @@ export function generateAuthorizationUrl(params: {
 /**
  * Exchange the authorization `code` from the redirect callback for tokens.
  *
- * @stable
+ * @public
  */
 export async function exchangeAuthorizationCode(params: {
   clientId: string;
@@ -112,7 +112,7 @@ export async function exchangeAuthorizationCode(params: {
  * Atlassian rotates the refresh token on every call: persist the one you get back and drop the old one, or the next
  * refresh fails.
  *
- * @stable
+ * @public
  */
 export async function refreshOAuth2Token(params: {
   clientId: string;
@@ -136,7 +136,7 @@ export async function refreshOAuth2Token(params: {
 /**
  * List the Confluence sites this access token can reach. The `id` of an entry is its cloud id.
  *
- * @stable
+ * @public
  */
 export async function getAccessibleResources(accessToken: string): Promise<AccessibleResource[]> {
   return requestJson<AccessibleResource[]>(ACCESSIBLE_RESOURCES_URL, {

--- a/src/core/oauth/parseCallbackUrl.ts
+++ b/src/core/oauth/parseCallbackUrl.ts
@@ -11,14 +11,14 @@ export interface ParseCallbackUrlOptions {
 }
 
 export interface CallbackParams {
-  /** The authorization code, ready for {@link exchangeAuthorizationCode}. */
+  /** The authorization code, ready for {@link core/oauth/helpers!exchangeAuthorizationCode}. */
   code: string;
   /** The `state` that came back, already verified against `expectedState`. */
   state: string;
 }
 
 /** Constant-time string comparison, so a mismatch leaks nothing through timing. */
-function equals(a: string, b: string): boolean {
+function timingSafeEquals(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
 
   let diff = 0;
@@ -39,7 +39,7 @@ function equals(a: string, b: string): boolean {
  * - `state` is missing or does not match the one you issued;
  * - The URL is simply not a callback — no code, no error.
  *
- * Each throws an {@link OAuthError}; for a decline, `error` is `access_denied`, which {@link isReauthorizationRequired}
+ * Each throws an {@link OAuthError}; for a decline, `error` is `access_denied`, which {@link core/errors/predicates!isReauthorizationRequired}
  * recognises.
  *
  * @example
@@ -49,7 +49,7 @@ function equals(a: string, b: string): boolean {
  *   const tokens = await exchangeAuthorizationCode({ clientId, clientSecret, code, redirectUri });
  *   ```;
  *
- * @stable
+ * @public
  */
 export function parseCallbackUrl(url: string | URL, options: ParseCallbackUrlOptions): CallbackParams {
   const parsed = typeof url === 'string' ? new URL(url, 'http://localhost') : url;
@@ -70,7 +70,7 @@ export function parseCallbackUrl(url: string | URL, options: ParseCallbackUrlOpt
 
   const state = params.get('state');
 
-  if (state === null || !equals(state, options.expectedState)) {
+  if (state === null || !timingSafeEquals(state, options.expectedState)) {
     throw new OAuthError(
       'The `state` in the callback does not match the one issued for this authorization request. The callback was ' +
         'not initiated by this session — discard it.',

--- a/src/core/productInfo.ts
+++ b/src/core/productInfo.ts
@@ -4,7 +4,7 @@
  * This file is generated. Everything else under `core/` is identical across the libraries, and stays that way by
  * reading these values rather than hard-coding a product name.
  */
-interface ProductInfo {
+export interface ProductInfo {
   packageName: string;
   gatewaySlug: string;
   scopeHint: string;

--- a/src/core/schemaAudit.ts
+++ b/src/core/schemaAudit.ts
@@ -36,6 +36,6 @@ export function recordSchemaDrift(entry: SchemaDrift): void {
   (store[STORE] ??= []).push(entry);
 }
 
-export function collectedSchemaDrift(): readonly SchemaDrift[] {
+export function getCollectedSchemaDrift(): readonly SchemaDrift[] {
   return (globalThis as Store)[STORE] ?? [];
 }

--- a/src/core/schemaMismatch.ts
+++ b/src/core/schemaMismatch.ts
@@ -55,7 +55,7 @@ function describeValue(value: unknown): string {
  * segment of an issue path is an object key or an array index, and anything no longer reachable is reported as absent —
  * which is itself the answer when the complaint is a missing field.
  */
-function typeAtPath(body: unknown, path: readonly PropertyKey[]): string {
+function describeTypeAtPath(body: unknown, path: readonly PropertyKey[]): string {
   let target = body;
 
   for (const segment of path) {
@@ -102,7 +102,7 @@ export function describeIssues(
     described.push({
       path: path.map(String).join('.'),
       expected: 'expected' in issue ? String(issue.expected) : issue.code,
-      received: typeAtPath(body, path),
+      received: describeTypeAtPath(body, path),
     });
   }
 

--- a/src/core/schemas/clientConfig.ts
+++ b/src/core/schemas/clientConfig.ts
@@ -48,9 +48,9 @@ export const clientConfigSchema = z
     path: ['host'],
   });
 
-type ParsedClientConfig = z.infer<typeof clientConfigSchema>;
+export type ParsedClientConfig = z.infer<typeof clientConfigSchema>;
 
-type CommonClientConfig = Omit<ParsedClientConfig, 'host' | 'auth'>;
+export type CommonClientConfig = Omit<ParsedClientConfig, 'host' | 'auth'>;
 
 /**
  * The shape accepted by `createClient`, `createV1Client` and `createV2Client`.

--- a/src/core/withRetry.ts
+++ b/src/core/withRetry.ts
@@ -33,7 +33,7 @@ export interface RetryOptions {
  *   );
  *   ```;
  *
- * @stable
+ * @public
  */
 export async function withRetry<T>(operation: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
   const { maxAttempts = 3, initialDelayMs = 1000, backoffFactor = 2, retryRateLimit = false } = options;

--- a/src/serviceDesk/api/customer.ts
+++ b/src/serviceDesk/api/customer.ts
@@ -12,7 +12,6 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Jira
  * Administrator Global permission
  */
-
 export async function createCustomer(client: Client, parameters: CreateCustomer): Promise<User> {
   const config: SendRequestOptions<User> = {
     url: '/rest/servicedeskapi/customer',
@@ -35,13 +34,12 @@ export async function createCustomer(client: Client, parameters: CreateCustomer)
  * Creates a customer account on behalf of jsd-nutmeg.
  *
  * This endpoint is restricted to jsd-nutmeg via ASAP authentication. It provides the same capability as the public
- * {@code POST /servicedeskapi/customer} endpoint, but does not require a User Context Token (UCT) or Connect app user
- * \u2014 authorization is enforced entirely via the ASAP token.
+ * `POST /servicedeskapi/customer` endpoint, but does not require a User Context Token (UCT) or Connect app user —
+ * authorization is enforced entirely via the ASAP token.
  *
- * No user permission checks are performed; {@code null} is passed as the acting user to bypass the permission check in
- * the underlying service.
+ * No user permission checks are performed; `null` is passed as the acting user to bypass the permission check in the
+ * underlying service.
  */
-
 export async function createCustomerSkippingPermissionCheck(
   client: Client,
   parameters: CreateCustomerSkippingPermissionCheck,
@@ -71,7 +69,6 @@ export async function createCustomerSkippingPermissionCheck(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required:** Site
  * administration (that is, member of the _site-admin_ [group](https://confluence.atlassian.com/x/24xjL)).
  */
-
 export async function revokePortalOnlyAccessForUser(
   client: Client,
   parameters: RevokePortalOnlyAccessForUser,

--- a/src/serviceDesk/api/servicedesk.ts
+++ b/src/serviceDesk/api/servicedesk.ts
@@ -35,7 +35,6 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Any
  */
-
 export async function getServiceDesks(client: Client, parameters?: GetServiceDesks): Promise<PagedServiceDesk> {
   const config: SendRequestOptions<PagedServiceDesk> = {
     url: '/rest/servicedeskapi/servicedesk',
@@ -58,7 +57,6 @@ export async function getServiceDesks(client: Client, parameters?: GetServiceDes
  * Permission to access the Service Desk. For example, being the Service Desk's Administrator or one of its Agents or
  * Users.
  */
-
 export async function getServiceDeskById(client: Client, parameters: GetServiceDeskById): Promise<ServiceDesk> {
   const config: SendRequestOptions<ServiceDesk> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}`,
@@ -94,7 +92,6 @@ export async function getServiceDeskById(client: Client, parameters: GetServiceD
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to add attachments in this Service Desk.
  */
-
 export async function attachTemporaryFile(
   client: Client,
   parameters: AttachTemporaryFileParameters,
@@ -116,7 +113,6 @@ export async function attachTemporaryFile(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk administrator
  */
-
 export async function addCustomers(client: Client, parameters: AddCustomers): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/customer`,
@@ -134,16 +130,15 @@ export async function addCustomers(client: Client, parameters: AddCustomers): Pr
  * Adds one or more customers to a service desk on behalf of jsd-nutmeg.
  *
  * This endpoint is restricted to jsd-nutmeg via ASAP authentication. It provides the same capability as the public
- * {@code POST /servicedeskapi/servicedesk/{serviceDeskId}/customer} endpoint, but does not require a User Context Token
- * (UCT) or Connect app user \u2014 authorization is enforced entirely via the ASAP token.
+ * `POST /servicedeskapi/servicedesk/{serviceDeskId}/customer` endpoint, but does not require a User Context Token (UCT)
+ * or Connect app user — authorization is enforced entirely via the ASAP token.
  *
- * No user permission checks are performed; {@code null} is passed as the acting user to bypass the permission check in
- * the underlying service.
+ * No user permission checks are performed; `null` is passed as the acting user to bypass the permission check in the
+ * underlying service.
  *
  * If any of the passed customers are already associated with the service desk, no changes will be made for those
  * customers and the resource returns a 204 success code.
  */
-
 export async function addCustomersSkippingPermissionCheck(
   client: Client,
   parameters: AddCustomersSkippingPermissionCheck,
@@ -166,7 +161,6 @@ export async function addCustomersSkippingPermissionCheck(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to access the service desk.
  */
-
 export async function getServiceDeskArticles(
   client: Client,
   parameters: GetServiceDeskArticles,
@@ -195,7 +189,6 @@ export async function getServiceDeskArticles(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: service
  * desk's Agent.
  */
-
 export async function getQueues(client: Client, parameters: GetQueues): Promise<PagedQueue> {
   const config: SendRequestOptions<PagedQueue> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/queue`,
@@ -218,7 +211,6 @@ export async function getQueues(client: Client, parameters: GetQueues): Promise<
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: service
  * desk's Agent.
  */
-
 export async function getQueue(client: Client, parameters: GetQueue): Promise<Queue> {
   const config: SendRequestOptions<Queue> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/queue/${parameters.queueId}`,
@@ -240,7 +232,6 @@ export async function getQueue(client: Client, parameters: GetQueue): Promise<Qu
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk's agent.
  */
-
 export async function getIssuesInQueue(client: Client, parameters: GetIssuesInQueue): Promise<PagedIssue> {
   const config: SendRequestOptions<PagedIssue> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/queue/${parameters.queueId}/issue`,
@@ -271,7 +262,6 @@ export async function getIssuesInQueue(client: Client, parameters: GetIssuesInQu
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to access the service desk.
  */
-
 export async function getRequestTypes(client: Client, parameters: GetRequestTypes): Promise<PagedRequestType> {
   const config: SendRequestOptions<PagedRequestType> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/requesttype`,
@@ -299,7 +289,6 @@ export async function getRequestTypes(client: Client, parameters: GetRequestType
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to access the service desk.
  */
-
 export async function getRequestTypeById(client: Client, parameters: GetRequestTypeById): Promise<RequestType> {
   const config: SendRequestOptions<RequestType> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/requesttype/${parameters.requestTypeId}`,
@@ -326,7 +315,6 @@ export async function getRequestTypeById(client: Client, parameters: GetRequestT
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the Service Desk. However, hidden fields would be visible to only Service desk's Administrator.
  */
-
 export async function getRequestTypeFields(
   client: Client,
   parameters: GetRequestTypeFields,
@@ -351,7 +339,6 @@ export async function getRequestTypeFields(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the service desk.
  */
-
 export async function getRequestTypeGroups(
   client: Client,
   parameters: GetRequestTypeGroups,

--- a/src/serviceDesk/parameters/createCustomerSkippingPermissionCheck.ts
+++ b/src/serviceDesk/parameters/createCustomerSkippingPermissionCheck.ts
@@ -3,7 +3,7 @@ import { CustomerCreateSchema } from '../models';
 
 export const CreateCustomerSkippingPermissionCheckSchema = z
   .object({
-    /** Optional boolean flag; when {@code true}, returns 409 Conflict for duplicate email instead of the default 400. */
+    /** Optional boolean flag; when `true`, returns 409 Conflict for duplicate email instead of the default 400. */
     strictConflictStatusCode: z.boolean().optional(),
   })
   .extend(CustomerCreateSchema.shape);

--- a/tests/live/setup/auditCollector.ts
+++ b/tests/live/setup/auditCollector.ts
@@ -1,6 +1,6 @@
 import { appendFileSync } from 'node:fs';
 import { afterAll } from 'vitest';
-import { collectedSchemaDrift } from '#/core/schemaAudit';
+import { getCollectedSchemaDrift } from '#/core/schemaAudit';
 
 /**
  * Carries the audit's findings out of the worker.
@@ -17,7 +17,7 @@ const OUTPUT = process.env.AUDIT_SCHEMAS_OUTPUT;
 afterAll(() => {
   if (!OUTPUT) return;
 
-  const drift = collectedSchemaDrift();
+  const drift = getCollectedSchemaDrift();
 
   if (drift.length === 0) return;
 


### PR DESCRIPTION
typedoc emitted 41 warnings while building the reference. All four causes were in `apis-code-gen`, so that is where they are fixed; this is the sync.

| cause | count | fix |
|---|---|---|
| `@stable` is not a tag typedoc knows | 30 | `@public` — same meaning in TSDoc, recognised out of the box |
| `ProductInfo`, `CommonClientConfig`, `ParsedClientConfig` referenced by exported types but unexported | 3 | exported |
| `{@link}` to a symbol in a sibling module | 3 | qualified as `{@link core/errors/predicates!isReauthorizationRequired}` |
| Javadoc in Atlassian's descriptions | 5 | normalised to backticks |

`@stable` was ours; nothing read it — not a script, not eslint — and there was no ladder around it, so `@public` loses nothing. The bare `{@link}`s failed because typedoc resolves against symbols in scope of the file: `{@link OAuthError}` beside them worked only because it is imported.

The specification itself arrives holding Javadoc — `\{@code POST /...\}` with escaped braces, and `\\u2014` where an em dash belongs, which reached the emitted comment as the literal escape. The normaliser unescapes the braces first, then matches: a path template inside a span is escaped too, and stopping at the first closing brace cut `\{serviceDeskId\}` in half. Covered by `packages/base/test/descriptionLinks.test.js`, 8 cases including both nesting forms; the generator suite is 237 green.

Result: **41 warnings → 0**, verified by running typedoc against this tree. Because the fix is in `base/core`, confluence.js and trello.js get it on their next regeneration.

### Riding along

**A rename already made upstream.** Syncing `core/` brings `collectedSchemaDrift` → `getCollectedSchemaDrift` and a module-private `typeAtPath` → `describeTypeAtPath`; jira.js was behind. Neither is exported from the public entry points — the only importer is `tests/live/setup/auditCollector.ts`, updated here.

**The changelog shows the codemod command** instead of naming the file it ships as. Verified by installing `jira.js@6.0.0` from npm into a clean project and running it: `Version3Client` → `createCloudClient` and `authentication.basic` → `auth: { type: 'basic' }`, 1 ok / 0 errors. The published release notes were updated to match, generated with the same regex `publish.yml` uses.

Specification drift picked up during regeneration — an expanded description and one newly documented 400 on the cloud surface — was deliberately left out; it belongs in its own change.