### PR TITLE
test(live): the board fixture survives being used more than once

### DIFF
--- a/tests/live/setup/fixtures.ts
+++ b/tests/live/setup/fixtures.ts
@@ -5,6 +5,7 @@
  * licence slot, and often cannot be deleted cleanly by the same token that made it. A dedicated test project is the
  * cheaper and more reliable unit of isolation, and run-scoped names keep concurrent runs apart inside it.
  */
+import { ApiError } from '#/core';
 import type { CloudClient } from '#/cloud/createCloudClient';
 import type { Document } from '#/cloud/models/document';
 import type { AgileClient } from '#/agile/createAgileClient';
@@ -76,13 +77,61 @@ export interface TestBoard {
  * deletable by whoever made it, and nothing outside this suite reads it. The filter comes first because a board is,
  * fundamentally, a saved filter with columns.
  */
+/**
+ * Creates the board, waiting out the moment where the filter it names is not visible yet.
+ *
+ * A filter reaches the Agile service through an index rather than directly, and a board built on one created a
+ * moment earlier is refused with *"The selected filter is not available to you, perhaps it has been deleted or had
+ * its permissions changed"* — a 400 that describes a permissions fault and is in fact a race with that index.
+ *
+ * It only bites when no board exists to reuse, which is why it surfaced as an occasional red run rather than a
+ * standing failure: the refusal comes from a `beforeAll`, so the whole file reports as failed while every test in it
+ * reports as skipped. Any other failure is rethrown untouched.
+ */
+async function createBoardOnceTheFilterIsVisible(
+  agile: AgileClient,
+  request: Parameters<AgileClient['board']['createBoard']>[0],
+): Promise<Awaited<ReturnType<AgileClient['board']['createBoard']>>> {
+  const attempts = 6;
+  let delay = 500;
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await agile.board.createBoard(request);
+    } catch (error) {
+      if (attempt + 1 >= attempts || !isFilterNotVisibleYet(error)) throw error;
+
+      await new Promise<void>(resolve => setTimeout(resolve, delay));
+      delay = Math.round(delay * 1.8);
+    }
+  }
+}
+
+function isFilterNotVisibleYet(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+
+  return /filter is not available/i.test(JSON.stringify(error.body ?? ''));
+}
+
+/**
+ * How many boards this process has built, so each gets its own filter name.
+ *
+ * `testName` is run-scoped by design — one name per label per process — and a filter name has to be unique on the
+ * site, so a second call landed on *"Filter with same name already exists"*. Every agile suite creates a board only
+ * when it finds none to reuse, and each deletes what it created, so on a site with no board the second suite to run
+ * hit exactly that.
+ */
+let boardsCreated = 0;
+
 export async function createTestBoard(
   client: CloudClient,
   agile: AgileClient,
   tracker: ResourceTracker,
 ): Promise<TestBoard> {
+  const ordinal = ++boardsCreated;
+
   const filter = await client.filters.createFilter({
-    name: testName('board filter'),
+    name: testName(`board filter ${ordinal}`),
     jql: `project = ${TEST_PROJECT_KEY} ORDER BY Rank ASC`,
   });
 
@@ -92,8 +141,8 @@ export async function createTestBoard(
     await client.filters.deleteFilter({ id: filterId });
   });
 
-  const board = await agile.board.createBoard({
-    name: testName('board').slice(0, 40),
+  const board = await createBoardOnceTheFilterIsVisible(agile, {
+    name: testName(`board ${ordinal}`).slice(0, 40),
     type: 'scrum',
     filterId,
     location: { type: 'project', projectKeyOrId: TEST_PROJECT_KEY },


### PR DESCRIPTION
The live run went red on 18 August with **no failing test in it** — 490 passed, 10 skipped, and one file reported as failed. The failure came from a `beforeAll` in `tests/live/agile/epic.test.ts`, which is why it reads as a broken suite rather than a broken fixture:

```
400 - {"errorMessages":["The selected filter is not available to you, perhaps it has been deleted or had its permissions changed."]}
```

Every agile suite shares the same fixture: reuse a scrum board if the site has one, build one otherwise. That second path had two faults, both of which only appear when the site has no board to reuse — which is why they surfaced as an occasional red run rather than a standing failure.

## The filter is not visible yet

A filter reaches the Agile service through an index, and a board built on one created a moment earlier is refused with a message about permissions that is really a race. That one refusal is now retried with backoff; anything else is rethrown untouched.

## The second board of a run collides

`testName` is run-scoped by design — one name per label per process — and a filter name has to be unique on the site. Each suite deletes the board it created, so on a board-less site the second suite to run asked for the same filter name and got:

```
400 - {"errors":{"filterName":"Filter with same name already exists."}}
```

Every board now carries its own ordinal. This one was not hypothetical: building three boards in a single process failed on the second before this change.

## Verification

Three boards built in one process — fails on the second before, passes after. The six agile live suites pass (42 tests).