### PR TITLE
test(live): stand down where the site's plan does not include the feature

### DIFF
--- a/tests/live/cloud/auditRecords.test.ts
+++ b/tests/live/cloud/auditRecords.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { isForbiddenError } from '#/core';
 import type { CloudClient } from '#/cloud/createCloudClient';
 import { getCloudClient } from '../setup/client';
+import { isNotEntitled } from '../setup/entitlement';
 
 /**
  * Live suite for the `auditRecords` API (`getAuditRecords`).
@@ -16,18 +17,22 @@ import { getCloudClient } from '../setup/client';
 describe('Jira Cloud — auditRecords (live, admin-gated)', () => {
   let client: CloudClient;
   let permitted = false;
+  let entitled = true;
 
   beforeAll(async () => {
     client = getCloudClient();
 
-    permitted = await client.auditRecords
-      .getAuditRecords({ limit: 1 })
-      .then(() => true)
-      .catch(() => false);
+    // Two different refusals wear the same 403, and the suite asserts opposite things about them: a site whose plan
+    // has no audit log at all, and an administrator-only endpoint reached without administrator rights.
+    const probe = await client.auditRecords.getAuditRecords({ limit: 1 }).catch((e: unknown) => e);
+
+    permitted = !(probe instanceof Error);
+    entitled = !isNotEntitled(probe);
   });
 
-  it('returns audit records for an administrator, each fully typed', async () => {
-    if (!permitted) return;
+  it('returns audit records for an administrator, each fully typed', async ctx => {
+    ctx.skip(!entitled, 'the site is on a Free plan, which has no audit log');
+    ctx.skip(!permitted, 'the account is not a Jira administrator');
 
     const page = await client.auditRecords.getAuditRecords({ limit: 5 });
 
@@ -42,16 +47,18 @@ describe('Jira Cloud — auditRecords (live, admin-gated)', () => {
     }
   });
 
-  it('fails typed rather than silently empty without admin rights', async () => {
-    if (permitted) return;
+  it('fails typed rather than silently empty without admin rights', async ctx => {
+    ctx.skip(!entitled, 'the site is on a Free plan, so the refusal names the plan rather than the missing rights');
+    ctx.skip(permitted, 'the account is a Jira administrator, so there is no refusal to inspect');
 
     const error = await client.auditRecords.getAuditRecords({ limit: 1 }).catch((e: unknown) => e);
 
     expect(isForbiddenError(error) || (error as { status?: number }).status === 401).toBe(true);
   });
 
-  it('pages with offset and limit, not startAt and maxResults', async () => {
-    if (!permitted) return;
+  it('pages with offset and limit, not startAt and maxResults', async ctx => {
+    ctx.skip(!entitled, 'the site is on a Free plan, which has no audit log');
+    ctx.skip(!permitted, 'the account is not a Jira administrator');
 
     const first = await client.auditRecords.getAuditRecords({ limit: 1 });
 
@@ -67,8 +74,9 @@ describe('Jira Cloud — auditRecords (live, admin-gated)', () => {
     }
   });
 
-  it('narrows the window with from and to', async () => {
-    if (!permitted) return;
+  it('narrows the window with from and to', async ctx => {
+    ctx.skip(!entitled, 'the site is on a Free plan, which has no audit log');
+    ctx.skip(!permitted, 'the account is not a Jira administrator');
 
     const from = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
@@ -81,8 +89,9 @@ describe('Jira Cloud — auditRecords (live, admin-gated)', () => {
     }
   });
 
-  it('answers a filter that matches nothing with an empty page', async () => {
-    if (!permitted) return;
+  it('answers a filter that matches nothing with an empty page', async ctx => {
+    ctx.skip(!entitled, 'the site is on a Free plan, which has no audit log');
+    ctx.skip(!permitted, 'the account is not a Jira administrator');
 
     const page = await client.auditRecords.getAuditRecords({ filter: 'nothingmatchesthisatall', limit: 10 });
 

--- a/tests/live/cloud/projectRoleActors.test.ts
+++ b/tests/live/cloud/projectRoleActors.test.ts
@@ -3,6 +3,7 @@ import { isNotFoundError } from '#/core';
 import type { CloudClient } from '#/cloud/createCloudClient';
 import { getCloudClient } from '../setup/client';
 import { TEST_PROJECT_KEY } from '../setup/fixtures';
+import { isNotEntitled } from '../setup/entitlement';
 
 /**
  * Live suite for the `projectRoleActors` API (`addActorUsers`, `setActors`, `deleteActor`,
@@ -72,19 +73,24 @@ describe('Jira Cloud — projectRoleActors (live, read-only)', () => {
     expect(isNotFoundError(error) || (error as { status?: number }).status === 400).toBe(true);
   });
 
-  it('rejects an actor addition naming nobody', async () => {
+  it('rejects an actor addition naming nobody', async ctx => {
     const error = await client.projectRoleActors
       .addActorUsers({ projectIdOrKey: TEST_PROJECT_KEY, id: roleId })
       .catch((e: unknown) => e);
+
+    // A Free plan refuses every role actor write, so the refusal here would say nothing about the empty payload.
+    ctx.skip(isNotEntitled(error), 'the site is on a Free plan, which refuses role actor writes whatever they say');
 
     expect(error).toBeInstanceOf(Error);
     expect((error as { status?: number }).status).toBeGreaterThanOrEqual(400);
   });
 
-  it('silently succeeds when removing an actor that is not in the role', async () => {
+  it('silently succeeds when removing an actor that is not in the role', async ctx => {
     const result = await client.projectRoleActors
       .deleteActor({ projectIdOrKey: TEST_PROJECT_KEY, id: roleId, user: 'no-such-account-id' })
       .catch((e: unknown) => e);
+
+    ctx.skip(isNotEntitled(result), 'the site is on a Free plan, which refuses role actor writes whatever they say');
 
     expect(result).toBeUndefined();
 

--- a/tests/live/setup/entitlement.ts
+++ b/tests/live/setup/entitlement.ts
@@ -1,0 +1,22 @@
+import { ApiError } from '#/core';
+
+/**
+ * True when the site refused because of the plan it is on, not because of the request.
+ *
+ * Project role actor writes and audit logs are paid-plan features. A site on a Free plan answers each of them with a
+ * refusal that names the plan rather than anything the caller did — a 400 saying role actors cannot be updated "as
+ * it's on the Jira Software Free plan", a 403 saying audit logs "aren't available for this site as all of its Jira
+ * Cloud products are on Free plans".
+ *
+ * None of that is drift and none of it is breakage: the endpoints are correct and the library reaches them. Treated as
+ * a failure, a lapsed trial turns the nightly run red for days and buries the signal it exists to carry — here it took
+ * the live suite and the schema audit down together for a week. The suites that need those features check this and
+ * stand down instead, visibly, so a skipped test reads as skipped rather than as passed.
+ *
+ * Every other failure stays a failure, so the same tests are real again the moment the site is on a paid plan.
+ */
+export function isNotEntitled(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+
+  return /Free plans?\b|not entitled to/i.test(JSON.stringify(error.body ?? ''));
+}


