### PR TITLE
chore: retire the develop branch

### DIFF
--- a/.github/workflows/live-tests.yaml
+++ b/.github/workflows/live-tests.yaml
@@ -2,7 +2,7 @@ name: 🧩 Live tests
 
 on:
   pull_request:
-    branches: [master, develop]
+    branches: [master]
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:

--- a/.github/workflows/live-tests.yaml
+++ b/.github/workflows/live-tests.yaml
@@ -7,6 +7,10 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: live-tests
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://www.npmjs.com/package/jira.js" target="_blank" rel="noopener noreferrer"><img alt="NPM version" src="https://img.shields.io/npm/v/jira.js.svg?maxAge=3600&style=flat-square" /></a>
   <a href="https://www.npmjs.com/package/jira.js" target="_blank" rel="noopener noreferrer"><img alt="NPM downloads per month" src="https://img.shields.io/npm/dm/jira.js.svg?maxAge=3600&style=flat-square" /></a>
   <a href="https://github.com/MrRefactoring/jira.js" target="_blank" rel="noopener noreferrer"><img alt="build status" src="https://img.shields.io/github/actions/workflow/status/mrrefactoring/jira.js/.github/workflows/ci.yaml?branch=master&style=flat-square"></a>
-  <a href="https://github.com/mrrefactoring/jira.js/blob/develop/LICENSE" target="_blank" rel="noopener noreferrer"><img alt="license" src="https://img.shields.io/github/license/mrrefactoring/jira.js?color=green&style=flat-square"/></a>
+  <a href="https://github.com/mrrefactoring/jira.js/blob/master/LICENSE" target="_blank" rel="noopener noreferrer"><img alt="license" src="https://img.shields.io/github/license/mrrefactoring/jira.js?color=green&style=flat-square"/></a>
   <a href="https://www.typescriptlang.org/" target="_blank" rel="noopener noreferrer"><img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-Ready-blue?style=flat-square&logo=typescript" /></a>
   <a href="https://nodejs.org/" target="_blank" rel="noopener noreferrer"><img alt="Node.js" src="https://img.shields.io/badge/Node.js-22%2B-green?style=flat-square&logo=node.js" /></a>
 
@@ -505,4 +505,4 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 ## License
 
 MIT License © MrRefactoring  
-See [LICENSE](https://github.com/mrrefactoring/jira.js/blob/develop/LICENSE) for details.
+See [LICENSE](https://github.com/mrrefactoring/jira.js/blob/master/LICENSE) for details.

--- a/README.ru.md
+++ b/README.ru.md
@@ -6,7 +6,7 @@
   <a href="https://www.npmjs.com/package/jira.js" target="_blank" rel="noopener noreferrer"><img alt="NPM version" src="https://img.shields.io/npm/v/jira.js.svg?maxAge=3600&style=flat-square" /></a>
   <a href="https://www.npmjs.com/package/jira.js" target="_blank" rel="noopener noreferrer"><img alt="NPM downloads per month" src="https://img.shields.io/npm/dm/jira.js.svg?maxAge=3600&style=flat-square" /></a>
   <a href="https://github.com/MrRefactoring/jira.js" target="_blank" rel="noopener noreferrer"><img alt="build status" src="https://img.shields.io/github/actions/workflow/status/mrrefactoring/jira.js/.github/workflows/ci.yaml?branch=master&style=flat-square"></a>
-  <a href="https://github.com/mrrefactoring/jira.js/blob/develop/LICENSE" target="_blank" rel="noopener noreferrer"><img alt="license" src="https://img.shields.io/github/license/mrrefactoring/jira.js?color=green&style=flat-square"/></a>
+  <a href="https://github.com/mrrefactoring/jira.js/blob/master/LICENSE" target="_blank" rel="noopener noreferrer"><img alt="license" src="https://img.shields.io/github/license/mrrefactoring/jira.js?color=green&style=flat-square"/></a>
   <a href="https://www.typescriptlang.org/" target="_blank" rel="noopener noreferrer"><img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-Ready-blue?style=flat-square&logo=typescript" /></a>
   <a href="https://nodejs.org/" target="_blank" rel="noopener noreferrer"><img alt="Node.js" src="https://img.shields.io/badge/Node.js-22%2B-green?style=flat-square&logo=node.js" /></a>
 
@@ -502,4 +502,4 @@ Jira.js идеально подходит для:
 ## Лицензия
 
 Лицензия MIT © MrRefactoring  
-Подробности см. в [LICENSE](https://github.com/mrrefactoring/jira.js/blob/develop/LICENSE).
+Подробности см. в [LICENSE](https://github.com/mrrefactoring/jira.js/blob/master/LICENSE).


### PR DESCRIPTION
`develop` last moved on 2026-05-12 and 6.0 shipped from another line, so the branch is being deleted. Two things still pointed at it and would have broken on their own.

**The licence links.** The badge in both READMEs, plus the licence link near the bottom of each, resolved through `blob/develop/LICENSE` — four links, all 404 the moment the branch goes. Now on `master`.

**The live-test trigger.** `live-tests.yaml` still opened its live suite for pull requests targeting `develop`. Those runs share one real Jira site, so a dead branch was holding a claim on it.

Nothing else in `.github/` or the READMEs named the branch — checked.

### What is being discarded

`develop` carried one commit master does not have: `5a2f7cc23` "v6.0.0" from 2026-05-12, 5382 files changed. It is a separate attempt at 6.0 — changesets, husky, commitlint, `release.yml", `changeset-check.yml`, `TESTING.md`, and consumer smoke tests for node-cjs / node-esm / ts-bundler. None of it reached `master`, and merging it now would mean 81k insertions from an approach that was dropped.

Deleting the branch by decision, without archiving it. Worth knowing: the consumer smoke tests have no equivalent on `master` — nothing currently checks that the published tarball resolves from an ESM consumer or through a bundler. That gap outlives this PR.