### PR TITLE
fix: the avatar image endpoints answer with the image, not an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.2.0
 
-The three avatar image endpoints could not be called at all. Atlassian's specification describes them as JSON, Jira answers them with an image, and the client rejected the response before it reached the caller — so every call threw, for every avatar, on every site.
+Avatars moved bytes in both directions and the specification described both as JSON, so neither direction worked. Reading an image threw before the response reached the caller; uploading one had no way to send an image at all. Both are fixed here, along with two column endpoints broken by the same reading of the same specification.
 
 ### Bug Fixes
 
@@ -12,13 +12,35 @@ The three avatar image endpoints could not be called at all. Atlassian's specifi
 
   Attachment downloads are unchanged. `getAttachmentContent` and `getAttachmentThumbnail` still return the bytes, because an attachment already carries its `mimeType` and `filename` in its metadata.
 
+* **`storeAvatar`, `createProjectAvatar` and `createIssueTypeAvatar` accept an image.** Their request body was generated as `Record<string, any>` — an object of arbitrary keys — because Atlassian declares it under a wildcard media type with an empty schema. It is now a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob):
+
+  ```ts
+  await jira.avatars.storeAvatar({
+    type: 'project',
+    entityId: project.id,
+    size: 48,
+    body: new Blob([bytes], { type: 'image/png' }),
+  });
+  ```
+
+  The `Blob` carries the content type the endpoint reads the image by; `fetch` takes the header from it, so nothing is passed alongside it and nothing can contradict it. The three calls also send `X-Atlassian-Token: no-check`, which Jira requires — without it the upload is refused outright, with it and no content type the image is rejected as an unsupported format. Both were verified against a live site.
+
+* **`setUserColumns` and `setIssueNavigatorDefaultColumns` take the columns.** Both declare a `ColumnRequestBody` reference under a wildcard media type and nowhere else; only `application/json` was read, so the reference was missed and the body degraded to the same shapeless object. They now take `columns: string[]`, like `setColumns` on a filter already did:
+
+  ```ts
+  await jira.users.setUserColumns({ columns: ['summary', 'status'] });
+  ```
+
 ### Types
 
 * **Those three methods are typed `Promise<Blob>`**, where they were `Promise<StreamingResponseBody>`. Nothing that compiled against the old type can have been working — the call threw before returning — so the compiler pointing at these lines is the first honest signal about them. `StreamingResponseBody` itself is still exported; nothing else referenced it.
 * **`BlobSchema` is exported from `jira.js/core`,** beside `BufferSchema`. It marks an endpoint whose response is bytes with a content type worth keeping; the client reads such a response with `response.blob()` rather than parsing it as JSON.
+* **The three upload bodies are typed `Blob`**, where they were `Record<string, any>`. No call could have worked: the endpoints refuse a request without the XSRF header, which the old shape had no way to send.
+* **`setUserColumns` and `setIssueNavigatorDefaultColumns` take `columns: string[]`** in place of `body`. Unlike the avatar uploads, these two had a working form — `{ body: { columns: [...] } }` reached Jira intact — so a call written that way needs the one-line change. `{ body: [...] }`, the other reading the old type invited, was answered with 400.
 
 ### General
 
+* **The writes are covered live now.** All three uploads store an image against the test site and delete it again, the filter, account and site-wide column endpoints are set and restored, and the avatar just uploaded is read back through `getAvatarImageByID` — the two halves proving each other. None of this had a single test before, which is how a body typed as an object survived a major release.
 * **The live test for these endpoints was passing without testing anything.** It looked for `avatarId=` in a project's `avatarUrls`, which give the path form and carry no such parameter, so the match failed, the test returned on its second line, and every assertion below it — including the one a `SchemaMismatchError` would have failed — was unreachable. That is why this shipped. The test now takes its avatar id from `getAllSystemAvatars`, asserted non-empty by the test above it, and has no branch that can turn it off; the two remaining image endpoints are covered as well.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Jira.js changelog
 
+## 6.2.0
+
+The three avatar image endpoints could not be called at all. Atlassian's specification describes them as JSON, Jira answers them with an image, and the client rejected the response before it reached the caller — so every call threw, for every avatar, on every site.
+
+### Bug Fixes
+
+* **`getAvatarImageByID`, `getAvatarImageByType` and `getAvatarImageByOwner` return the image.** All three were generated with `StreamingResponseBodySchema` — the specification's `StreamingResponseBody`, an object with no properties — so a response arriving as `image/png` or `image/svg+xml` was reported as `SchemaMismatchError: Expected a JSON response to validate against the schema`. There was no input for which they could succeed. They now return a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob). Fixes [#434](https://github.com/MrRefactoring/jira.js/issues/434).
+
+  A `Blob` rather than the bytes alone, because the content type cannot be worked out from the request: the same avatar URL answers with SVG for a system avatar and PNG for an uploaded one, and `format` is optional. `image.type` is the content type, `await image.arrayBuffer()` the bytes, and `new Response(image)` passes it straight to a browser. In v5 this was `AvatarWithDetails` — `{ avatar, contentType }`; the two fields are now one value.
+
+  Attachment downloads are unchanged. `getAttachmentContent` and `getAttachmentThumbnail` still return the bytes, because an attachment already carries its `mimeType` and `filename` in its metadata.
+
+### Types
+
+* **Those three methods are typed `Promise<Blob>`**, where they were `Promise<StreamingResponseBody>`. Nothing that compiled against the old type can have been working — the call threw before returning — so the compiler pointing at these lines is the first honest signal about them. `StreamingResponseBody` itself is still exported; nothing else referenced it.
+* **`BlobSchema` is exported from `jira.js/core`,** beside `BufferSchema`. It marks an endpoint whose response is bytes with a content type worth keeping; the client reads such a response with `response.blob()` rather than parsing it as JSON.
+
+### General
+
+* **The live test for these endpoints was passing without testing anything.** It looked for `avatarId=` in a project's `avatarUrls`, which give the path form and carry no such parameter, so the match failed, the test returned on its second line, and every assertion below it — including the one a `SchemaMismatchError` would have failed — was unreachable. That is why this shipped. The test now takes its avatar id from `getAllSystemAvatars`, asserted non-empty by the test above it, and has no branch that can turn it off; the two remaining image endpoints are covered as well.
+
+
 ## 6.1.0
 
 Atlassian's specification lists the values it knows a field can hold, and that list falls behind the API it describes. Reading a project of a type the list has not caught up with was never an error — the response came back whole — but it printed a warning, once per project, that named neither the values it wanted nor the one it got. All three of those are fixed here.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -138,6 +138,23 @@ Use the predicates rather than `instanceof`. They read a branded symbol instead 
 - **The CJS build.** The package is ESM-only.
 - **`mime-types`.** Attachment content types come from a built-in table now; an unknown extension is `application/octet-stream`, as before.
 
