### PR TITLE
test: prove the packed tarball works from a consumer project

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: 🏗️ Build
         run: pnpm run build
+      - name: 📥 Consumer install and resolution
+        run: pnpm run check:consumers
       - name: 🌐 Browser-safe build
         run: pnpm run check:browser
       - name: 🎭 Install Chromium

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "code:formatting": "pnpm run prettier && pnpm run lint:fix",
     "check:browser": "node scripts/checkBrowserSafe.ts",
     "check:browser:e2e": "node scripts/checkBrowser.ts",
+    "check:consumers": "node scripts/checkConsumers.ts",
     "test": "vitest run",
     "test:live": "vitest run --config vitest.config.live.ts",
     "audit:schemas": "node scripts/schemaAudit.ts",

--- a/scripts/checkConsumers.ts
+++ b/scripts/checkConsumers.ts
@@ -1,0 +1,134 @@
+/**
+ * Installs the packed tarball into a throwaway project and uses it the way a consumer would.
+ *
+ * Everything else in CI reads this repository's own tree, where the source resolves through `tsconfig` paths and the
+ * `#/` alias. A consumer has neither. The failures that class produces have all shipped before:
+ *
+ * - a subpath that resolves here and 404s from `node_modules` (#403);
+ * - an `exports` map that answers for `import` but not for a type resolver, so every consumer's `tsc` fails while the
+ *   runtime is fine (#381, #383);
+ * - a stray `package.json` inside `src/`, which redefines `#/` for the files under it and breaks the source
+ *   navigation that shipping `src/` exists to provide — invisible to a build that resolves the alias through
+ *   `tsconfig` instead.
+ *
+ * Both type resolvers are exercised, because they disagree: `bundler` reads `exports` loosely, `nodenext` enforces
+ * extensions and the ESM/CJS split.
+ *
+ * Runs on bare `node`; keep the types erasable.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+if (!existsSync(join(root, 'dist'))) {
+  console.error('[consumers] dist/ is missing. Run `pnpm run build` first.');
+  process.exit(1);
+}
+
+const problems: string[] = [];
+const workspace = mkdtempSync(join(tmpdir(), 'jira-js-consumer-'));
+
+function run(command: string, args: string[], cwd: string): string {
+  return execFileSync(command, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+try {
+  const packOutput = run('npm', ['pack', '--pack-destination', workspace, '--silent'], root);
+  const tarball = join(workspace, packOutput.trim().split('\n').at(-1) as string);
+
+  const packed = run('tar', ['tzf', tarball], workspace)
+    .split('\n')
+    .map(entry => entry.replace(/^package\//, ''));
+
+  const nestedManifests = packed.filter(entry => /^src\/.+\/package\.json$/.test(entry));
+
+  if (nestedManifests.length > 0) {
+    problems.push(
+      `the tarball carries a package.json inside src/ (${nestedManifests.join(', ')}). ` +
+        'It overrides the root `imports` map for every file beneath it, so `#/` stops pointing at src/.',
+    );
+  }
+
+  writeFileSync(
+    join(workspace, 'package.json'),
+    `${JSON.stringify({ name: 'consumer', private: true, type: 'module', version: '0.0.0' }, null, 2)}\n`,
+  );
+
+  run('npm', ['install', '--no-audit', '--no-fund', '--silent', tarball], workspace);
+
+  const SUBPATHS = ['jira.js', 'jira.js/core', 'jira.js/cloud', 'jira.js/agile', 'jira.js/serviceDesk'];
+
+  const runtimeProbe = [
+    ...SUBPATHS.map((subpath, index) => `import * as m${index} from '${subpath}';`),
+    `const surfaces = [${SUBPATHS.map((_, index) => `m${index}`).join(', ')}];`,
+    `const names = ${JSON.stringify(SUBPATHS)};`,
+    'surfaces.forEach((surface, index) => {',
+    '  if (Object.keys(surface).length === 0) {',
+    "    console.error(`empty namespace from ${names[index]}`);",
+    '    process.exitCode = 1;',
+    '  }',
+    '});',
+    "if (typeof m0.createCloudClient !== 'function') {",
+    "  console.error('createCloudClient is not a function on the root export');",
+    '  process.exitCode = 1;',
+    '}',
+  ].join('\n');
+
+  writeFileSync(join(workspace, 'probe.mjs'), `${runtimeProbe}\n`);
+
+  try {
+    run('node', ['probe.mjs'], workspace);
+  } catch (error) {
+    problems.push(`the package does not import from a consumer project:\n${(error as Error).message}`);
+  }
+
+  const typeProbe = [
+    "import { createCloudClient, isNotFoundError } from 'jira.js';",
+    "import { createClient } from 'jira.js/core';",
+    "import type { Client } from 'jira.js/core';",
+    '',
+    "const client: Client = createClient({ host: 'https://example.atlassian.net' });",
+    'export const jira = createCloudClient(client);',
+    'export const predicate: (value: unknown) => boolean = isNotFoundError;',
+  ].join('\n');
+
+  writeFileSync(join(workspace, 'probe.ts'), `${typeProbe}\n`);
+
+  for (const moduleResolution of ['bundler', 'nodenext'] as const) {
+    const module = moduleResolution === 'nodenext' ? 'nodenext' : 'esnext';
+
+    writeFileSync(
+      join(workspace, `tsconfig.${moduleResolution}.json`),
+      `${JSON.stringify(
+        {
+          compilerOptions: { module, moduleResolution, noEmit: true, skipLibCheck: true, strict: true, target: 'es2022' },
+          files: ['probe.ts'],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    try {
+      run('node', [join(root, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', `tsconfig.${moduleResolution}.json`], workspace);
+    } catch (error) {
+      const output = ((error as { stdout?: string }).stdout ?? (error as Error).message).trim();
+
+      problems.push(`types do not resolve under moduleResolution "${moduleResolution}":\n${output}`);
+    }
+  }
+} finally {
+  rmSync(workspace, { recursive: true, force: true });
+}
+
+if (problems.length > 0) {
+  console.error(`[consumers] ${problems.length} problem(s):\n`);
+  problems.forEach(problem => console.error(`  - ${problem}\n`));
+  process.exit(1);
+}
+
+console.log('[consumers] the packed tarball installs, imports and type-checks from a clean project.');


### PR DESCRIPTION
Closes the gap that let today's defect through.

Every other check reads this repository's own tree, where imports resolve through `tsconfig` paths and the `#/` alias. A consumer installing from npm has neither. That gap has shipped three times — a subpath that resolved here and 404'd from `node_modules` (#403), and an `exports` map that answered for `import` but not for a type resolver (#381, #383).

It happened again in #426: a stray `package.json` copied into `src/` redefined `#/` for the files beneath it, breaking the source navigation that shipping `src/` exists to provide. All ten checks stayed green, because the build resolves that alias through `tsconfig` rather than `imports`. Fixed in #427; nothing existed to catch it.

### What the gate does

`npm pack`, then install the tarball into a throwaway ESM project outside the repository, and from there:

- import the root and every subpath — `core`, `cloud`, `agile`, `serviceDesk` — asserting each namespace is non-empty and `createCloudClient` is callable;
- type-check a small consumer file under **both** `moduleResolution: bundler` and `nodenext`. They disagree — `bundler` reads `exports` loosely, `nodenext` enforces extensions and the ESM/CJS split — so either can fail while the other passes;
- reject a `package.json` nested inside `src/`.

Wired into the existing 📦 Package checks job, before the browser gates, since it needs the same build.

### Verified in both directions

A check that cannot fail proves nothing, so I reintroduced today's defect and confirmed the exit code rather than reasoning about it:

```
код возврата при дефекте: 1
код возврата на чистом:   0
```

The failure message names the file and says why it matters, rather than reporting a diff.

The script follows the existing convention for `scripts/` — bare `node`, erasable types, a doc comment stating which shipped failures it guards. Like `checkBrowser.ts` beside it, it sits outside `tsconfig`'s `include`; type-checked separately and clean.