### PR TITLE
fix: two models stop collapsing to an empty object

### DIFF
--- a/src/cloud/models/fieldIdIdentifier.ts
+++ b/src/cloud/models/fieldIdIdentifier.ts
@@ -1,6 +1,9 @@
-import type { z } from 'zod';
+import { z } from 'zod';
 import { apiObject } from '#/core';
+import { FieldIdentifierObjectSchema } from '../models';
 
-export const FieldIdIdentifierSchema = apiObject({});
+export const FieldIdIdentifierSchema = apiObject({}).extend(FieldIdentifierObjectSchema.shape).extend({
+  identifier: z.string().optional(),
+});
 
 export type FieldIdIdentifier = z.infer<typeof FieldIdIdentifierSchema>;

--- a/src/cloud/models/projectIdAssociationContext.ts
+++ b/src/cloud/models/projectIdAssociationContext.ts
@@ -1,6 +1,9 @@
-import type { z } from 'zod';
+import { z } from 'zod';
 import { apiObject } from '#/core';
+import { AssociationContextObjectSchema } from '../models';
 
-export const ProjectIdAssociationContextSchema = apiObject({});
+export const ProjectIdAssociationContextSchema = apiObject({}).extend(AssociationContextObjectSchema.shape).extend({
+  identifier: z.number().optional(),
+});
 
 export type ProjectIdAssociationContext = z.infer<typeof ProjectIdAssociationContextSchema>;

--- a/src/cloud/parameters/addActorUsers.ts
+++ b/src/cloud/parameters/addActorUsers.ts
@@ -1,17 +1,15 @@
 import { z } from 'zod';
 import { ActorsMapSchema } from '../models';
 
-export const AddActorUsersSchema = z
-  .object({
-    /** The project ID or project key (case sensitive). */
-    projectIdOrKey: z.string(),
-    /**
-     * The ID of the project role. Use [Get all project
-     * roles](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-role/#api-rest-api-3-role-get) to
-     * get a list of project role IDs.
-     */
-    id: z.number(),
-  })
-  .extend(ActorsMapSchema.shape);
+export const AddActorUsersSchema = z.object({}).extend(ActorsMapSchema.shape).extend({
+  /** The project ID or project key (case sensitive). */
+  projectIdOrKey: z.string(),
+  /**
+   * The ID of the project role. Use [Get all project
+   * roles](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-role/#api-rest-api-3-role-get) to get
+   * a list of project role IDs.
+   */
+  id: z.number(),
+});
 
 export type AddActorUsers = z.input<typeof AddActorUsersSchema>;

--- a/src/cloud/parameters/addComment.ts
+++ b/src/cloud/parameters/addComment.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { CommentInputSchema } from '../models';
 
 export const AddCommentSchema = z