+## Avatar images come back as a `Blob`
+
+In v5 the three avatar image methods returned `AvatarWithDetails` — `{ avatar: Uint8Array, contentType: string }`. In v6 they return a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob), which carries both:
+
+```ts
+const image = await client.avatars.getAvatarImageByID({ type: 'project', id: 10011 });
+
+image.type;                                   // 'image/svg+xml' — was `contentType`
+new Uint8Array(await image.arrayBuffer());    // the bytes — was `avatar`
+
+return new Response(image);                   // proxying it on takes no unpacking at all
+```
+
+The content type is worth keeping hold of: the same endpoint answers with SVG for a system avatar and PNG for an uploaded one, and nothing in the request says which is coming.
+
+This landed in **6.2.0**. Between 6.0.0 and 6.1.0 these three methods were generated from a JSON schema and threw `SchemaMismatchError` on every call — see [#434](https://github.com/MrRefactoring/jira.js/issues/434). Attachments are unaffected: `getAttachmentContent` and `getAttachmentThumbnail` still return the bytes alone, since their content type is already on the attachment metadata.
+
 ## Responses are validated, and a mismatch does not stop you
 
 Every response is checked against a schema. When one does not match, the body comes back **unvalidated** and the library reports the problem once — one line on stderr per distinct field, however many responses repeat it:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -155,6 +155,19 @@ The content type is worth keeping hold of: the same endpoint answers with SVG fo
 
 This landed in **6.2.0**. Between 6.0.0 and 6.1.0 these three methods were generated from a JSON schema and threw `SchemaMismatchError` on every call — see [#434](https://github.com/MrRefactoring/jira.js/issues/434). Attachments are unaffected: `getAttachmentContent` and `getAttachmentThumbnail` still return the bytes alone, since their content type is already on the attachment metadata.
 
+Uploading works the same way round. In v5 `storeAvatar` took `{ avatar, mimeType }`; it now takes a `Blob`, which carries both:
+
+```ts
+await jira.avatars.storeAvatar({
+  type: 'project',
+  entityId: project.id,
+  size: 48,
+  body: new Blob([bytes], { type: 'image/png' }),   // was `avatar` + `mimeType`
+});
+```
+
+The same applies to `createProjectAvatar` and `createIssueTypeAvatar`. The `X-Atlassian-Token: no-check` header v5 asked you to think about is now sent for you.
+
 ## Responses are validated, and a mismatch does not stop you
 
 Every response is checked against a schema. When one does not match, the body comes back **unvalidated** and the library reports the problem once — one line on stderr per distinct field, however many responses repeat it:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira.js",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Modern Jira REST API client for JavaScript and TypeScript. Full-featured library for the Jira Cloud platform API, Jira Agile API, and Jira Service Management API, with every response validated at runtime. Works in Node.js and browsers with TypeScript support, tree-shaking, and comprehensive type definitions.",
   "repository": {
     "type": "git",

--- a/src/cloud/api/avatars.ts
+++ b/src/cloud/api/avatars.ts
@@ -1,7 +1,6 @@
 import { SystemAvatarsSchema, type SystemAvatars } from '../models/systemAvatars';
 import { AvatarsSchema, type Avatars } from '../models/avatars';
 import { AvatarSchema, type Avatar } from '../models/avatar';
-import { StreamingResponseBodySchema, type StreamingResponseBody } from '../models/streamingResponseBody';
 import type { GetAllSystemAvatars } from '../parameters/getAllSystemAvatars';
 import type { GetAvatars } from '../parameters/getAvatars';
 import type { StoreAvatar } from '../parameters/storeAvatar';
@@ -9,7 +8,7 @@ import type { DeleteAvatar } from '../parameters/deleteAvatar';
 import type { GetAvatarImageByType } from '../parameters/getAvatarImageByType';
 import type { GetAvatarImageByID } from '../parameters/getAvatarImageByID';
 import type { GetAvatarImageByOwner } from '../parameters/getAvatarImageByOwner';
-import type { Client, SendRequestOptions } from '#/core';
+import { type Client, type SendRequestOptions, BlobSchema } from '#/core';
 
 /**
  * Returns a list of system avatar details by owner type, where the owner types are issue type, project, user or
@@ -132,18 +131,15 @@ export async function deleteAvatar(client: Client, parameters: DeleteAvatar): Pr
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAvatarImageByType(
-  client: Client,
-  parameters: GetAvatarImageByType,
-): Promise<StreamingResponseBody> {
-  const config: SendRequestOptions<StreamingResponseBody> = {
+export async function getAvatarImageByType(client: Client, parameters: GetAvatarImageByType): Promise<Blob> {
+  const config: SendRequestOptions<Blob> = {
     url: `/rest/api/3/universal_avatar/view/type/${parameters.type}`,
     method: 'GET',
     searchParams: {
       size: parameters.size,
       format: parameters.format,
     },
-    schema: StreamingResponseBodySchema,
+    schema: BlobSchema,
   };
 
   return await client.sendRequest(config);
@@ -163,18 +159,15 @@ export async function getAvatarImageByType(
  *   at least one project the issue type is used in.
  * - For priority avatars, none.
  */
-export async function getAvatarImageByID(
-  client: Client,
-  parameters: GetAvatarImageByID,
-): Promise<StreamingResponseBody> {
-  const config: SendRequestOptions<StreamingResponseBody> = {
+export async function getAvatarImageByID(client: Client, parameters: GetAvatarImageByID): Promise<Blob> {
+  const config: SendRequestOptions<Blob> = {
     url: `/rest/api/3/universal_avatar/view/type/${parameters.type}/avatar/${parameters.id}`,
     method: 'GET',
     searchParams: {
       size: parameters.size,
       format: parameters.format,
     },
-    schema: StreamingResponseBodySchema,
+    schema: BlobSchema,
   };
 
   return await client.sendRequest(config);
@@ -194,18 +187,15 @@ export async function getAvatarImageByID(
  *   at least one project the issue type is used in.
  * - For priority avatars, none.
  */
-export async function getAvatarImageByOwner(
-  client: Client,
-  parameters: GetAvatarImageByOwner,
-): Promise<StreamingResponseBody> {
-  const config: SendRequestOptions<StreamingResponseBody> = {
+export async function getAvatarImageByOwner(client: Client, parameters: GetAvatarImageByOwner): Promise<Blob> {
+  const config: SendRequestOptions<Blob> = {
     url: `/rest/api/3/universal_avatar/view/type/${parameters.type}/owner/${parameters.entityId}`,
     method: 'GET',
     searchParams: {
       size: parameters.size,
       format: parameters.format,
     },
-    schema: StreamingResponseBodySchema,
+    schema: BlobSchema,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/avatars.ts
+++ b/src/cloud/api/avatars.ts
@@ -97,6 +97,9 @@ export async function storeAvatar(client: Client, parameters: StoreAvatar): Prom
   const config: SendRequestOptions<Avatar> = {
     url: `/rest/api/3/universal_avatar/type/${parameters.type}/owner/${parameters.entityId}`,
     method: 'POST',
+    headers: {
+      'X-Atlassian-Token': 'no-check',
+    },
     searchParams: {
       x: parameters.x,
       y: parameters.y,

--- a/src/cloud/api/issueNavigatorSettings.ts
+++ b/src/cloud/api/issueNavigatorSettings.ts
@@ -43,7 +43,9 @@ export async function setIssueNavigatorDefaultColumns(
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/settings/columns',
     method: 'PUT',
-    body: parameters.body,
+    body: {
+      columns: parameters.columns,
+    },
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueTypes.ts
+++ b/src/cloud/api/issueTypes.ts
@@ -166,6 +166,9 @@ export async function createIssueTypeAvatar(client: Client, parameters: CreateIs
   const config: SendRequestOptions<Avatar> = {
     url: `/rest/api/3/issuetype/${parameters.id}/avatar2`,
     method: 'POST',
+    headers: {
+      'X-Atlassian-Token': 'no-check',
+    },
     searchParams: {
       x: parameters.x,
       y: parameters.y,

--- a/src/cloud/api/projectAvatars.ts
+++ b/src/cloud/api/projectAvatars.ts
@@ -86,6 +86,9 @@ export async function createProjectAvatar(client: Client, parameters: CreateProj
   const config: SendRequestOptions<Avatar> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/avatar2`,
     method: 'POST',
+    headers: {
+      'X-Atlassian-Token': 'no-check',
+    },
     searchParams: {
       x: parameters.x,
       y: parameters.y,

--- a/src/cloud/api/users.ts
+++ b/src/cloud/api/users.ts
@@ -132,7 +132,9 @@ export async function setUserColumns(client: Client, parameters: SetUserColumns)
     searchParams: {
       accountId: parameters.accountId,
     },
-    body: parameters.body,
+    body: {
+      columns: parameters.columns,
+    },
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/createCloudClient.ts
+++ b/src/cloud/createCloudClient.ts
@@ -549,7 +549,6 @@ import type {
   SystemAvatars,
   Avatars,
   Avatar,
-  StreamingResponseBody,
   SubmittedBulkOperation,
   BulkEditGetFields,
   BulkTransitionGetAvailableTransitions,
@@ -797,11 +796,11 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
       getAvatars: (parameters: GetAvatars): Promise<Avatars> => avatars.getAvatars(client, parameters),
       storeAvatar: (parameters: StoreAvatar): Promise<Avatar> => avatars.storeAvatar(client, parameters),
       deleteAvatar: (parameters: DeleteAvatar): Promise<void> => avatars.deleteAvatar(client, parameters),
-      getAvatarImageByType: (parameters: GetAvatarImageByType): Promise<StreamingResponseBody> =>
+      getAvatarImageByType: (parameters: GetAvatarImageByType): Promise<Blob> =>
         avatars.getAvatarImageByType(client, parameters),
-      getAvatarImageByID: (parameters: GetAvatarImageByID): Promise<StreamingResponseBody> =>
+      getAvatarImageByID: (parameters: GetAvatarImageByID): Promise<Blob> =>
         avatars.getAvatarImageByID(client, parameters),
-      getAvatarImageByOwner: (parameters: GetAvatarImageByOwner): Promise<StreamingResponseBody> =>
+      getAvatarImageByOwner: (parameters: GetAvatarImageByOwner): Promise<Blob> =>
         avatars.getAvatarImageByOwner(client, parameters),
     },
     issueBulkOperations: {

--- a/src/cloud/parameters/createIssueTypeAvatar.ts
+++ b/src/cloud/parameters/createIssueTypeAvatar.ts
@@ -9,7 +9,7 @@ export const CreateIssueTypeAvatarSchema = z.object({
   y: z.number().optional(),
   /** The length of each side of the crop region. */
   size: z.number(),
-  body: z.record(z.string(), z.any()),
+  body: z.custom<Blob>(),
 });
 
 export type CreateIssueTypeAvatar = z.input<typeof CreateIssueTypeAvatarSchema>;

--- a/src/cloud/parameters/createProjectAvatar.ts
+++ b/src/cloud/parameters/createProjectAvatar.ts
@@ -9,7 +9,7 @@ export const CreateProjectAvatarSchema = z.object({
   y: z.number().optional(),
   /** The length of each side of the crop region. */
   size: z.number().optional(),
-  body: z.record(z.string(), z.any()),
+  body: z.custom<Blob>(),
 });
 
 export type CreateProjectAvatar = z.input<typeof CreateProjectAvatarSchema>;

--- a/src/cloud/parameters/setIssueNavigatorDefaultColumns.ts
+++ b/src/cloud/parameters/setIssueNavigatorDefaultColumns.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
+import { ColumnRequestBodySchema } from '../models';
 
-export const SetIssueNavigatorDefaultColumnsSchema = z.object({
-  body: z.record(z.string(), z.any()),
-});
+export const SetIssueNavigatorDefaultColumnsSchema = z.object({}).extend(ColumnRequestBodySchema.shape);
 
 export type SetIssueNavigatorDefaultColumns = z.input<typeof SetIssueNavigatorDefaultColumnsSchema>;

--- a/src/cloud/parameters/setUserColumns.ts
+++ b/src/cloud/parameters/setUserColumns.ts
@@ -1,12 +1,15 @@
 import { z } from 'zod';
+import { UserColumnRequestBodySchema } from '../models';
 
-export const SetUserColumnsSchema = z.object({
-  /**
-   * The account ID of the user, which uniquely identifies the user across all Atlassian products. For example,
-   * _5b10ac8d82e05b22cc7d4ef5_.
-   */
-  accountId: z.string().max(128, 'accountId must be at most 128 characters').optional(),
-  body: z.record(z.string(), z.any()),
-});
+export const SetUserColumnsSchema = z
+  .object({})
+  .extend(UserColumnRequestBodySchema.shape)
+  .extend({
+    /**
+     * The account ID of the user, which uniquely identifies the user across all Atlassian products. For example,
+     * _5b10ac8d82e05b22cc7d4ef5_.
+     */
+    accountId: z.string().max(128, 'accountId must be at most 128 characters').optional(),
+  });
 
 export type SetUserColumns = z.input<typeof SetUserColumnsSchema>;

--- a/src/cloud/parameters/storeAvatar.ts
+++ b/src/cloud/parameters/storeAvatar.ts
@@ -12,7 +12,7 @@ export const StoreAvatarSchema = z.object({
   y: z.number().optional(),
   /** The length of each side of the crop region. */
   size: z.number(),
-  body: z.record(z.string(), z.any()),
+  body: z.custom<Blob>(),
 });
 
 export type StoreAvatar = z.input<typeof StoreAvatarSchema>;

--- a/src/core/createClient.ts
+++ b/src/core/createClient.ts
@@ -10,7 +10,7 @@ import {
   toNetworkError,
   TRANSIENT_HTTP_STATUSES,
 } from './errors/index.js';
-import { BufferSchema } from './formData/index.js';
+import { BlobSchema, BufferSchema } from './formData/index.js';
 import { isSchemaAuditEnabled, recordSchemaDrift } from './schemaAudit.js';
 import { describeIssues, reportSchemaMismatch } from './schemaMismatch.js';
 import type { SchemaMismatchReport } from './schemaMismatch.js';
@@ -332,6 +332,13 @@ export function createClient(config: ClientConfig | Client): Client {
 
       if ((requestConfig.schema as unknown) === BufferSchema) {
         return BufferSchema.parse(new Uint8Array(await response.arrayBuffer())) as T;
+      }
+
+      // A `Blob` carries the content type with the bytes, which is the whole reason these endpoints ask for one: the
+      // same avatar URL answers with SVG for a system avatar and PNG for an uploaded one, and nothing in the request
+      // says which is coming.
+      if ((requestConfig.schema as unknown) === BlobSchema) {
+        return BlobSchema.parse(await response.blob()) as T;
       }
 
       if (contentType && !contentType.includes('application/json')) {

--- a/src/core/formData/blobSchema.ts
+++ b/src/core/formData/blobSchema.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const BlobSchema = z.custom<Blob>(val => typeof Blob !== 'undefined' && val instanceof Blob);

--- a/src/core/formData/index.ts
+++ b/src/core/formData/index.ts
@@ -1,5 +1,7 @@
 export type { AttachmentContent, AttachmentInput } from './attachmentInput.js';
 
+export { BlobSchema } from './blobSchema.js';
+
 export { BufferSchema, type Buffer } from './bufferSchema.js';
 
 export { createMultipartRequestBody, toFormDataFile, type MultipartRequestBody } from './multipartRequest.js';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -70,7 +70,7 @@ export type {
   OnTokenRefresh,
 } from './oauth/index.js';
 
-export { BufferSchema, createMultipartRequestBody, toFormDataFile, mimeTypeFor } from './formData/index.js';
+export { BlobSchema, BufferSchema, createMultipartRequestBody, toFormDataFile, mimeTypeFor } from './formData/index.js';
 
 export type { AttachmentContent, AttachmentInput, Buffer, MultipartRequestBody } from './formData/index.js';
 

--- a/tests/live/cloud/avatars.test.ts
+++ b/tests/live/cloud/avatars.test.ts
@@ -1,23 +1,30 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { CloudClient } from '#/cloud/createCloudClient';
 import { getCloudClient } from '../setup/client';
+import { ResourceTracker } from '../setup/resources';
 import { TEST_PROJECT_KEY } from '../setup/fixtures';
+import { pngBlob } from '../helpers/image';
 
 /**
  * Live suite for the `avatars` API (`getAllSystemAvatars`, `getAvatars`, `storeAvatar`, `deleteAvatar`,
  * `getAvatarImageByType`, `getAvatarImageByID`, `getAvatarImageByOwner`).
  *
- * Read-only. Uploading an avatar is a binary write against site or project configuration, and the image endpoints
- * answer with an image rather than JSON — which is the part worth asserting here, because a client that tries to parse
- * an image as JSON fails in a way that looks like a corrupt response. The fixtures are taken from endpoints asserted
- * above rather than guarded on, so nothing in this file can quietly stop testing.
+ * Both directions carry bytes, and the specification describes both as JSON, so both are asserted here: an image
+ * comes back as an image rather than as a parse failure that reads like a corrupt response, and an upload is accepted
+ * as an image rather than as an object. The upload is the one write this file makes — a custom avatar added to the
+ * test project and deleted again, which touches nothing else on the site.
+ *
+ * Fixtures come from endpoints asserted above rather than from guards, so nothing here can quietly stop testing.
  */
-describe('Jira Cloud — avatars (live, read-only)', () => {
+describe('Jira Cloud — avatars (live)', () => {
+  const tracker = new ResourceTracker();
   let client: CloudClient;
 
   beforeAll(() => {
     client = getCloudClient();
   });
+
+  afterAll(() => tracker.cleanup());
 
   it('lists the system avatars for each type', async () => {
     for (const type of ['project', 'issuetype', 'user', 'priority'] as const) {
@@ -67,6 +74,54 @@ describe('Jira Cloud — avatars (live, read-only)', () => {
       expect(image.type).toMatch(/^image\//);
       expect(image.size).toBeGreaterThan(50);
     }
+  });
+
+  it('stores a custom avatar from image bytes, and lists it as custom', async () => {
+    const project = await client.projects.getProject({ projectIdOrKey: TEST_PROJECT_KEY });
+
+    const stored = await client.avatars.storeAvatar({
+      type: 'project',
+      entityId: project.id!,
+      size: 48,
+      x: 0,
+      y: 0,
+      body: pngBlob(48),
+    });
+
+    expect(stored.id).toBeTruthy();
+    expect(stored.isSystemAvatar).toBe(false);
+    expect(stored.isDeletable).toBe(true);
+
+    tracker.defer(async () => {
+      await client.avatars.deleteAvatar({ type: 'project', owningObjectId: project.id!, id: Number(stored.id) });
+    });
+
+    const avatars = await client.avatars.getAvatars({ type: 'project', entityId: project.id! });
+
+    expect(avatars.custom?.some(avatar => avatar.id === stored.id)).toBe(true);
+  });
+
+  it('serves the avatar it was just given, as the image it was given', async () => {
+    const project = await client.projects.getProject({ projectIdOrKey: TEST_PROJECT_KEY });
+
+    const stored = await client.avatars.storeAvatar({
+      type: 'project',
+      entityId: project.id!,
+      size: 48,
+      x: 0,
+      y: 0,
+      body: pngBlob(48),
+    });
+
+    tracker.defer(async () => {
+      await client.avatars.deleteAvatar({ type: 'project', owningObjectId: project.id!, id: Number(stored.id) });
+    });
+
+    const image = await client.avatars.getAvatarImageByID({ type: 'project', id: Number(stored.id) });
+
+    // Jira answers with the charset appended — `image/png;charset=utf-8` — so the essence is what can be asserted.
+    expect(image.type).toMatch(/^image\/png\b/);
+    expect(image.size).toBeGreaterThan(50);
   });
 
   it('answers an unknown avatar type with an empty list rather than an error', async () => {

--- a/tests/live/cloud/avatars.test.ts
+++ b/tests/live/cloud/avatars.test.ts
@@ -1,5 +1,4 @@
 import { beforeAll, describe, expect, it } from 'vitest';
-import { isForbiddenError, isNotFoundError } from '#/core';
 import type { CloudClient } from '#/cloud/createCloudClient';
 import { getCloudClient } from '../setup/client';
 import { TEST_PROJECT_KEY } from '../setup/fixtures';
@@ -9,8 +8,9 @@ import { TEST_PROJECT_KEY } from '../setup/fixtures';
  * `getAvatarImageByType`, `getAvatarImageByID`, `getAvatarImageByOwner`).
  *
  * Read-only. Uploading an avatar is a binary write against site or project configuration, and the image endpoints
- * return raw bytes rather than JSON — which is the part worth asserting here, because a client that tries to parse an
- * image as JSON fails in a way that looks like a corrupt response.
+ * answer with an image rather than JSON — which is the part worth asserting here, because a client that tries to parse
+ * an image as JSON fails in a way that looks like a corrupt response. The fixtures are taken from endpoints asserted
+ * above rather than guarded on, so nothing in this file can quietly stop testing.
  */
 describe('Jira Cloud — avatars (live, read-only)', () => {
   let client: CloudClient;
@@ -46,25 +46,27 @@ describe('Jira Cloud — avatars (live, read-only)', () => {
   });
 
   it('returns an avatar image as bytes, not JSON', async () => {
+    const avatars = await client.avatars.getAllSystemAvatars({ type: 'project' });
+    const avatarId = Number(avatars.system![0].id);
+
+    const image = await client.avatars.getAvatarImageByID({ type: 'project', id: avatarId });
+
+    expect(image).toBeInstanceOf(Blob);
+    expect(image.type).toMatch(/^image\//);
+    expect(image.size).toBeGreaterThan(50);
+  });
+
+  it('returns the default avatar image for a type, and the image of an owner', async () => {
     const project = await client.projects.getProject({ projectIdOrKey: TEST_PROJECT_KEY });
-    const avatarId = (project.avatarUrls?.['48x48'] ?? '').match(/avatarId=(\d+)/)?.[1];
 
-    if (!avatarId) return;
+    const byType = await client.avatars.getAvatarImageByType({ type: 'project' });
+    const byOwner = await client.avatars.getAvatarImageByOwner({ type: 'project', entityId: project.id! });
 
-    const image = await client.avatars
-      .getAvatarImageByID({ type: 'project', id: Number(avatarId) })
-      .catch((e: unknown) => e);
-
-    if (image instanceof Error) {
-      expect(isForbiddenError(image) || isNotFoundError(image)).toBe(true);
-
-      return;
+    for (const image of [byType, byOwner]) {
+      expect(image).toBeInstanceOf(Blob);
+      expect(image.type).toMatch(/^image\//);
+      expect(image.size).toBeGreaterThan(50);
     }
-
-    const bytes = new Uint8Array(image as ArrayBufferLike);
-
-    expect(bytes.byteLength).toBeGreaterThan(0);
-    expect(bytes.byteLength).toBeGreaterThan(50);
   });
 
   it('answers an unknown avatar type with an empty list rather than an error', async () => {

--- a/tests/live/cloud/filters.test.ts
+++ b/tests/live/cloud/filters.test.ts
@@ -142,4 +142,23 @@ describe('Jira Cloud — filters (live)', () => {
 
     expect(isNotFoundError(error)).toBe(true);
   });
+  it('gives a filter its own columns, then takes them away again', async () => {
+    // A filter without columns of its own has no layout at all rather than an empty one, and Jira says so with a 404.
+    // Reading that as "the filter is gone" is the mistake this pins.
+    const missing = await client.filters.getColumns({ id: filterId }).catch((e: unknown) => e);
+
+    expect(isNotFoundError(missing)).toBe(true);
+
+    await client.filters.setColumns({ id: filterId, columns: ['summary', 'status'] });
+
+    const columns = await client.filters.getColumns({ id: filterId });
+
+    expect(columns.map(column => column.value)).toEqual(['summary', 'status']);
+
+    await client.filters.resetColumns({ id: filterId });
+
+    const afterReset = await client.filters.getColumns({ id: filterId }).catch((e: unknown) => e);
+
+    expect(isNotFoundError(afterReset)).toBe(true);
+  });
 });

--- a/tests/live/cloud/issueNavigatorSettings.test.ts
+++ b/tests/live/cloud/issueNavigatorSettings.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { CloudClient } from '#/cloud/createCloudClient';
+import { getCloudClient } from '../setup/client';
+
+/**
+ * Live suite for the `issueNavigatorSettings` API (`getIssueNavigatorDefaultColumns`,
+ * `setIssueNavigatorDefaultColumns`).
+ *
+ * The one endpoint here writes site-wide state: these are the columns every account sees in the issue navigator until
+ * it sets its own. The suite therefore reads the current list first and restores it in `afterAll`, so the site ends
+ * the run exactly as it started it.
+ *
+ * Worth its own file because the write is easy to get wrong in a way that looks like a transport fault. Atlassian
+ * declares the body only under a wildcard media type, which generated a shapeless object; Jira answers a bare array
+ * with 400 and a form-encoded body with 415, and accepts exactly `{ columns: [...] }` as JSON.
+ */
+describe('Jira Cloud — issueNavigatorSettings (live)', () => {
+  let client: CloudClient;
+  let original: string[] = [];
+
+  beforeAll(async () => {
+    client = getCloudClient();
+
+    const columns = await client.issueNavigatorSettings.getIssueNavigatorDefaultColumns();
+
+    original = columns.map(column => column.value!).filter(Boolean);
+
+    expect(original.length).toBeGreaterThan(0);
+  });
+
+  afterAll(async () => {
+    if (original.length > 0) {
+      await client.issueNavigatorSettings.setIssueNavigatorDefaultColumns({ columns: original });
+    }
+  });
+
+  it('lists the default columns, each carrying a value and a label', async () => {
+    const columns = await client.issueNavigatorSettings.getIssueNavigatorDefaultColumns();
+
+    expect(columns.length).toBeGreaterThan(0);
+
+    for (const column of columns) {
+      expect(typeof column.value).toBe('string');
+      expect(typeof column.label).toBe('string');
+    }
+  });
+
+  it('replaces the default columns and reads the replacement back', async () => {
+    await client.issueNavigatorSettings.setIssueNavigatorDefaultColumns({ columns: ['summary', 'status'] });
+
+    const columns = await client.issueNavigatorSettings.getIssueNavigatorDefaultColumns();
+
+    expect(columns.map(column => column.value)).toEqual(['summary', 'status']);
+  });
+
+  it('rejects a column that does not exist', async () => {
+    const error = await client.issueNavigatorSettings
+      .setIssueNavigatorDefaultColumns({ columns: ['nosuchcolumn'] })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { status?: number }).status).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/tests/live/cloud/issueTypes.test.ts
+++ b/tests/live/cloud/issueTypes.test.ts
@@ -1,23 +1,56 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { isForbiddenError, isNotFoundError } from '#/core';
 import type { CloudClient } from '#/cloud/createCloudClient';
 import { getCloudClient } from '../setup/client';
+import { ResourceTracker } from '../setup/resources';
 import { TEST_PROJECT_KEY } from '../setup/fixtures';
+import { pngBlob } from '../helpers/image';
 
 /**
  * Live suite for the `issueTypes` API (`getIssueAllTypes`, `getIssueType`, `getAlternativeIssueTypes`, and the
  * admin-only create/update/delete group).
  *
- * Read-only. Issue types are site-wide configuration shared by every project on the tenant: creating one adds an
- * option everywhere, and deleting one asks Jira to migrate every issue that used it. Neither belongs in a suite that
- * runs against a working site, so the write half is pinned through its error channel and aimed only at ids that
- * cannot exist.
+ * Read-only but for one write. Issue types are site-wide configuration shared by every project on the tenant:
+ * creating one adds an option everywhere, and deleting one asks Jira to migrate every issue that used it. Neither
+ * belongs in a suite that runs against a working site, so that half is pinned through its error channel and aimed
+ * only at ids that cannot exist.
+ *
+ * `createIssueTypeAvatar` is the exception, and it is exercised because it takes image bytes — the shape the
+ * specification describes as an object of arbitrary keys, which is what made it unusable. It adds an avatar to the
+ * type's list of available avatars and deletes it again; nothing selects it, so what the type displays never changes.
  */
-describe('Jira Cloud — issueTypes (live, read-only)', () => {
+describe('Jira Cloud — issueTypes (live)', () => {
+  const tracker = new ResourceTracker();
   let client: CloudClient;
 
   beforeAll(() => {
     client = getCloudClient();
+  });
+
+  afterAll(() => tracker.cleanup());
+
+  it('stores an avatar for an issue type from image bytes', async () => {
+    const types = await client.issueTypes.getIssueAllTypes();
+    const type = types.find(candidate => candidate.subtask === false) ?? types[0]!;
+
+    const avatar = await client.issueTypes.createIssueTypeAvatar({
+      id: type.id!,
+      size: 48,
+      x: 0,
+      y: 0,
+      body: pngBlob(48),
+    });
+
+    expect(avatar.id).toBeTruthy();
+    expect(avatar.isSystemAvatar).toBe(false);
+
+    tracker.defer(async () => {
+      await client.avatars.deleteAvatar({ type: 'issuetype', owningObjectId: type.id!, id: Number(avatar.id) });
+    });
+
+    const avatars = await client.avatars.getAvatars({ type: 'issuetype', entityId: type.id! });
+
+    expect(avatars.custom?.some(candidate => candidate.id === avatar.id)).toBe(true);
   });
 
   it('lists the site issue types, each fully typed', async () => {

--- a/tests/live/cloud/projectAvatars.test.ts
+++ b/tests/live/cloud/projectAvatars.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { CloudClient } from '#/cloud/createCloudClient';
+import { getCloudClient } from '../setup/client';
+import { ResourceTracker } from '../setup/resources';
+import { TEST_PROJECT_KEY } from '../setup/fixtures';
+import { pngBlob } from '../helpers/image';
+
+/**
+ * Live suite for the `projectAvatars` API (`createProjectAvatar`, `getAllProjectAvatars`, `deleteProjectAvatar`).
+ *
+ * `createProjectAvatar` takes image bytes, which the specification describes as an object of arbitrary keys — the
+ * shape that made this endpoint unusable before. Adding an avatar to a project is a write, but a contained one: it
+ * lands in the project's list of custom avatars and is deleted again here. `updateProjectAvatar`, which would select
+ * one as the project's displayed avatar, is deliberately not called — that changes what everyone sees.
+ */
+describe('Jira Cloud — projectAvatars (live)', () => {
+  const tracker = new ResourceTracker();
+  let client: CloudClient;
+
+  beforeAll(() => {
+    client = getCloudClient();
+  });
+
+  afterAll(() => tracker.cleanup());
+
+  it('adds an avatar from image bytes and lists it among the custom ones', async () => {
+    const created = await client.projectAvatars.createProjectAvatar({
+      projectIdOrKey: TEST_PROJECT_KEY,
+      size: 48,
+      x: 0,
+      y: 0,
+      body: pngBlob(48),
+    });
+
+    expect(created.id).toBeTruthy();
+    expect(created.isSystemAvatar).toBe(false);
+
+    tracker.defer(async () => {
+      await client.projectAvatars.deleteProjectAvatar({ projectIdOrKey: TEST_PROJECT_KEY, id: Number(created.id) });
+    });
+
+    const avatars = await client.projectAvatars.getAllProjectAvatars({ projectIdOrKey: TEST_PROJECT_KEY });
+
+    expect(avatars.system!.length).toBeGreaterThan(0);
+    expect(avatars.custom?.some(avatar => avatar.id === created.id)).toBe(true);
+  });
+
+  it('refuses bytes that are not an image', async () => {
+    const error = await client.projectAvatars
+      .createProjectAvatar({
+        projectIdOrKey: TEST_PROJECT_KEY,
+        size: 48,
+        body: new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/png' }),
+      })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { status?: number }).status).toBe(400);
+  });
+});

--- a/tests/live/cloud/users.test.ts
+++ b/tests/live/cloud/users.test.ts
@@ -7,13 +7,16 @@ import { getCloudClient } from '../setup/client';
  * Live suite for the `users` API (`getUser`, `getAllUsers`, `getAllUsersDefault`, `getUserGroups`, `getUserEmail`,
  * `getUserEmailBulk`, the column preferences group, and the admin-only `createUser`/`removeUser`).
  *
- * Read-only against the authenticating account. Creating or removing a user is an identity operation with billing
+ * Confined to the authenticating account. Creating or removing a user is an identity operation with billing
  * consequences and no clean undo, so neither is exercised — they are pinned only through their error channel.
  *
  * The theme worth pinning here is privacy: Cloud hides personal data by default, so `emailAddress` and `displayName`
  * may legitimately be absent. Code that assumes otherwise works on one tenant and breaks on the next.
+ *
+ * The column preferences are the one write, and they belong to the authenticating account alone: `setUserColumns`
+ * changes what this account sees in the issue navigator and `resetUserColumns` puts the site default back.
  */
-describe('Jira Cloud — users (live, read-only)', () => {
+describe('Jira Cloud — users (live)', () => {
   let client: CloudClient;
   let accountId: string;
 
@@ -94,5 +97,22 @@ describe('Jira Cloud — users (live, read-only)', () => {
 
     expect(error).toBeInstanceOf(Error);
     expect((error as { status?: number }).status).toBeGreaterThanOrEqual(400);
+  });
+  it('sets the calling account\'s issue navigator columns, then resets them', async () => {
+    const before = await client.users.getUserDefaultColumns({});
+
+    expect(Array.isArray(before)).toBe(true);
+
+    await client.users.setUserColumns({ columns: ['summary', 'status'] });
+
+    const columns = await client.users.getUserDefaultColumns({});
+
+    expect(columns.map(column => column.value)).toEqual(['summary', 'status']);
+
+    await client.users.resetUserColumns({});
+
+    const reset = await client.users.getUserDefaultColumns({});
+
+    expect(reset.map(column => column.value)).toEqual(before.map(column => column.value));
   });
 });

--- a/tests/live/helpers/image.ts
+++ b/tests/live/helpers/image.ts
@@ -1,0 +1,85 @@
+import { deflateSync } from 'node:zlib';
+
+/**
+ * A valid PNG of a solid colour, built here rather than committed as a fixture.
+ *
+ * The avatar endpoints read the image: Jira answers "not a supported image format" to anything it cannot decode, so a
+ * placeholder of arbitrary bytes proves nothing. Generating one keeps the suite free of a binary fixture, and keeps
+ * the size a parameter — Jira refuses an avatar smaller than the crop it is asked for.
+ */
+export function pngBytes(side: number): Uint8Array<ArrayBuffer> {
+  const scanlines = new Uint8Array(side * (1 + side * 3));
+
+  for (let y = 0; y < side; y++) {
+    const row = y * (1 + side * 3);
+
+    scanlines[row] = 0;
+
+    for (let x = 0; x < side; x++) {
+      scanlines[row + 1 + x * 3] = 200;
+      scanlines[row + 2 + x * 3] = 60;
+      scanlines[row + 3 + x * 3] = 60;
+    }
+  }
+
+  const header = new Uint8Array(13);
+  const headerView = new DataView(header.buffer);
+
+  headerView.setUint32(0, side);
+  headerView.setUint32(4, side);
+  header[8] = 8;
+  header[9] = 2;
+
+  const parts = [
+    new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', header),
+    chunk('IDAT', new Uint8Array(deflateSync(scanlines))),
+    chunk('IEND', new Uint8Array(0)),
+  ];
+
+  const png = new Uint8Array(parts.reduce((size, part) => size + part.length, 0));
+
+  let at = 0;
+
+  for (const part of parts) {
+    png.set(part, at);
+    at += part.length;
+  }
+
+  return png;
+}
+
+/** A PNG as the endpoints want it: a `Blob` carrying the content type they read it by. */
+export function pngBlob(side: number): Blob {
+  return new Blob([pngBytes(side)], { type: 'image/png' });
+}
+
+function chunk(type: string, data: Uint8Array): Uint8Array<ArrayBuffer> {
+  const framed = new Uint8Array(12 + data.length);
+  const view = new DataView(framed.buffer);
+
+  view.setUint32(0, data.length);
+  framed.set(new TextEncoder().encode(type), 4);
+  framed.set(data, 8);
+  view.setUint32(8 + data.length, crc32(framed.subarray(4, 8 + data.length)));
+
+  return framed;
+}
+
+function crc32(bytes: Uint8Array): number {
+  const table: number[] = [];
+
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+
+    table[n] = c;
+  }
+
+  let crc = 0xffffffff;
+
+  for (const byte of bytes) crc = table[(crc ^ byte) & 0xff]! ^ (crc >>> 8);
+
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/tests/unit/core/createClient.test.ts
+++ b/tests/unit/core/createClient.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import {
   ApiError,
+  BlobSchema,
   BufferSchema,
   createClient,
   isNetworkError,
@@ -286,6 +287,28 @@ describe('responses', () => {
     const body = await createClient({ host: HOST }).sendRequest({ url: '/x', method: 'GET', schema: BufferSchema });
 
     expect(Buffer.from(body as Uint8Array).toString('utf8')).toBe('file contents');
+  });
+
+  it('returns a Blob carrying the content type for an endpoint that asks for one', async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+    mockFetch([new Response(bytes, { status: 200, headers: { 'content-type': 'image/png' } })]);
+
+    const body = await createClient({ host: HOST }).sendRequest({ url: '/x', method: 'GET', schema: BlobSchema });
+
+    expect(body).toBeInstanceOf(Blob);
+    expect((body as Blob).type).toBe('image/png');
+    expect(new Uint8Array(await (body as Blob).arrayBuffer())).toEqual(bytes);
+  });
+
+  it('reads an image as a Blob rather than reporting a schema mismatch', async () => {
+    mockFetch([
+      new Response('<svg/>', { status: 200, headers: { 'content-type': 'image/svg+xml;charset=UTF-8' } }),
+    ]);
+
+    const body = await createClient({ host: HOST }).sendRequest({ url: '/x', method: 'GET', schema: BlobSchema });
+
+    expect((body as Blob).type).toBe('image/svg+xml;charset=utf-8');
   });
 
   it('still discards a non-JSON body when the endpoint does not ask for a Buffer', async () => {

--- a/tests/unit/core/createClient.test.ts
+++ b/tests/unit/core/createClient.test.ts
@@ -311,6 +311,23 @@ describe('responses', () => {
     expect((body as Blob).type).toBe('image/svg+xml;charset=utf-8');
   });
 
+  it('sends a Blob body untouched, letting it carry its own content type', async () => {
+    const calls = mockFetch([new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })]);
+
+    await createClient({ host: HOST }).sendRequest({
+      url: '/x',
+      method: 'POST',
+      headers: { 'X-Atlassian-Token': 'no-check' },
+      body: new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }),
+    });
+
+    const headers = calls[0]!.init.headers as Record<string, string>;
+
+    expect(calls[0]!.init.body).toBeInstanceOf(Blob);
+    expect(headers['Content-Type']).toBeUndefined();
+    expect(headers['X-Atlassian-Token']).toBe('no-check');
+  });
+
   it('still discards a non-JSON body when the endpoint does not ask for a Buffer', async () => {
     mockFetch([new Response('<html/>', { status: 200, headers: { 'content-type': 'text/html' } })]);
 


### PR DESCRIPTION
Fixes #434.

## What was wrong

`getAvatarImageByID`, `getAvatarImageByType` and `getAvatarImageByOwner` threw on every call, for every avatar, on every site:

```
SchemaMismatchError: Expected a JSON response to validate against the schema, got image/svg+xml;charset=UTF-8
```

Atlassian's specification describes all three responses as `application/json` holding `StreamingResponseBody` — an object with no properties — beside empty `image/png` and `image/svg+xml` entries. JSON is the media type the generator picks, so the endpoints were generated with `apiObject({})`, and `createClient` rejects a non-JSON body before it reaches the caller. There was no input for which these could succeed.

## What changed

All three return a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob):

```ts
const image = await client.avatars.getAvatarImageByID({ type: 'project', id: 10011 });

image.type;                                   // 'image/svg+xml'
new Uint8Array(await image.arrayBuffer());    // the bytes
return new Response(image);                   // proxying it on takes no unpacking
```

A `Blob` rather than the bytes alone, because the content type cannot be worked out from the request: the same avatar URL answers with SVG for a system avatar and PNG for an uploaded one, and `format` is optional. In v5 this was `AvatarWithDetails` — `{ avatar, contentType }`; the two fields are now one value.

`BlobSchema` is exported from `jira.js/core` beside `BufferSchema`, and `createClient` reads such a response with `response.blob()`. Attachment downloads are untouched — `getAttachmentContent` and `getAttachmentThumbnail` still return the bytes, since an attachment already carries its `mimeType` and `filename` in its metadata.

The generated files here come from a matching change in the generator: a spec patch drops the JSON entry these responses have no fallback to and marks the binary one `x-binary-kind: 'blob'`.

## Why it shipped

The live test for these endpoints was green without testing anything:

```ts
const avatarId = (project.avatarUrls?.['48x48'] ?? '').match(/avatarId=(\d+)/)?.[1];

if (!avatarId) return;
```

`avatarUrls` give the path form — `/rest/api/3/universal_avatar/view/type/project/avatar/11021` — and carry no `avatarId` parameter, so the match never succeeded, the test returned on its second line, and every assertion below it was unreachable. Reported by @kang8 in the issue.

The test now takes its avatar id from `getAllSystemAvatars`, asserted non-empty by the test above it, and has no branch that can turn it off. `getAvatarImageByType` and `getAvatarImageByOwner` are covered too.

## Verification

Against a real site, the two image tests fail on `master` with exactly the error from the issue and pass here; the whole `avatars` live suite is 7/7. Unit tests cover the new path in `createClient`, including the `image/svg+xml` case. `typecheck`, `build` and `check:browser` are clean.

Released as **6.2.0** — a minor, because `BlobSchema` is a new export from `jira.js/core`.