### PR DESCRIPTION
The test site's premium trial lapsed to a Free plan around 10 August. The nightly live run has been red since the 11th, and the nightly schema audit with it — one failing test, no fault in this library:

```
400 - {"errorMessages":["You can't update role actors for this project as it's on the Jira Software Free plan."]}
```

The audit refuses to report drift when the suite itself fails ("The audit suite itself failed — that is real breakage, not drift"), so a week of Atlassian drift went unreported over one entitlement refusal.

## What the plan actually gates

Probed directly against the site rather than guessed:

| Endpoint | On this plan |
|---|---|
| `projectRoleActors` writes | `400` — "as it's on the Jira Software Free plan" |
| `auditRecords.getAuditRecords` | `403` — "Audit logs aren't available for this site as all of its Jira Cloud products are on Free plans" |
| permission / notification / workflow / screen schemes, issue security schemes, project roles | answer normally |

`appDataPolicies.getPolicy` answers `401` "Only apps can access this resource" — app-only, unrelated to the plan.

## What changed

**`tests/live/setup/entitlement.ts`** — `isNotEntitled(error)` recognises a refusal that names the plan rather than the request, following the same helper in confluence.js. Every other failure stays a failure, so these tests are real again the moment the site is on a paid plan.

**`projectRoleActors`** — the two writes stand down. The addition naming nobody keeps asserting: Jira validates the payload before it checks the plan, so that refusal is still about the payload; the check is there in case that order ever changes.

**`auditRecords`** was the worse half — green while testing nothing. `permitted` was false on a Free site, so four of its five tests returned on their first line, and the fifth passed on a `403` about the plan while claiming to prove the refusal for *missing admin rights*. Those are now two flags, because the same `403` carries both cases and the suite asserts opposite things of them.

Standing down is `ctx.skip` with a reason rather than a bare `return`, so a test that did not run reads as skipped in the report instead of as passed:

```
↓ silently succeeds when removing an actor that is not in the role [the site is on a Free plan, which refuses role actor writes whatever they say]
↓ returns audit records for an administrator, each fully typed [the site is on a Free plan, which has no audit log]
```

## Verification

Full live suite against the site: **73/73 files, 494 passed, 6 skipped, exit 0**. Before this change the same run was 1 failed / 499 passed, matching the nightly.