-  .object({
+  .object({})
+  .extend(CommentInputSchema.shape)
+  .extend({
     /** The ID or key of the issue. */
     issueIdOrKey: z.string(),
     /**
@@ -13,7 +15,6 @@ export const AddCommentSchema = z
     expand: z
       .union([z.string(), z.array(z.string()), z.enum(['renderedBody']), z.array(z.enum(['renderedBody']))])
       .optional(),
-  })
-  .extend(CommentInputSchema.shape);
+  });
 
 export type AddComment = z.input<typeof AddCommentSchema>;

--- a/src/cloud/parameters/addIssueTypesToContext.ts
+++ b/src/cloud/parameters/addIssueTypesToContext.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { IssueTypeIdsSchema } from '../models';
 
-export const AddIssueTypesToContextSchema = z
-  .object({
-    /** The ID of the custom field. */
-    fieldId: z.string(),
-    /** The ID of the context. */
-    contextId: z.number(),
-  })
-  .extend(IssueTypeIdsSchema.shape);
+export const AddIssueTypesToContextSchema = z.object({}).extend(IssueTypeIdsSchema.shape).extend({
+  /** The ID of the custom field. */
+  fieldId: z.string(),
+  /** The ID of the context. */
+  contextId: z.number(),
+});
 
 export type AddIssueTypesToContext = z.input<typeof AddIssueTypesToContextSchema>;

--- a/src/cloud/parameters/addIssueTypesToIssueTypeScheme.ts
+++ b/src/cloud/parameters/addIssueTypesToIssueTypeScheme.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { IssueTypeIdsSchema } from '../models';
 
-export const AddIssueTypesToIssueTypeSchemeSchema = z
-  .object({
-    /** The ID of the issue type scheme. */
-    issueTypeSchemeId: z.number(),
-  })
-  .extend(IssueTypeIdsSchema.shape);
+export const AddIssueTypesToIssueTypeSchemeSchema = z.object({}).extend(IssueTypeIdsSchema.shape).extend({
+  /** The ID of the issue type scheme. */
+  issueTypeSchemeId: z.number(),
+});
 
 export type AddIssueTypesToIssueTypeScheme = z.input<typeof AddIssueTypesToIssueTypeSchemeSchema>;

--- a/src/cloud/parameters/addNotifications.ts
+++ b/src/cloud/parameters/addNotifications.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { AddNotificationsDetailsSchema } from '../models';
 
-export const AddNotificationsSchema = z
-  .object({
-    /** The ID of the notification scheme. */
-    id: z.string(),
-  })
-  .extend(AddNotificationsDetailsSchema.shape);
+export const AddNotificationsSchema = z.object({}).extend(AddNotificationsDetailsSchema.shape).extend({
+  /** The ID of the notification scheme. */
+  id: z.string(),
+});
 
 export type AddNotifications = z.input<typeof AddNotificationsSchema>;

--- a/src/cloud/parameters/addProjectRoleActorsToRole.ts
+++ b/src/cloud/parameters/addProjectRoleActorsToRole.ts
@@ -1,15 +1,13 @@
 import { z } from 'zod';
 import { ActorInputSchema } from '../models';
 
-export const AddProjectRoleActorsToRoleSchema = z
-  .object({
-    /**
-     * The ID of the project role. Use [Get all project
-     * roles](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-role/#api-rest-api-3-role-get) to
-     * get a list of project role IDs.
-     */
-    id: z.number(),
-  })
-  .extend(ActorInputSchema.shape);
+export const AddProjectRoleActorsToRoleSchema = z.object({}).extend(ActorInputSchema.shape).extend({
+  /**
+   * The ID of the project role. Use [Get all project
+   * roles](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-role/#api-rest-api-3-role-get) to get
+   * a list of project role IDs.
+   */
+  id: z.number(),
+});
 
 export type AddProjectRoleActorsToRole = z.input<typeof AddProjectRoleActorsToRoleSchema>;

--- a/src/cloud/parameters/addScreenTab.ts
+++ b/src/cloud/parameters/addScreenTab.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { ScreenableTabSchema } from '../models';
 
-export const AddScreenTabSchema = z
-  .object({
-    /** The ID of the screen. */
-    screenId: z.number(),
-  })
-  .extend(ScreenableTabSchema.shape);
+export const AddScreenTabSchema = z.object({}).extend(ScreenableTabSchema.shape).extend({
+  /** The ID of the screen. */
+  screenId: z.number(),
+});
 
 export type AddScreenTab = z.input<typeof AddScreenTabSchema>;

--- a/src/cloud/parameters/addScreenTabField.ts
+++ b/src/cloud/parameters/addScreenTabField.ts
@@ -1,14 +1,12 @@
 import { z } from 'zod';
 import { AddFieldSchema } from '../models';
 
-export const AddScreenTabFieldSchema = z
-  .object({
-    /** The ID of the screen. */
-    screenId: z.number(),
-    /** The ID of the screen tab. */
-    tabId: z.number(),
-    skipFieldAssociation: z.boolean().optional(),
-  })
-  .extend(AddFieldSchema.shape);
+export const AddScreenTabFieldSchema = z.object({}).extend(AddFieldSchema.shape).extend({
+  /** The ID of the screen. */
+  screenId: z.number(),
+  /** The ID of the screen tab. */
+  tabId: z.number(),
+  skipFieldAssociation: z.boolean().optional(),
+});
 
 export type AddScreenTabField = z.input<typeof AddScreenTabFieldSchema>;

--- a/src/cloud/parameters/addSharePermission.ts
+++ b/src/cloud/parameters/addSharePermission.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { SharePermissionInputSchema } from '../models';
 
-export const AddSharePermissionSchema = z
-  .object({
-    /** The ID of the filter. */
-    id: z.number(),
-  })
-  .extend(SharePermissionInputSchema.shape);
+export const AddSharePermissionSchema = z.object({}).extend(SharePermissionInputSchema.shape).extend({
+  /** The ID of the filter. */
+  id: z.number(),
+});
 
 export type AddSharePermission = z.input<typeof AddSharePermissionSchema>;

--- a/src/cloud/parameters/addUserToGroup.ts
+++ b/src/cloud/parameters/addUserToGroup.ts
@@ -1,16 +1,14 @@
 import { z } from 'zod';
 import { UpdateUserToGroupSchema } from '../models';
 
-export const AddUserToGroupSchema = z
-  .object({
-    /**
-     * As a group's name can change, use of `groupId` is recommended to identify a group. The name of the group. This
-     * parameter cannot be used with the `groupId` parameter.
-     */
-    groupname: z.string().optional(),
-    /** The ID of the group. This parameter cannot be used with the `groupName` parameter. */
-    groupId: z.string().optional(),
-  })
-  .extend(UpdateUserToGroupSchema.shape);
+export const AddUserToGroupSchema = z.object({}).extend(UpdateUserToGroupSchema.shape).extend({
+  /**
+   * As a group's name can change, use of `groupId` is recommended to identify a group. The name of the group. This
+   * parameter cannot be used with the `groupId` parameter.
+   */
+  groupname: z.string().optional(),
+  /** The ID of the group. This parameter cannot be used with the `groupName` parameter. */
+  groupId: z.string().optional(),
+});
 
 export type AddUserToGroup = z.input<typeof AddUserToGroupSchema>;

--- a/src/cloud/parameters/addWorklog.ts
+++ b/src/cloud/parameters/addWorklog.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { WorklogInputSchema } from '../models';
 
 export const AddWorklogSchema = z
-  .object({
+  .object({})
+  .extend(WorklogInputSchema.shape)
+  .extend({
     /** The ID or key the issue. */
     issueIdOrKey: z.string(),
     /** Whether users watching the issue are notified by email. */
@@ -40,7 +42,6 @@ export const AddWorklogSchema = z
      * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) can use this flag.
      */
     overrideEditableFlag: z.boolean().optional(),
-  })
-  .extend(WorklogInputSchema.shape);
+  });
 
 export type AddWorklog = z.input<typeof AddWorklogSchema>;

--- a/src/cloud/parameters/analyseExpression.ts
+++ b/src/cloud/parameters/analyseExpression.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { JiraExpressionForAnalysisSchema } from '../models';
 
 export const AnalyseExpressionSchema = z
-  .object({
+  .object({})
+  .extend(JiraExpressionForAnalysisSchema.shape)
+  .extend({
     /**
      * The check to perform:
      *
@@ -16,7 +18,6 @@ export const AnalyseExpressionSchema = z
      *   expression may execute.
      */
     check: z.enum(['syntax', 'type', 'complexity']).optional(),
-  })
-  .extend(JiraExpressionForAnalysisSchema.shape);
+  });
 
 export type AnalyseExpression = z.input<typeof AnalyseExpressionSchema>;

--- a/src/cloud/parameters/appendMappingsForIssueTypeScreenScheme.ts
+++ b/src/cloud/parameters/appendMappingsForIssueTypeScreenScheme.ts
@@ -2,10 +2,11 @@ import { z } from 'zod';
 import { IssueTypeScreenSchemeMappingDetailsSchema } from '../models';
 
 export const AppendMappingsForIssueTypeScreenSchemeSchema = z
-  .object({
+  .object({})
+  .extend(IssueTypeScreenSchemeMappingDetailsSchema.shape)
+  .extend({
     /** The ID of the issue type screen scheme. */
     issueTypeScreenSchemeId: z.string(),
-  })
-  .extend(IssueTypeScreenSchemeMappingDetailsSchema.shape);
+  });
 
 export type AppendMappingsForIssueTypeScreenScheme = z.input<typeof AppendMappingsForIssueTypeScreenSchemeSchema>;

--- a/src/cloud/parameters/assignIssue.ts
+++ b/src/cloud/parameters/assignIssue.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { DashboardUserSchema } from '../models';
 
-export const AssignIssueSchema = z
-  .object({
-    /** The ID or key of the issue to be assigned. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(DashboardUserSchema.shape);
+export const AssignIssueSchema = z.object({}).extend(DashboardUserSchema.shape).extend({
+  /** The ID or key of the issue to be assigned. */
+  issueIdOrKey: z.string(),
+});
 
 export type AssignIssue = z.input<typeof AssignIssueSchema>;

--- a/src/cloud/parameters/assignPermissionScheme.ts
+++ b/src/cloud/parameters/assignPermissionScheme.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { IdSchema } from '../models';
 
 export const AssignPermissionSchemeSchema = z
-  .object({
+  .object({})
+  .extend(IdSchema.shape)
+  .extend({
     /** The project ID or project key (case sensitive). */
     projectKeyOrId: z.string(),
     /**
@@ -25,7 +27,6 @@ export const AssignPermissionSchemeSchema = z
         z.array(z.enum(['all', 'field', 'group', 'permissions', 'projectRole', 'user'])),
       ])
       .optional(),
-  })
-  .extend(IdSchema.shape);
+  });
 
 export type AssignPermissionScheme = z.input<typeof AssignPermissionSchemeSchema>;

--- a/src/cloud/parameters/assignProjectsToCustomFieldContext.ts
+++ b/src/cloud/parameters/assignProjectsToCustomFieldContext.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { ProjectIdsSchema } from '../models';
 
-export const AssignProjectsToCustomFieldContextSchema = z
-  .object({
-    /** The ID of the custom field. */
-    fieldId: z.string(),
-    /** The ID of the context. */
-    contextId: z.number(),
-  })
-  .extend(ProjectIdsSchema.shape);
+export const AssignProjectsToCustomFieldContextSchema = z.object({}).extend(ProjectIdsSchema.shape).extend({
+  /** The ID of the custom field. */
+  fieldId: z.string(),
+  /** The ID of the context. */
+  contextId: z.number(),
+});
 
 export type AssignProjectsToCustomFieldContext = z.input<typeof AssignProjectsToCustomFieldContextSchema>;

--- a/src/cloud/parameters/bulkDeleteIssueProperty.ts
+++ b/src/cloud/parameters/bulkDeleteIssueProperty.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { IssueFilterForBulkPropertyDeleteSchema } from '../models';
 
-export const BulkDeleteIssuePropertySchema = z
-  .object({
-    /** The key of the property. */
-    propertyKey: z.string(),
-  })
-  .extend(IssueFilterForBulkPropertyDeleteSchema.shape);
+export const BulkDeleteIssuePropertySchema = z.object({}).extend(IssueFilterForBulkPropertyDeleteSchema.shape).extend({
+  /** The key of the property. */
+  propertyKey: z.string(),
+});
 
 export type BulkDeleteIssueProperty = z.input<typeof BulkDeleteIssuePropertySchema>;

--- a/src/cloud/parameters/bulkSetIssueProperty.ts
+++ b/src/cloud/parameters/bulkSetIssueProperty.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { BulkIssuePropertyUpdateRequestSchema } from '../models';
 
-export const BulkSetIssuePropertySchema = z
-  .object({
-    /** The key of the property. The maximum length is 255 characters. */
-    propertyKey: z.string(),
-  })
-  .extend(BulkIssuePropertyUpdateRequestSchema.shape);
+export const BulkSetIssuePropertySchema = z.object({}).extend(BulkIssuePropertyUpdateRequestSchema.shape).extend({
+  /** The key of the property. The maximum length is 255 characters. */
+  propertyKey: z.string(),
+});
 
 export type BulkSetIssueProperty = z.input<typeof BulkSetIssuePropertySchema>;

--- a/src/cloud/parameters/createCustomFieldContext.ts
+++ b/src/cloud/parameters/createCustomFieldContext.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { CreateCustomFieldContextSchema as CreateCustomFieldContextModelSchema } from '../models';
 
-export const CreateCustomFieldContextSchema = z
-  .object({
-    /** The ID of the custom field. */
-    fieldId: z.string(),
-  })
-  .extend(CreateCustomFieldContextModelSchema.shape);
+export const CreateCustomFieldContextSchema = z.object({}).extend(CreateCustomFieldContextModelSchema.shape).extend({
+  /** The ID of the custom field. */
+  fieldId: z.string(),
+});
 
 export type CreateCustomFieldContext = z.input<typeof CreateCustomFieldContextSchema>;

--- a/src/cloud/parameters/createCustomFieldOption.ts
+++ b/src/cloud/parameters/createCustomFieldOption.ts
@@ -2,12 +2,13 @@ import { z } from 'zod';
 import { BulkCustomFieldOptionCreateRequestSchema } from '../models';
 
 export const CreateCustomFieldOptionSchema = z
-  .object({
+  .object({})
+  .extend(BulkCustomFieldOptionCreateRequestSchema.shape)
+  .extend({
     /** The ID of the custom field. */
     fieldId: z.string(),
     /** The ID of the context. */
     contextId: z.number(),
-  })
-  .extend(BulkCustomFieldOptionCreateRequestSchema.shape);
+  });
 
 export type CreateCustomFieldOption = z.input<typeof CreateCustomFieldOptionSchema>;

--- a/src/cloud/parameters/createFilter.ts
+++ b/src/cloud/parameters/createFilter.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { FilterSchema } from '../models';
 
 export const CreateFilterSchema = z
-  .object({
+  .object({})
+  .extend(FilterSchema.shape)
+  .extend({
     /**
      * Use [expand](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#expansion) to include additional
      * information about filter in the response. This parameter accepts a comma-separated list. Expand options include:
@@ -31,7 +33,6 @@ export const CreateFilterSchema = z
      * permission](https://confluence.atlassian.com/x/x4dKLg).
      */
     overrideSharePermissions: z.boolean().optional(),
-  })
-  .extend(FilterSchema.shape);
+  });
 
 export type CreateFilter = z.input<typeof CreateFilterSchema>;

--- a/src/cloud/parameters/createIssue.ts
+++ b/src/cloud/parameters/createIssue.ts
@@ -1,15 +1,13 @@
 import { z } from 'zod';
 import { IssueUpdateDetailsSchema } from '../models';
 
-export const CreateIssueSchema = z
-  .object({
-    /**
-     * Whether the project in which the issue is created is added to the user's **Recently viewed** project list, as
-     * shown under **Projects** in Jira. When provided, the issue type and request type are added to the user's history
-     * for a project. These values are then used to provide defaults on the issue create screen.
-     */
-    updateHistory: z.boolean().optional(),
-  })
-  .extend(IssueUpdateDetailsSchema.shape);
+export const CreateIssueSchema = z.object({}).extend(IssueUpdateDetailsSchema.shape).extend({
+  /**
+   * Whether the project in which the issue is created is added to the user's **Recently viewed** project list, as shown
+   * under **Projects** in Jira. When provided, the issue type and request type are added to the user's history for a
+   * project. These values are then used to provide defaults on the issue create screen.
+   */
+  updateHistory: z.boolean().optional(),
+});
 
 export type CreateIssue = z.input<typeof CreateIssueSchema>;

--- a/src/cloud/parameters/createIssueFieldOption.ts
+++ b/src/cloud/parameters/createIssueFieldOption.ts
@@ -1,22 +1,19 @@
 import { z } from 'zod';
 import { IssueFieldOptionCreateSchema } from '../models';
 
-export const CreateIssueFieldOptionSchema = z
-  .object({
-    /**
-     * The field key is specified in the following format: **$(app-key)__$(field-key)**. For example,
-     * _example-add-on__example-issue-field_. To determine the `fieldKey` value, do one of the following:
-     *
-     * - Open the app's plugin descriptor, then **app-key** is the key at the top and **field-key** is the key in the
-     *   `jiraIssueFields` module. **app-key** can also be found in the app listing in the Atlassian Universal Plugin
-     *   Manager.
-     * - Run [Get
-     *   fields](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-rest-api-3-field-get)
-     *   and in the field details the value is returned in `key`. For example, `"key":
-     *   "teams-add-on__team-issue-field"`
-     */
-    fieldKey: z.string(),
-  })
-  .extend(IssueFieldOptionCreateSchema.shape);
+export const CreateIssueFieldOptionSchema = z.object({}).extend(IssueFieldOptionCreateSchema.shape).extend({
+  /**
+   * The field key is specified in the following format: **$(app-key)__$(field-key)**. For example,
+   * _example-add-on__example-issue-field_. To determine the `fieldKey` value, do one of the following:
+   *
+   * - Open the app's plugin descriptor, then **app-key** is the key at the top and **field-key** is the key in the
+   *   `jiraIssueFields` module. **app-key** can also be found in the app listing in the Atlassian Universal Plugin
+   *   Manager.
+   * - Run [Get
+   *   fields](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-rest-api-3-field-get)
+   *   and in the field details the value is returned in `key`. For example, `"key": "teams-add-on__team-issue-field"`
+   */
+  fieldKey: z.string(),
+});
 
 export type CreateIssueFieldOption = z.input<typeof CreateIssueFieldOptionSchema>;

--- a/src/cloud/parameters/createOrUpdateRemoteIssueLink.ts
+++ b/src/cloud/parameters/createOrUpdateRemoteIssueLink.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { RemoteIssueLinkRequestSchema } from '../models';
 
-export const CreateOrUpdateRemoteIssueLinkSchema = z
-  .object({
-    /** The ID or key of the issue. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(RemoteIssueLinkRequestSchema.shape);
+export const CreateOrUpdateRemoteIssueLinkSchema = z.object({}).extend(RemoteIssueLinkRequestSchema.shape).extend({
+  /** The ID or key of the issue. */
+  issueIdOrKey: z.string(),
+});
 
 export type CreateOrUpdateRemoteIssueLink = z.input<typeof CreateOrUpdateRemoteIssueLinkSchema>;

--- a/src/cloud/parameters/createPermissionGrant.ts
+++ b/src/cloud/parameters/createPermissionGrant.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { PermissionGrantSchema } from '../models';
 
 export const CreatePermissionGrantSchema = z
-  .object({
+  .object({})
+  .extend(PermissionGrantSchema.shape)
+  .extend({
     /** The ID of the permission scheme in which to create a new permission grant. */
     schemeId: z.number(),
     /**
@@ -24,7 +26,6 @@ export const CreatePermissionGrantSchema = z
         z.array(z.enum(['permissions', 'user', 'group', 'projectRole', 'field', 'all'])),
       ])
       .optional(),
-  })
-  .extend(PermissionGrantSchema.shape);
+  });
 
 export type CreatePermissionGrant = z.input<typeof CreatePermissionGrantSchema>;

--- a/src/cloud/parameters/createRelatedWork.ts
+++ b/src/cloud/parameters/createRelatedWork.ts
@@ -1,10 +1,8 @@
 import { z } from 'zod';
 import { VersionRelatedWorkSchema } from '../models';
 
-export const CreateRelatedWorkSchema = z
-  .object({
-    id: z.string(),
-  })
-  .extend(VersionRelatedWorkSchema.shape);
+export const CreateRelatedWorkSchema = z.object({}).extend(VersionRelatedWorkSchema.shape).extend({
+  id: z.string(),
+});
 
 export type CreateRelatedWork = z.input<typeof CreateRelatedWorkSchema>;

--- a/src/cloud/parameters/deleteAndReplaceVersion.ts
+++ b/src/cloud/parameters/deleteAndReplaceVersion.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { DeleteAndReplaceVersionSchema as DeleteAndReplaceVersionModelSchema } from '../models';
 
-export const DeleteAndReplaceVersionSchema = z
-  .object({
-    /** The ID of the version. */
-    id: z.string(),
-  })
-  .extend(DeleteAndReplaceVersionModelSchema.shape);
+export const DeleteAndReplaceVersionSchema = z.object({}).extend(DeleteAndReplaceVersionModelSchema.shape).extend({
+  /** The ID of the version. */
+  id: z.string(),
+});
 
 export type DeleteAndReplaceVersion = z.input<typeof DeleteAndReplaceVersionSchema>;

--- a/src/cloud/parameters/doTransition.ts
+++ b/src/cloud/parameters/doTransition.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { IssueUpdateDetailsSchema } from '../models';
 
-export const DoTransitionSchema = z
-  .object({
-    /** The ID or key of the issue. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(IssueUpdateDetailsSchema.shape);
+export const DoTransitionSchema = z.object({}).extend(IssueUpdateDetailsSchema.shape).extend({
+  /** The ID or key of the issue. */
+  issueIdOrKey: z.string(),
+});
 
 export type DoTransition = z.input<typeof DoTransitionSchema>;

--- a/src/cloud/parameters/editIssue.ts
+++ b/src/cloud/parameters/editIssue.ts
@@ -1,37 +1,35 @@
 import { z } from 'zod';
 import { IssueUpdateDetailsSchema } from '../models';
 
-export const EditIssueSchema = z
-  .object({
-    /** The ID or key of the issue. */
-    issueIdOrKey: z.string(),
-    /**
-     * Whether a notification email about the issue update is sent to all watchers. To disable the notification,
-     * administer Jira or administer project permissions are required. If the user doesn't have the necessary permission
-     * the request is ignored.
-     */
-    notifyUsers: z.boolean().optional(),
-    /**
-     * Whether screen security is overridden to enable hidden fields to be edited. Available to Connect and Forge app
-     * users with _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) and Forge apps acting
-     * on behalf of users with _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
-     */
-    overrideScreenSecurity: z.boolean().optional(),
-    /**
-     * Whether screen security is overridden to enable uneditable fields to be edited. Available to Connect and Forge
-     * app users with _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) and Forge apps
-     * acting on behalf of users with _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
-     */
-    overrideEditableFlag: z.boolean().optional(),
-    /**
-     * Whether the response should contain the issue with fields edited in this request. The returned issue will have
-     * the same format as in the [Get issue
-     * API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get).
-     */
-    returnIssue: z.boolean().optional(),
-    /** The Get issue API expand parameter to use in the response if the `returnIssue` parameter is `true`. */
-    expand: z.string().optional(),
-  })
-  .extend(IssueUpdateDetailsSchema.shape);
+export const EditIssueSchema = z.object({}).extend(IssueUpdateDetailsSchema.shape).extend({
+  /** The ID or key of the issue. */
+  issueIdOrKey: z.string(),
+  /**
+   * Whether a notification email about the issue update is sent to all watchers. To disable the notification,
+   * administer Jira or administer project permissions are required. If the user doesn't have the necessary permission
+   * the request is ignored.
+   */
+  notifyUsers: z.boolean().optional(),
+  /**
+   * Whether screen security is overridden to enable hidden fields to be edited. Available to Connect and Forge app
+   * users with _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) and Forge apps acting
+   * on behalf of users with _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
+   */
+  overrideScreenSecurity: z.boolean().optional(),
+  /**
+   * Whether screen security is overridden to enable uneditable fields to be edited. Available to Connect and Forge app
+   * users with _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) and Forge apps acting
+   * on behalf of users with _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
+   */
+  overrideEditableFlag: z.boolean().optional(),
+  /**
+   * Whether the response should contain the issue with fields edited in this request. The returned issue will have the
+   * same format as in the [Get issue
+   * API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get).
+   */
+  returnIssue: z.boolean().optional(),
+  /** The Get issue API expand parameter to use in the response if the `returnIssue` parameter is `true`. */
+  expand: z.string().optional(),
+});
 
 export type EditIssue = z.input<typeof EditIssueSchema>;

--- a/src/cloud/parameters/evaluateJSISJiraExpression.ts
+++ b/src/cloud/parameters/evaluateJSISJiraExpression.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { JiraExpressionEvaluateRequestSchema } from '../models';
 
 export const EvaluateJSISJiraExpressionSchema = z
-  .object({
+  .object({})
+  .extend(JiraExpressionEvaluateRequestSchema.shape)
+  .extend({
     /**
      * Use [expand](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#expansion) to include additional
      * information in the response. This parameter accepts `meta.complexity` that returns information about the
@@ -14,7 +16,6 @@ export const EvaluateJSISJiraExpressionSchema = z
     expand: z
       .union([z.string(), z.array(z.string()), z.enum(['meta.complexity']), z.array(z.enum(['meta.complexity']))])
       .optional(),
-  })
-  .extend(JiraExpressionEvaluateRequestSchema.shape);
+  });
 
 export type EvaluateJSISJiraExpression = z.input<typeof EvaluateJSISJiraExpressionSchema>;

--- a/src/cloud/parameters/fullyUpdateProjectRole.ts
+++ b/src/cloud/parameters/fullyUpdateProjectRole.ts
@@ -1,15 +1,13 @@
 import { z } from 'zod';
 import { CreateUpdateRoleRequestSchema } from '../models';
 
-export const FullyUpdateProjectRoleSchema = z
-  .object({
-    /**
-     * The ID of the project role. Use [Get all project
-     * roles](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-role/#api-rest-api-3-role-get) to
-     * get a list of project role IDs.
-     */
-    id: z.number(),
-  })
-  .extend(CreateUpdateRoleRequestSchema.shape);
+export const FullyUpdateProjectRoleSchema = z.object({}).extend(CreateUpdateRoleRequestSchema.shape).extend({
+  /**
+   * The ID of the project role. Use [Get all project
+   * roles](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-role/#api-rest-api-3-role-get) to get
+   * a list of project role IDs.
+   */
+  id: z.number(),
+});
 
 export type FullyUpdateProjectRole = z.input<typeof FullyUpdateProjectRoleSchema>;

--- a/src/cloud/parameters/getChangeLogsByIds.ts
+++ b/src/cloud/parameters/getChangeLogsByIds.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { IssueChangelogIdsSchema } from '../models';
 
-export const GetChangeLogsByIdsSchema = z
-  .object({
-    /** The ID or key of the issue. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(IssueChangelogIdsSchema.shape);
+export const GetChangeLogsByIdsSchema = z.object({}).extend(IssueChangelogIdsSchema.shape).extend({
+  /** The ID or key of the issue. */
+  issueIdOrKey: z.string(),
+});
 
 export type GetChangeLogsByIds = z.input<typeof GetChangeLogsByIdsSchema>;

--- a/src/cloud/parameters/getCommentsByIds.ts
+++ b/src/cloud/parameters/getCommentsByIds.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { IssueCommentListRequestSchema } from '../models';
 
 export const GetCommentsByIdsSchema = z
-  .object({
+  .object({})
+  .extend(IssueCommentListRequestSchema.shape)
+  .extend({
     /**
      * Use [expand](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#expansion) to include additional
      * information about comments in the response. This parameter accepts a comma-separated list. Expand options
@@ -19,7 +21,6 @@ export const GetCommentsByIdsSchema = z
         z.array(z.enum(['renderedBody', 'properties'])),
       ])
       .optional(),
-  })
-  .extend(IssueCommentListRequestSchema.shape);
+  });
 
 export type GetCommentsByIds = z.input<typeof GetCommentsByIdsSchema>;

--- a/src/cloud/parameters/getCustomFieldContextsForProjectsAndIssueTypes.ts
+++ b/src/cloud/parameters/getCustomFieldContextsForProjectsAndIssueTypes.ts
@@ -2,15 +2,16 @@ import { z } from 'zod';
 import { ProjectIssueTypeMappingsSchema } from '../models';
 
 export const GetCustomFieldContextsForProjectsAndIssueTypesSchema = z
-  .object({
+  .object({})
+  .extend(ProjectIssueTypeMappingsSchema.shape)
+  .extend({
     /** The ID of the custom field. */
     fieldId: z.string(),
     /** The index of the first item to return in a page of results (page offset). */
     startAt: z.number().optional(),
     /** The maximum number of items to return per page. */
     maxResults: z.number().optional(),
-  })
-  .extend(ProjectIssueTypeMappingsSchema.shape);
+  });
 
 export type GetCustomFieldContextsForProjectsAndIssueTypes = z.input<
   typeof GetCustomFieldContextsForProjectsAndIssueTypesSchema

--- a/src/cloud/parameters/getPrecomputationsByID.ts
+++ b/src/cloud/parameters/getPrecomputationsByID.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { JqlFunctionPrecomputationGetByIdRequestSchema } from '../models';
 
 export const GetPrecomputationsByIDSchema = z
-  .object({
+  .object({})
+  .extend(JqlFunctionPrecomputationGetByIdRequestSchema.shape)
+  .extend({
     /**
      * [Order](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#ordering) the results by a field:
      *
@@ -12,7 +14,6 @@ export const GetPrecomputationsByIDSchema = z
      * - `updated` Sorts by the updated timestamp.
      */
     orderBy: z.string().optional(),
-  })
-  .extend(JqlFunctionPrecomputationGetByIdRequestSchema.shape);
+  });
 
 export type GetPrecomputationsByID = z.input<typeof GetPrecomputationsByIDSchema>;

--- a/src/cloud/parameters/getWorklogsForIds.ts
+++ b/src/cloud/parameters/getWorklogsForIds.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { WorklogIdsRequestSchema } from '../models';
 
 export const GetWorklogsForIdsSchema = z
-  .object({
+  .object({})
+  .extend(WorklogIdsRequestSchema.shape)
+  .extend({
     /**
      * Use [expand](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#expansion) to include additional
      * information about worklogs in the response. This parameter accepts `properties` that returns the properties of
@@ -11,7 +13,6 @@ export const GetWorklogsForIdsSchema = z
     expand: z
       .union([z.string(), z.array(z.string()), z.enum(['properties']), z.array(z.enum(['properties']))])
       .optional(),
-  })
-  .extend(WorklogIdsRequestSchema.shape);
+  });
 
 export type GetWorklogsForIds = z.input<typeof GetWorklogsForIdsSchema>;

--- a/src/cloud/parameters/listWorkflowHistory.ts
+++ b/src/cloud/parameters/listWorkflowHistory.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { WorkflowHistoryListRequestSchema } from '../models';
 
 export const ListWorkflowHistorySchema = z
-  .object({
+  .object({})
+  .extend(WorkflowHistoryListRequestSchema.shape)
+  .extend({
     /**
      * Use [expand](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#expansion) to include additional
      * information in the response. This parameter accepts a comma-separated list. Expand options include:
@@ -18,7 +20,6 @@ export const ListWorkflowHistorySchema = z
         z.array(z.enum(['includeIntermediateWorkflows'])),
       ])
       .optional(),
-  })
-  .extend(WorkflowHistoryListRequestSchema.shape);
+  });
 
 export type ListWorkflowHistory = z.input<typeof ListWorkflowHistorySchema>;

--- a/src/cloud/parameters/moveScreenTabField.ts
+++ b/src/cloud/parameters/moveScreenTabField.ts
@@ -1,15 +1,13 @@
 import { z } from 'zod';
 import { MoveFieldSchema } from '../models';
 
-export const MoveScreenTabFieldSchema = z
-  .object({
-    /** The ID of the screen. */
-    screenId: z.number(),
-    /** The ID of the screen tab. */
-    tabId: z.number(),
-    /** The ID of the field. */
-    id: z.string(),
-  })
-  .extend(MoveFieldSchema.shape);
+export const MoveScreenTabFieldSchema = z.object({}).extend(MoveFieldSchema.shape).extend({
+  /** The ID of the screen. */
+  screenId: z.number(),
+  /** The ID of the screen tab. */
+  tabId: z.number(),
+  /** The ID of the field. */
+  id: z.string(),
+});
 
 export type MoveScreenTabField = z.input<typeof MoveScreenTabFieldSchema>;

--- a/src/cloud/parameters/moveVersion.ts
+++ b/src/cloud/parameters/moveVersion.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { VersionMoveSchema } from '../models';
 
-export const MoveVersionSchema = z
-  .object({
-    /** The ID of the version to be moved. */
-    id: z.string(),
-  })
-  .extend(VersionMoveSchema.shape);
+export const MoveVersionSchema = z.object({}).extend(VersionMoveSchema.shape).extend({
+  /** The ID of the version to be moved. */
+  id: z.string(),
+});
 
 export type MoveVersion = z.input<typeof MoveVersionSchema>;

--- a/src/cloud/parameters/notify.ts
+++ b/src/cloud/parameters/notify.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { NotificationSchema } from '../models';
 
-export const NotifySchema = z
-  .object({
-    /** ID or key of the issue that the notification is sent for. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(NotificationSchema.shape);
+export const NotifySchema = z.object({}).extend(NotificationSchema.shape).extend({
+  /** ID or key of the issue that the notification is sent for. */
+  issueIdOrKey: z.string(),
+});
 
 export type Notify = z.input<typeof NotifySchema>;

--- a/src/cloud/parameters/parseJqlQueries.ts
+++ b/src/cloud/parameters/parseJqlQueries.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { JqlQueriesToParseSchema } from '../models';
 
 export const ParseJqlQueriesSchema = z
-  .object({
+  .object({})
+  .extend(JqlQueriesToParseSchema.shape)
+  .extend({
     /**
      * How to validate the JQL query and treat the validation results. Validation options include:
      *
@@ -12,7 +14,6 @@ export const ParseJqlQueriesSchema = z
      * - `none` No validation is performed. If JQL query is correctly formed, the query structure is returned.
      */
     validation: z.enum(['strict', 'warn', 'none']),
-  })
-  .extend(JqlQueriesToParseSchema.shape);
+  });
 
 export type ParseJqlQueries = z.input<typeof ParseJqlQueriesSchema>;

--- a/src/cloud/parameters/partialUpdateProjectRole.ts
+++ b/src/cloud/parameters/partialUpdateProjectRole.ts
@@ -1,15 +1,13 @@
 import { z } from 'zod';
 import { CreateUpdateRoleRequestSchema } from '../models';
 
-export const PartialUpdateProjectRoleSchema = z
-  .object({
-    /**
-     * The ID of the project role. Use [Get all project
-     * roles](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-role/#api-rest-api-3-role-get) to
-     * get a list of project role IDs.
-     */
-    id: z.number(),
-  })
-  .extend(CreateUpdateRoleRequestSchema.shape);
+export const PartialUpdateProjectRoleSchema = z.object({}).extend(CreateUpdateRoleRequestSchema.shape).extend({
+  /**
+   * The ID of the project role. Use [Get all project
+   * roles](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-role/#api-rest-api-3-role-get) to get
+   * a list of project role IDs.
+   */
+  id: z.number(),
+});
 
 export type PartialUpdateProjectRole = z.input<typeof PartialUpdateProjectRoleSchema>;

--- a/src/cloud/parameters/publishDraftWorkflowScheme.ts
+++ b/src/cloud/parameters/publishDraftWorkflowScheme.ts
@@ -2,12 +2,13 @@ import { z } from 'zod';
 import { PublishDraftWorkflowSchemeSchema as PublishDraftWorkflowSchemeModelSchema } from '../models';
 
 export const PublishDraftWorkflowSchemeSchema = z
-  .object({
+  .object({})
+  .extend(PublishDraftWorkflowSchemeModelSchema.shape)
+  .extend({
     /** The ID of the workflow scheme that the draft belongs to. */
     id: z.number(),
     /** Whether the request only performs a validation. */
     validateOnly: z.boolean().optional(),
-  })
-  .extend(PublishDraftWorkflowSchemeModelSchema.shape);
+  });
 
 export type PublishDraftWorkflowScheme = z.input<typeof PublishDraftWorkflowSchemeSchema>;

--- a/src/cloud/parameters/removeCustomFieldContextFromProjects.ts
+++ b/src/cloud/parameters/removeCustomFieldContextFromProjects.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { ProjectIdsSchema } from '../models';
 
-export const RemoveCustomFieldContextFromProjectsSchema = z
-  .object({
-    /** The ID of the custom field. */
-    fieldId: z.string(),
-    /** The ID of the context. */
-    contextId: z.number(),
-  })
-  .extend(ProjectIdsSchema.shape);
+export const RemoveCustomFieldContextFromProjectsSchema = z.object({}).extend(ProjectIdsSchema.shape).extend({
+  /** The ID of the custom field. */
+  fieldId: z.string(),
+  /** The ID of the context. */
+  contextId: z.number(),
+});
 
 export type RemoveCustomFieldContextFromProjects = z.input<typeof RemoveCustomFieldContextFromProjectsSchema>;

--- a/src/cloud/parameters/removeIssueTypesFromContext.ts
+++ b/src/cloud/parameters/removeIssueTypesFromContext.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { IssueTypeIdsSchema } from '../models';
 
-export const RemoveIssueTypesFromContextSchema = z
-  .object({
-    /** The ID of the custom field. */
-    fieldId: z.string(),
-    /** The ID of the context. */
-    contextId: z.number(),
-  })
-  .extend(IssueTypeIdsSchema.shape);
+export const RemoveIssueTypesFromContextSchema = z.object({}).extend(IssueTypeIdsSchema.shape).extend({
+  /** The ID of the custom field. */
+  fieldId: z.string(),
+  /** The ID of the context. */
+  contextId: z.number(),
+});
 
 export type RemoveIssueTypesFromContext = z.input<typeof RemoveIssueTypesFromContextSchema>;

--- a/src/cloud/parameters/removeMappingsFromIssueTypeScreenScheme.ts
+++ b/src/cloud/parameters/removeMappingsFromIssueTypeScreenScheme.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { IssueTypeIdsSchema } from '../models';
 
-export const RemoveMappingsFromIssueTypeScreenSchemeSchema = z
-  .object({
-    /** The ID of the issue type screen scheme. */
-    issueTypeScreenSchemeId: z.string(),
-  })
-  .extend(IssueTypeIdsSchema.shape);
+export const RemoveMappingsFromIssueTypeScreenSchemeSchema = z.object({}).extend(IssueTypeIdsSchema.shape).extend({
+  /** The ID of the issue type screen scheme. */
+  issueTypeScreenSchemeId: z.string(),
+});
 
 export type RemoveMappingsFromIssueTypeScreenScheme = z.input<typeof RemoveMappingsFromIssueTypeScreenSchemeSchema>;

--- a/src/cloud/parameters/renameScreenTab.ts
+++ b/src/cloud/parameters/renameScreenTab.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { ScreenableTabSchema } from '../models';
 
-export const RenameScreenTabSchema = z
-  .object({
-    /** The ID of the screen. */
-    screenId: z.number(),
-    /** The ID of the screen tab. */
-    tabId: z.number(),
-  })
-  .extend(ScreenableTabSchema.shape);
+export const RenameScreenTabSchema = z.object({}).extend(ScreenableTabSchema.shape).extend({
+  /** The ID of the screen. */
+  screenId: z.number(),
+  /** The ID of the screen tab. */
+  tabId: z.number(),
+});
 
 export type RenameScreenTab = z.input<typeof RenameScreenTabSchema>;

--- a/src/cloud/parameters/reorderCustomFieldOptions.ts
+++ b/src/cloud/parameters/reorderCustomFieldOptions.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { OrderOfCustomFieldOptionsSchema } from '../models';
 
-export const ReorderCustomFieldOptionsSchema = z
-  .object({
-    /** The ID of the custom field. */
-    fieldId: z.string(),
-    /** The ID of the context. */
-    contextId: z.number(),
-  })
-  .extend(OrderOfCustomFieldOptionsSchema.shape);
+export const ReorderCustomFieldOptionsSchema = z.object({}).extend(OrderOfCustomFieldOptionsSchema.shape).extend({
+  /** The ID of the custom field. */
+  fieldId: z.string(),
+  /** The ID of the context. */
+  contextId: z.number(),
+});
 
 export type ReorderCustomFieldOptions = z.input<typeof ReorderCustomFieldOptionsSchema>;

--- a/src/cloud/parameters/reorderIssueTypesInIssueTypeScheme.ts
+++ b/src/cloud/parameters/reorderIssueTypesInIssueTypeScheme.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { OrderOfIssueTypesSchema } from '../models';
 
-export const ReorderIssueTypesInIssueTypeSchemeSchema = z
-  .object({
-    /** The ID of the issue type scheme. */
-    issueTypeSchemeId: z.number(),
-  })
-  .extend(OrderOfIssueTypesSchema.shape);
+export const ReorderIssueTypesInIssueTypeSchemeSchema = z.object({}).extend(OrderOfIssueTypesSchema.shape).extend({
+  /** The ID of the issue type scheme. */
+  issueTypeSchemeId: z.number(),
+});
 
 export type ReorderIssueTypesInIssueTypeScheme = z.input<typeof ReorderIssueTypesInIssueTypeSchemeSchema>;

--- a/src/cloud/parameters/setColumns.ts
+++ b/src/cloud/parameters/setColumns.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { ColumnRequestBodySchema } from '../models';
 
-export const SetColumnsSchema = z
-  .object({
-    /** The ID of the filter. */
-    id: z.number(),
-  })
-  .extend(ColumnRequestBodySchema.shape);
+export const SetColumnsSchema = z.object({}).extend(ColumnRequestBodySchema.shape).extend({
+  /** The ID of the filter. */
+  id: z.number(),
+});
 
 export type SetColumns = z.input<typeof SetColumnsSchema>;

--- a/src/cloud/parameters/toggleFeatureForProject.ts
+++ b/src/cloud/parameters/toggleFeatureForProject.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { ProjectFeatureStateSchema } from '../models';
 
-export const ToggleFeatureForProjectSchema = z
-  .object({
-    /** The ID or (case-sensitive) key of the project. */
-    projectIdOrKey: z.string(),
-    /** The key of the feature. */
-    featureKey: z.string(),
-  })
-  .extend(ProjectFeatureStateSchema.shape);
+export const ToggleFeatureForProjectSchema = z.object({}).extend(ProjectFeatureStateSchema.shape).extend({
+  /** The ID or (case-sensitive) key of the project. */
+  projectIdOrKey: z.string(),
+  /** The key of the feature. */
+  featureKey: z.string(),
+});
 
 export type ToggleFeatureForProject = z.input<typeof ToggleFeatureForProjectSchema>;

--- a/src/cloud/parameters/updateCustomField.ts
+++ b/src/cloud/parameters/updateCustomField.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { UpdateCustomFieldDetailsSchema } from '../models';
 
-export const UpdateCustomFieldSchema = z
-  .object({
-    /** The ID of the custom field. */
-    fieldId: z.string(),
-  })
-  .extend(UpdateCustomFieldDetailsSchema.shape);
+export const UpdateCustomFieldSchema = z.object({}).extend(UpdateCustomFieldDetailsSchema.shape).extend({
+  /** The ID of the custom field. */
+  fieldId: z.string(),
+});
 
 export type UpdateCustomField = z.input<typeof UpdateCustomFieldSchema>;

--- a/src/cloud/parameters/updateCustomFieldConfiguration.ts
+++ b/src/cloud/parameters/updateCustomFieldConfiguration.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { CustomFieldConfigurationsSchema } from '../models';
 
-export const UpdateCustomFieldConfigurationSchema = z
-  .object({
-    /** The ID or key of the custom field, for example `customfield_10000`. */
-    fieldIdOrKey: z.string(),
-  })
-  .extend(CustomFieldConfigurationsSchema.shape);
+export const UpdateCustomFieldConfigurationSchema = z.object({}).extend(CustomFieldConfigurationsSchema.shape).extend({
+  /** The ID or key of the custom field, for example `customfield_10000`. */
+  fieldIdOrKey: z.string(),
+});
 
 export type UpdateCustomFieldConfiguration = z.input<typeof UpdateCustomFieldConfigurationSchema>;

--- a/src/cloud/parameters/updateCustomFieldContext.ts
+++ b/src/cloud/parameters/updateCustomFieldContext.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { CustomFieldContextUpdateDetailsSchema } from '../models';
 
-export const UpdateCustomFieldContextSchema = z
-  .object({
-    /** The ID of the custom field. */
-    fieldId: z.string(),
-    /** The ID of the context. */
-    contextId: z.number(),
-  })
-  .extend(CustomFieldContextUpdateDetailsSchema.shape);
+export const UpdateCustomFieldContextSchema = z.object({}).extend(CustomFieldContextUpdateDetailsSchema.shape).extend({
+  /** The ID of the custom field. */
+  fieldId: z.string(),
+  /** The ID of the context. */
+  contextId: z.number(),
+});
 
 export type UpdateCustomFieldContext = z.input<typeof UpdateCustomFieldContextSchema>;

--- a/src/cloud/parameters/updateCustomFieldOption.ts
+++ b/src/cloud/parameters/updateCustomFieldOption.ts
@@ -2,12 +2,13 @@ import { z } from 'zod';
 import { BulkCustomFieldOptionUpdateRequestSchema } from '../models';
 
 export const UpdateCustomFieldOptionSchema = z
-  .object({
+  .object({})
+  .extend(BulkCustomFieldOptionUpdateRequestSchema.shape)
+  .extend({
     /** The ID of the custom field. */
     fieldId: z.string(),
     /** The ID of the context. */
     contextId: z.number(),
-  })
-  .extend(BulkCustomFieldOptionUpdateRequestSchema.shape);
+  });
 
 export type UpdateCustomFieldOption = z.input<typeof UpdateCustomFieldOptionSchema>;

--- a/src/cloud/parameters/updateCustomFieldValue.ts
+++ b/src/cloud/parameters/updateCustomFieldValue.ts
@@ -1,21 +1,19 @@
 import { z } from 'zod';
 import { CustomFieldValueUpdateDetailsSchema } from '../models';
 
-export const UpdateCustomFieldValueSchema = z
-  .object({
-    /** The ID or key of the custom field. For example, `customfield_10010`. */
-    fieldIdOrKey: z.string(),
-    /** Whether to generate a changelog for this update. */
-    generateChangelog: z.boolean().optional(),
-    /**
-     * Whether to generate app events for this update. Suppresses Forge, Connect, OAuth 2.0, and admin-configured
-     * webhooks (registered via the Jira admin UI). Note: Suppressing events means that "issue updated" events will not
-     * be emitted for your app or any other apps installed in Jira. This may cause other apps to retain stale data for
-     * the updated field, resulting in potentially confusing behaviour. We do not recommend using this flag in a
-     * Marketplace app as it may result in incompatibilities with other apps that depend on up-to-date issue data.
-     */
-    generateAppEvents: z.boolean().optional(),
-  })
-  .extend(CustomFieldValueUpdateDetailsSchema.shape);
+export const UpdateCustomFieldValueSchema = z.object({}).extend(CustomFieldValueUpdateDetailsSchema.shape).extend({
+  /** The ID or key of the custom field. For example, `customfield_10010`. */
+  fieldIdOrKey: z.string(),
+  /** Whether to generate a changelog for this update. */
+  generateChangelog: z.boolean().optional(),
+  /**
+   * Whether to generate app events for this update. Suppresses Forge, Connect, OAuth 2.0, and admin-configured webhooks
+   * (registered via the Jira admin UI). Note: Suppressing events means that "issue updated" events will not be emitted
+   * for your app or any other apps installed in Jira. This may cause other apps to retain stale data for the updated
+   * field, resulting in potentially confusing behaviour. We do not recommend using this flag in a Marketplace app as it
+   * may result in incompatibilities with other apps that depend on up-to-date issue data.
+   */
+  generateAppEvents: z.boolean().optional(),
+});
 
 export type UpdateCustomFieldValue = z.input<typeof UpdateCustomFieldValueSchema>;

--- a/src/cloud/parameters/updateDefaultScreenScheme.ts
+++ b/src/cloud/parameters/updateDefaultScreenScheme.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { UpdateDefaultScreenSchemeSchema as UpdateDefaultScreenSchemeModelSchema } from '../models';
 
-export const UpdateDefaultScreenSchemeSchema = z
-  .object({
-    /** The ID of the issue type screen scheme. */
-    issueTypeScreenSchemeId: z.string(),
-  })
-  .extend(UpdateDefaultScreenSchemeModelSchema.shape);
+export const UpdateDefaultScreenSchemeSchema = z.object({}).extend(UpdateDefaultScreenSchemeModelSchema.shape).extend({
+  /** The ID of the issue type screen scheme. */
+  issueTypeScreenSchemeId: z.string(),
+});
 
 export type UpdateDefaultScreenScheme = z.input<typeof UpdateDefaultScreenSchemeSchema>;

--- a/src/cloud/parameters/updateDefaultWorkflow.ts
+++ b/src/cloud/parameters/updateDefaultWorkflow.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { DefaultWorkflowSchema } from '../models';
 
-export const UpdateDefaultWorkflowSchema = z
-  .object({
-    /** The ID of the workflow scheme. */
-    id: z.number(),
-  })
-  .extend(DefaultWorkflowSchema.shape);
+export const UpdateDefaultWorkflowSchema = z.object({}).extend(DefaultWorkflowSchema.shape).extend({
+  /** The ID of the workflow scheme. */
+  id: z.number(),
+});
 
 export type UpdateDefaultWorkflow = z.input<typeof UpdateDefaultWorkflowSchema>;

--- a/src/cloud/parameters/updateDraftDefaultWorkflow.ts
+++ b/src/cloud/parameters/updateDraftDefaultWorkflow.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { DefaultWorkflowSchema } from '../models';
 
-export const UpdateDraftDefaultWorkflowSchema = z
-  .object({
-    /** The ID of the workflow scheme that the draft belongs to. */
-    id: z.number(),
-  })
-  .extend(DefaultWorkflowSchema.shape);
+export const UpdateDraftDefaultWorkflowSchema = z.object({}).extend(DefaultWorkflowSchema.shape).extend({
+  /** The ID of the workflow scheme that the draft belongs to. */
+  id: z.number(),
+});
 
 export type UpdateDraftDefaultWorkflow = z.input<typeof UpdateDraftDefaultWorkflowSchema>;

--- a/src/cloud/parameters/updateDraftWorkflowMapping.ts
+++ b/src/cloud/parameters/updateDraftWorkflowMapping.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { IssueTypesWorkflowMappingSchema } from '../models';
 
-export const UpdateDraftWorkflowMappingSchema = z
-  .object({
-    /** The ID of the workflow scheme that the draft belongs to. */
-    id: z.number(),
-    /** The name of the workflow. */
-    workflowName: z.string(),
-  })
-  .extend(IssueTypesWorkflowMappingSchema.shape);
+export const UpdateDraftWorkflowMappingSchema = z.object({}).extend(IssueTypesWorkflowMappingSchema.shape).extend({
+  /** The ID of the workflow scheme that the draft belongs to. */
+  id: z.number(),
+  /** The name of the workflow. */
+  workflowName: z.string(),
+});
 
 export type UpdateDraftWorkflowMapping = z.input<typeof UpdateDraftWorkflowMappingSchema>;

--- a/src/cloud/parameters/updateIssueFieldOption.ts
+++ b/src/cloud/parameters/updateIssueFieldOption.ts
@@ -1,24 +1,21 @@
 import { z } from 'zod';
 import { IssueFieldOptionSchema } from '../models';
 
-export const UpdateIssueFieldOptionSchema = z
-  .object({
-    /**
-     * The field key is specified in the following format: **$(app-key)__$(field-key)**. For example,
-     * _example-add-on__example-issue-field_. To determine the `fieldKey` value, do one of the following:
-     *
-     * - Open the app's plugin descriptor, then **app-key** is the key at the top and **field-key** is the key in the
-     *   `jiraIssueFields` module. **app-key** can also be found in the app listing in the Atlassian Universal Plugin
-     *   Manager.
-     * - Run [Get
-     *   fields](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-rest-api-3-field-get)
-     *   and in the field details the value is returned in `key`. For example, `"key":
-     *   "teams-add-on__team-issue-field"`
-     */
-    fieldKey: z.string(),
-    /** The ID of the option to be updated. */
-    optionId: z.number(),
-  })
-  .extend(IssueFieldOptionSchema.shape);
+export const UpdateIssueFieldOptionSchema = z.object({}).extend(IssueFieldOptionSchema.shape).extend({
+  /**
+   * The field key is specified in the following format: **$(app-key)__$(field-key)**. For example,
+   * _example-add-on__example-issue-field_. To determine the `fieldKey` value, do one of the following:
+   *
+   * - Open the app's plugin descriptor, then **app-key** is the key at the top and **field-key** is the key in the
+   *   `jiraIssueFields` module. **app-key** can also be found in the app listing in the Atlassian Universal Plugin
+   *   Manager.
+   * - Run [Get
+   *   fields](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-rest-api-3-field-get)
+   *   and in the field details the value is returned in `key`. For example, `"key": "teams-add-on__team-issue-field"`
+   */
+  fieldKey: z.string(),
+  /** The ID of the option to be updated. */
+  optionId: z.number(),
+});
 
 export type UpdateIssueFieldOption = z.input<typeof UpdateIssueFieldOptionSchema>;

--- a/src/cloud/parameters/updateIssueFields.ts
+++ b/src/cloud/parameters/updateIssueFields.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { ConnectCustomFieldValuesSchema } from '../models';
 
-export const UpdateIssueFieldsSchema = z
-  .object({
-    /** The ID of the transfer. */
-    'Atlassian-Transfer-Id': z.string(),
-  })
-  .extend(ConnectCustomFieldValuesSchema.shape);
+export const UpdateIssueFieldsSchema = z.object({}).extend(ConnectCustomFieldValuesSchema.shape).extend({
+  /** The ID of the transfer. */
+  'Atlassian-Transfer-Id': z.string(),
+});
 
 export type UpdateIssueFields = z.input<typeof UpdateIssueFieldsSchema>;

--- a/src/cloud/parameters/updateIssueLinkType.ts
+++ b/src/cloud/parameters/updateIssueLinkType.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { IssueLinkTypeSchema } from '../models';
 
-export const UpdateIssueLinkTypeSchema = z
-  .object({
-    /** The ID of the issue link type. */
-    issueLinkTypeId: z.string(),
-  })
-  .extend(IssueLinkTypeSchema.shape);
+export const UpdateIssueLinkTypeSchema = z.object({}).extend(IssueLinkTypeSchema.shape).extend({
+  /** The ID of the issue link type. */
+  issueLinkTypeId: z.string(),
+});
 
 export type UpdateIssueLinkType = z.input<typeof UpdateIssueLinkTypeSchema>;

--- a/src/cloud/parameters/updateIssueType.ts
+++ b/src/cloud/parameters/updateIssueType.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { IssueTypeUpdateSchema } from '../models';
 
-export const UpdateIssueTypeSchema = z
-  .object({
-    /** The ID of the issue type. */
-    id: z.string(),
-  })
-  .extend(IssueTypeUpdateSchema.shape);
+export const UpdateIssueTypeSchema = z.object({}).extend(IssueTypeUpdateSchema.shape).extend({
+  /** The ID of the issue type. */
+  id: z.string(),
+});
 
 export type UpdateIssueType = z.input<typeof UpdateIssueTypeSchema>;

--- a/src/cloud/parameters/updateIssueTypeScheme.ts
+++ b/src/cloud/parameters/updateIssueTypeScheme.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { IssueTypeSchemeUpdateDetailsSchema } from '../models';
 
-export const UpdateIssueTypeSchemeSchema = z
-  .object({
-    /** The ID of the issue type scheme. */
-    issueTypeSchemeId: z.number(),
-  })
-  .extend(IssueTypeSchemeUpdateDetailsSchema.shape);
+export const UpdateIssueTypeSchemeSchema = z.object({}).extend(IssueTypeSchemeUpdateDetailsSchema.shape).extend({
+  /** The ID of the issue type scheme. */
+  issueTypeSchemeId: z.number(),
+});
 
 export type UpdateIssueTypeScheme = z.input<typeof UpdateIssueTypeSchemeSchema>;

--- a/src/cloud/parameters/updateIssueTypeScreenScheme.ts
+++ b/src/cloud/parameters/updateIssueTypeScreenScheme.ts
@@ -2,10 +2,11 @@ import { z } from 'zod';
 import { IssueTypeScreenSchemeUpdateDetailsSchema } from '../models';
 
 export const UpdateIssueTypeScreenSchemeSchema = z
-  .object({
+  .object({})
+  .extend(IssueTypeScreenSchemeUpdateDetailsSchema.shape)
+  .extend({
     /** The ID of the issue type screen scheme. */
     issueTypeScreenSchemeId: z.string(),
-  })
-  .extend(IssueTypeScreenSchemeUpdateDetailsSchema.shape);
+  });
 
 export type UpdateIssueTypeScreenScheme = z.input<typeof UpdateIssueTypeScreenSchemeSchema>;

--- a/src/cloud/parameters/updateMultipleCustomFieldValues.ts
+++ b/src/cloud/parameters/updateMultipleCustomFieldValues.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { MultipleCustomFieldValuesUpdateDetailsSchema } from '../models';
 
 export const UpdateMultipleCustomFieldValuesSchema = z
-  .object({
+  .object({})
+  .extend(MultipleCustomFieldValuesUpdateDetailsSchema.shape)
+  .extend({
     /** Whether to generate a changelog for this update. */
     generateChangelog: z.boolean().optional(),
     /**
@@ -13,7 +15,6 @@ export const UpdateMultipleCustomFieldValuesSchema = z
      * Marketplace app as it may result in incompatibilities with other apps that depend on up-to-date issue data.
      */
     generateAppEvents: z.boolean().optional(),
-  })
-  .extend(MultipleCustomFieldValuesUpdateDetailsSchema.shape);
+  });
 
 export type UpdateMultipleCustomFieldValues = z.input<typeof UpdateMultipleCustomFieldValuesSchema>;

--- a/src/cloud/parameters/updatePrecomputations.ts
+++ b/src/cloud/parameters/updatePrecomputations.ts
@@ -2,9 +2,10 @@ import { z } from 'zod';
 import { JqlFunctionPrecomputationUpdateRequestSchema } from '../models';
 
 export const UpdatePrecomputationsSchema = z
-  .object({
+  .object({})
+  .extend(JqlFunctionPrecomputationUpdateRequestSchema.shape)
+  .extend({
     skipNotFoundPrecomputations: z.boolean().optional(),
-  })
-  .extend(JqlFunctionPrecomputationUpdateRequestSchema.shape);
+  });
 
 export type UpdatePrecomputations = z.input<typeof UpdatePrecomputationsSchema>;

--- a/src/cloud/parameters/updatePriority.ts
+++ b/src/cloud/parameters/updatePriority.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { UpdatePriorityDetailsSchema } from '../models';
 
-export const UpdatePrioritySchema = z
-  .object({
-    /** The ID of the issue priority. */
-    id: z.string(),
-  })
-  .extend(UpdatePriorityDetailsSchema.shape);
+export const UpdatePrioritySchema = z.object({}).extend(UpdatePriorityDetailsSchema.shape).extend({
+  /** The ID of the issue priority. */
+  id: z.string(),
+});
 
 export type UpdatePriority = z.input<typeof UpdatePrioritySchema>;

--- a/src/cloud/parameters/updateProject.ts
+++ b/src/cloud/parameters/updateProject.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import { UpdateProjectDetailsSchema } from '../models';
 
 export const UpdateProjectSchema = z
-  .object({
+  .object({})
+  .extend(UpdateProjectDetailsSchema.shape)
+  .extend({
     /** The project ID or project key (case sensitive). */
     projectIdOrKey: z.string(),
     /**
@@ -23,7 +25,6 @@ export const UpdateProjectSchema = z
         z.array(z.enum(['description', 'issueTypes', 'lead', 'projectKeys'])),
       ])
       .optional(),
-  })
-  .extend(UpdateProjectDetailsSchema.shape);
+  });
 
 export type UpdateProject = z.input<typeof UpdateProjectSchema>;

--- a/src/cloud/parameters/updateProjectAvatar.ts
+++ b/src/cloud/parameters/updateProjectAvatar.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { AvatarSchema } from '../models';
 
-export const UpdateProjectAvatarSchema = z
-  .object({
-    /** The ID or (case-sensitive) key of the project. */
-    projectIdOrKey: z.string(),
-  })
-  .extend(AvatarSchema.shape);
+export const UpdateProjectAvatarSchema = z.object({}).extend(AvatarSchema.shape).extend({
+  /** The ID or (case-sensitive) key of the project. */
+  projectIdOrKey: z.string(),
+});
 
 export type UpdateProjectAvatar = z.input<typeof UpdateProjectAvatarSchema>;

--- a/src/cloud/parameters/updateProjectEmail.ts
+++ b/src/cloud/parameters/updateProjectEmail.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { ProjectEmailAddressSchema } from '../models';
 
-export const UpdateProjectEmailSchema = z
-  .object({
-    /** The project ID. */
-    projectId: z.number(),
-  })
-  .extend(ProjectEmailAddressSchema.shape);
+export const UpdateProjectEmailSchema = z.object({}).extend(ProjectEmailAddressSchema.shape).extend({
+  /** The project ID. */
+  projectId: z.number(),
+});
 
 export type UpdateProjectEmail = z.input<typeof UpdateProjectEmailSchema>;

--- a/src/cloud/parameters/updateRelatedWork.ts
+++ b/src/cloud/parameters/updateRelatedWork.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { VersionRelatedWorkSchema } from '../models';
 
-export const UpdateRelatedWorkSchema = z
-  .object({
-    /** The ID of the version to update the related work on. For the related work id, pass it to the input JSON. */
-    id: z.string(),
-  })
-  .extend(VersionRelatedWorkSchema.shape);
+export const UpdateRelatedWorkSchema = z.object({}).extend(VersionRelatedWorkSchema.shape).extend({
+  /** The ID of the version to update the related work on. For the related work id, pass it to the input JSON. */
+  id: z.string(),
+});
 
 export type UpdateRelatedWork = z.input<typeof UpdateRelatedWorkSchema>;

--- a/src/cloud/parameters/updateRemoteIssueLink.ts
+++ b/src/cloud/parameters/updateRemoteIssueLink.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { RemoteIssueLinkRequestSchema } from '../models';
 
-export const UpdateRemoteIssueLinkSchema = z
-  .object({
-    /** The ID or key of the issue. */
-    issueIdOrKey: z.string(),
-    /** The ID of the remote issue link. */
-    linkId: z.string(),
-  })
-  .extend(RemoteIssueLinkRequestSchema.shape);
+export const UpdateRemoteIssueLinkSchema = z.object({}).extend(RemoteIssueLinkRequestSchema.shape).extend({
+  /** The ID or key of the issue. */
+  issueIdOrKey: z.string(),
+  /** The ID of the remote issue link. */
+  linkId: z.string(),
+});
 
 export type UpdateRemoteIssueLink = z.input<typeof UpdateRemoteIssueLinkSchema>;

--- a/src/cloud/parameters/updateScreenScheme.ts
+++ b/src/cloud/parameters/updateScreenScheme.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { UpdateScreenSchemeDetailsSchema } from '../models';
 
-export const UpdateScreenSchemeSchema = z
-  .object({
-    /** The ID of the screen scheme. */
-    screenSchemeId: z.string(),
-  })
-  .extend(UpdateScreenSchemeDetailsSchema.shape);
+export const UpdateScreenSchemeSchema = z.object({}).extend(UpdateScreenSchemeDetailsSchema.shape).extend({
+  /** The ID of the screen scheme. */
+  screenSchemeId: z.string(),
+});
 
 export type UpdateScreenScheme = z.input<typeof UpdateScreenSchemeSchema>;

--- a/src/cloud/parameters/updateUiModification.ts
+++ b/src/cloud/parameters/updateUiModification.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { UpdateUiModificationDetailsSchema } from '../models';
 
-export const UpdateUiModificationSchema = z
-  .object({
-    /** The ID of the UI modification. */
-    uiModificationId: z.string(),
-  })
-  .extend(UpdateUiModificationDetailsSchema.shape);
+export const UpdateUiModificationSchema = z.object({}).extend(UpdateUiModificationDetailsSchema.shape).extend({
+  /** The ID of the UI modification. */
+  uiModificationId: z.string(),
+});
 
 export type UpdateUiModification = z.input<typeof UpdateUiModificationSchema>;

--- a/src/cloud/parameters/updateWorkflowMapping.ts
+++ b/src/cloud/parameters/updateWorkflowMapping.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { IssueTypesWorkflowMappingSchema } from '../models';
 
-export const UpdateWorkflowMappingSchema = z
-  .object({
-    /** The ID of the workflow scheme. */
-    id: z.number(),
-    /** The name of the workflow. */
-    workflowName: z.string(),
-  })
-  .extend(IssueTypesWorkflowMappingSchema.shape);
+export const UpdateWorkflowMappingSchema = z.object({}).extend(IssueTypesWorkflowMappingSchema.shape).extend({
+  /** The ID of the workflow scheme. */
+  id: z.number(),
+  /** The name of the workflow. */
+  workflowName: z.string(),
+});
 
 export type UpdateWorkflowMapping = z.input<typeof UpdateWorkflowMappingSchema>;

--- a/src/cloud/parameters/workflowRuleSearch.ts
+++ b/src/cloud/parameters/workflowRuleSearch.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { WorkflowRulesSearchSchema } from '../models';
 
-export const WorkflowRuleSearchSchema = z
-  .object({
-    /** The app migration transfer ID. */
-    'Atlassian-Transfer-Id': z.string(),
-  })
-  .extend(WorkflowRulesSearchSchema.shape);
+export const WorkflowRuleSearchSchema = z.object({}).extend(WorkflowRulesSearchSchema.shape).extend({
+  /** The app migration transfer ID. */
+  'Atlassian-Transfer-Id': z.string(),
+});
 
 export type WorkflowRuleSearch = z.input<typeof WorkflowRuleSearchSchema>;

--- a/src/serviceDesk/parameters/addCustomers.ts
+++ b/src/serviceDesk/parameters/addCustomers.ts
@@ -1,14 +1,12 @@
 import { z } from 'zod';
 import { ServiceDeskCustomerSchema } from '../models';
 
-export const AddCustomersSchema = z
-  .object({
-    /**
-     * The ID of the service desk the customer list should be returned from. This can alternatively be a [project
-     * identifier.](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#project-identifiers)
-     */
-    serviceDeskId: z.string(),
-  })
-  .extend(ServiceDeskCustomerSchema.shape);
+export const AddCustomersSchema = z.object({}).extend(ServiceDeskCustomerSchema.shape).extend({
+  /**
+   * The ID of the service desk the customer list should be returned from. This can alternatively be a [project
+   * identifier.](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#project-identifiers)
+   */
+  serviceDeskId: z.string(),
+});
 
 export type AddCustomers = z.input<typeof AddCustomersSchema>;

--- a/src/serviceDesk/parameters/addCustomersSkippingPermissionCheck.ts
+++ b/src/serviceDesk/parameters/addCustomersSkippingPermissionCheck.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { ServiceDeskCustomerSchema } from '../models';
 
-export const AddCustomersSkippingPermissionCheckSchema = z
-  .object({
-    /** The ID of the service desk to add customers to. This can alternatively be a project identifier. */
-    serviceDeskId: z.string(),
-  })
-  .extend(ServiceDeskCustomerSchema.shape);
+export const AddCustomersSkippingPermissionCheckSchema = z.object({}).extend(ServiceDeskCustomerSchema.shape).extend({
+  /** The ID of the service desk to add customers to. This can alternatively be a project identifier. */
+  serviceDeskId: z.string(),
+});
 
 export type AddCustomersSkippingPermissionCheck = z.input<typeof AddCustomersSkippingPermissionCheckSchema>;

--- a/src/serviceDesk/parameters/addRequestParticipants.ts
+++ b/src/serviceDesk/parameters/addRequestParticipants.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { RequestParticipantUpdateSchema } from '../models';
 
-export const AddRequestParticipantsSchema = z
-  .object({
-    /** The ID or key of the customer request to have participants added. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(RequestParticipantUpdateSchema.shape);
+export const AddRequestParticipantsSchema = z.object({}).extend(RequestParticipantUpdateSchema.shape).extend({
+  /** The ID or key of the customer request to have participants added. */
+  issueIdOrKey: z.string(),
+});
 
 export type AddRequestParticipants = z.input<typeof AddRequestParticipantsSchema>;

--- a/src/serviceDesk/parameters/answerApproval.ts
+++ b/src/serviceDesk/parameters/answerApproval.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 import { ApprovalDecisionRequestSchema } from '../models';
 
-export const AnswerApprovalSchema = z
-  .object({
-    /** The ID or key of the customer request to be updated. */
-    issueIdOrKey: z.string(),
-    /** The ID of the approval to be updated. */
-    approvalId: z.number(),
-  })
-  .extend(ApprovalDecisionRequestSchema.shape);
+export const AnswerApprovalSchema = z.object({}).extend(ApprovalDecisionRequestSchema.shape).extend({
+  /** The ID or key of the customer request to be updated. */
+  issueIdOrKey: z.string(),
+  /** The ID of the approval to be updated. */
+  approvalId: z.number(),
+});
 
 export type AnswerApproval = z.input<typeof AnswerApprovalSchema>;

--- a/src/serviceDesk/parameters/createCommentWithAttachment.ts
+++ b/src/serviceDesk/parameters/createCommentWithAttachment.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { AttachmentCreateSchema } from '../models';
 
-export const CreateCommentWithAttachmentSchema = z
-  .object({
-    /** The ID or key of the customer request to which the attachment will be added. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(AttachmentCreateSchema.shape);
+export const CreateCommentWithAttachmentSchema = z.object({}).extend(AttachmentCreateSchema.shape).extend({
+  /** The ID or key of the customer request to which the attachment will be added. */
+  issueIdOrKey: z.string(),
+});
 
 export type CreateCommentWithAttachment = z.input<typeof CreateCommentWithAttachmentSchema>;

--- a/src/serviceDesk/parameters/createCustomer.ts
+++ b/src/serviceDesk/parameters/createCustomer.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { CustomerCreateSchema } from '../models';
 
-export const CreateCustomerSchema = z
-  .object({
-    /** Optional boolean flag to return 409 Conflict status code for duplicate customer creation request */
-    strictConflictStatusCode: z.boolean().optional(),
-  })
-  .extend(CustomerCreateSchema.shape);
+export const CreateCustomerSchema = z.object({}).extend(CustomerCreateSchema.shape).extend({
+  /** Optional boolean flag to return 409 Conflict status code for duplicate customer creation request */
+  strictConflictStatusCode: z.boolean().optional(),
+});
 
 export type CreateCustomer = z.input<typeof CreateCustomerSchema>;

--- a/src/serviceDesk/parameters/createCustomerSkippingPermissionCheck.ts
+++ b/src/serviceDesk/parameters/createCustomerSkippingPermissionCheck.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { CustomerCreateSchema } from '../models';
 
-export const CreateCustomerSkippingPermissionCheckSchema = z
-  .object({
-    /** Optional boolean flag; when `true`, returns 409 Conflict for duplicate email instead of the default 400. */
-    strictConflictStatusCode: z.boolean().optional(),
-  })
-  .extend(CustomerCreateSchema.shape);
+export const CreateCustomerSkippingPermissionCheckSchema = z.object({}).extend(CustomerCreateSchema.shape).extend({
+  /** Optional boolean flag; when `true`, returns 409 Conflict for duplicate email instead of the default 400. */
+  strictConflictStatusCode: z.boolean().optional(),
+});
 
 export type CreateCustomerSkippingPermissionCheck = z.input<typeof CreateCustomerSkippingPermissionCheckSchema>;

--- a/src/serviceDesk/parameters/createRequestComment.ts
+++ b/src/serviceDesk/parameters/createRequestComment.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { CommentCreateSchema } from '../models';
 
-export const CreateRequestCommentSchema = z
-  .object({
-    /** The ID or key of the customer request to which the comment will be added. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(CommentCreateSchema.shape);
+export const CreateRequestCommentSchema = z.object({}).extend(CommentCreateSchema.shape).extend({
+  /** The ID or key of the customer request to which the comment will be added. */
+  issueIdOrKey: z.string(),
+});
 
 export type CreateRequestComment = z.input<typeof CreateRequestCommentSchema>;

--- a/src/serviceDesk/parameters/performCustomerTransition.ts
+++ b/src/serviceDesk/parameters/performCustomerTransition.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { CustomerTransitionExecutionSchema } from '../models';
 
-export const PerformCustomerTransitionSchema = z
-  .object({
-    /** ID or key of the issue to transition */
-    issueIdOrKey: z.string(),
-  })
-  .extend(CustomerTransitionExecutionSchema.shape);
+export const PerformCustomerTransitionSchema = z.object({}).extend(CustomerTransitionExecutionSchema.shape).extend({
+  /** ID or key of the issue to transition */
+  issueIdOrKey: z.string(),
+});
 
 export type PerformCustomerTransition = z.input<typeof PerformCustomerTransitionSchema>;

--- a/src/serviceDesk/parameters/removeRequestParticipants.ts
+++ b/src/serviceDesk/parameters/removeRequestParticipants.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 import { RequestParticipantUpdateSchema } from '../models';
 
-export const RemoveRequestParticipantsSchema = z
-  .object({
-    /** The ID or key of the customer request to have participants removed. */
-    issueIdOrKey: z.string(),
-  })
-  .extend(RequestParticipantUpdateSchema.shape);
+export const RemoveRequestParticipantsSchema = z.object({}).extend(RequestParticipantUpdateSchema.shape).extend({
+  /** The ID or key of the customer request to have participants removed. */
+  issueIdOrKey: z.string(),
+});
 
 export type RemoveRequestParticipants = z.input<typeof RemoveRequestParticipantsSchema>;


### PR DESCRIPTION
`FieldIdIdentifier` and `ProjectIdAssociationContext` were generated as `apiObject({})` — accepting anything, validating nothing.

Both are `allOf: [$ref, { identifier }]`. The generator recognised only the single-`$ref`-with-`required` form, so anything with a second member fell through to the object branch and lost the inherited properties and the schema's own alike.

```diff
-export const FieldIdIdentifierSchema = apiObject({});
+export const FieldIdIdentifierSchema = apiObject({}).extend(FieldIdentifierObjectSchema.shape).extend({
+  identifier: z.string().optional(),
+});
```

The narrowing is the entire point of these two: their base declares `identifier: { type: object }`, and the model says it is a string, or an int64.

### Order matters here, so it changed

Own properties are now applied **after** the base, not seeded before it. `.extend` overwrites, and in `allOf` a later member refines an earlier one — seeding `identifier` first would have let the base overwrite exactly the narrowing the model exists for. Three of the four schemas affected across this and confluence.js restate a property their base already declares, so the overlap is the rule rather than the exception.

### Why 88 parameter files are in the diff

Parameter models extend a body schema onto path and query parameters, so the reordering reaches them too. **No fix rides along and no behaviour changes** — I checked every one of the 88 for a name declared on both sides and found none, so only the shape of the emitted call moves:

```diff
-export const AddCommentSchema = z
-  .object({ issueIdOrKey: z.string(), ... })
-  .extend(CommentInputSchema.shape);
+export const AddCommentSchema = z
+  .object({})
+  .extend(CommentInputSchema.shape)
+  .extend({ issueIdOrKey: z.string(), ... });
```

### Upstream

Fixed in `apis-code-gen` (cff5bde), so confluence.js gets it on its next regeneration — its `ContentBlogpost` and `LookAndFeelWithLinks` have the same defect.

The generator's own fixture, named `all-of`, had `Dog = allOf[Animal, { breed }]` producing `apiObject({})` **recorded as the expected output** — the bug was frozen into the golden. 237 generator tests pass with the goldens corrected.

Typecheck, lint and the 174 unit tests pass here.

Two related gaps stay open and are tracked separately: `additionalProperties` open maps still collapse to `{}` (7 models), and `connectModule` is legitimately free-form.