### PR TITLE
feat: a page of things is typed Page<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,20 @@ Avatars moved bytes in both directions and the specification described both as J
 * **Five more agile models are deprecated in favour of the components they were copies of.** `createBoard` and `getBoard` answer with `Board`, `getAllBoards` with `PageBoard`, `getBoardByFilterId` with `PageBoardFilter`, and `getAllQuickFilters` with `PageQuickFilter`. Each of those responses is declared inline in the specification, field for field the component sitting beside it, so the generator had nothing to name it after but the operation — and the component it duplicated went unused: no agile model referenced `Board` at all, while six of them wrote a board out in full. The retired names are still exported as `@deprecated` aliases of the new ones, assignable in both directions, and go at the next major version. Nothing has to change today.
 
   A board reports its type properly now, as a side effect worth naming. `Board.type` is `'scrum' | 'kanban' | 'simple' | (string & {})`; every copy of it was a plain `string`, and since each of these methods returned a copy, the narrowing reached none of them. `getBoard()` and the boards inside `getAllBoards().values` carry it now.
+* **A page of things is typed `Page<T>`.** Atlassian restates the pagination envelope once per item type — `PageBoard`, `PageUser`, `PagedArticle`, ninety-odd of them across the three APIs, identical but for what sits in `values` — and each generated a model of its own. So a page of boards and a page of users were two unrelated shapes with the same seven fields, and nothing said they were the same idea. Each API now has one `Page<T>`, and the endpoints answering with a page are typed with it:
+
+  ```ts
+  const boards: Page<Board> = await agile.board.getAllBoards();
+  const comments: Page<Comment> = await jira.issueComments.getCommentsByIds({ ids: [10000, 10001] });
+  ```
+
+  Three generics, not one: the envelopes genuinely differ. Cloud's carries `nextPage` and `self`, Agile's does not, and Service Desk's is `_expands`/`_links`/`isLastPage`/`limit`/`size`/`start` — giving Agile cloud's would document two fields Jira Software never sends. Each is exported from its own entry point, all three under the name `Page`.
+
+  Nothing is removed and nothing changes shape: the 82 retired names — 62 in cloud, 17 in Service Desk, 3 in Agile — remain exported as `@deprecated` aliases of the generic (`type PageBoard = Page<Board>`), assignable in both directions, going at the next major version. The schemas keep their own names, since `PageBoardSchema` is the only handle on the runtime schema. Every page type was compared against the one it replaces, in both directions, before this shipped.
+
+  Only exact matches folded. A page that differs by a field, a description or a format — the cursor-based pages, `PageOfChangelogs`, `PageOfComments`, `PageOfWorklogs`, `PagedLink` — generates exactly as it did.
+
+  The browser bundle drops from 481 kB to 471 kB, and the generated sources by a thousand lines: 82 copies of an envelope became three.
 
 ### General
 

--- a/src/agile/api/board.ts
+++ b/src/agile/api/board.ts
@@ -1,6 +1,8 @@
-import { PageBoardSchema, type PageBoard } from '../models/pageBoard';
+import { PageBoardSchema } from '../models/pageBoard';
+import type { Page } from '../models/page';
 import { BoardSchema, type Board } from '../models/board';
-import { PageBoardFilterSchema, type PageBoardFilter } from '../models/pageBoardFilter';
+import { PageBoardFilterSchema } from '../models/pageBoardFilter';
+import type { BoardFilter } from '../models/boardFilter';
 import { SoftwareIssueResultsSchema, type SoftwareIssueResults } from '../models/softwareIssueResults';
 import { IssueCountSchema, type IssueCount } from '../models/issueCount';
 import { GetConfigurationSchema, type GetConfiguration } from '../models/getConfiguration';
@@ -11,7 +13,7 @@ import { GetProjectsSchema, type GetProjects } from '../models/getProjects';
 import { GetProjectsFullSchema, type GetProjectsFull } from '../models/getProjectsFull';
 import { PropertyKeysSchema, type PropertyKeys } from '../models/propertyKeys';
 import { EntityPropertySchema, type EntityProperty } from '../models/entityProperty';
-import { PageQuickFilterSchema, type PageQuickFilter } from '../models/pageQuickFilter';
+import { PageQuickFilterSchema } from '../models/pageQuickFilter';
 import { QuickFilterSchema, type QuickFilter } from '../models/quickFilter';
 import { GetReportsForBoardSchema, type GetReportsForBoard } from '../models/getReportsForBoard';
 import { GetAllSprintsSchema, type GetAllSprints } from '../models/getAllSprints';
@@ -53,8 +55,8 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * - `read:board-scope:jira-software`, `read:project:jira`
  */
-export async function getAllBoards(client: Client, parameters?: GetAllBoards): Promise<PageBoard> {
-  const config: SendRequestOptions<PageBoard> = {
+export async function getAllBoards(client: Client, parameters?: GetAllBoards): Promise<Page<Board>> {
+  const config: SendRequestOptions<Page<Board>> = {
     url: '/rest/agile/1.0/board',
     method: 'GET',
     searchParams: {
@@ -124,8 +126,8 @@ export async function createBoard(client: Client, parameters: CreateBoard): Prom
  * Returns any boards which use the provided filter id. This method can be executed by users without a valid software
  * license in order to find which boards are using a particular filter.
  */
-export async function getBoardByFilterId(client: Client, parameters: GetBoardByFilterId): Promise<PageBoardFilter> {
-  const config: SendRequestOptions<PageBoardFilter> = {
+export async function getBoardByFilterId(client: Client, parameters: GetBoardByFilterId): Promise<Page<BoardFilter>> {
+  const config: SendRequestOptions<Page<BoardFilter>> = {
     url: `/rest/agile/1.0/board/filter/${parameters.filterId}`,
     method: 'GET',
     searchParams: {
@@ -527,8 +529,8 @@ export async function deleteBoardProperty(client: Client, parameters: DeleteBoar
 }
 
 /** Returns all quick filters from a board, for a given board ID. */
-export async function getAllQuickFilters(client: Client, parameters: GetAllQuickFilters): Promise<PageQuickFilter> {
-  const config: SendRequestOptions<PageQuickFilter> = {
+export async function getAllQuickFilters(client: Client, parameters: GetAllQuickFilters): Promise<Page<QuickFilter>> {
+  const config: SendRequestOptions<Page<QuickFilter>> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/quickfilter`,
     method: 'GET',
     searchParams: {

--- a/src/agile/createAgileClient.ts
+++ b/src/agile/createAgileClient.ts
@@ -111,9 +111,9 @@ import type {
   DeleteComponentById,
 } from './parameters';
 import type {
-  PageBoard,
+  Page,
   Board,
-  PageBoardFilter,
+  BoardFilter,
   SoftwareIssueResults,
   IssueCount,
   GetConfiguration as GetConfigurationModel,
@@ -124,7 +124,6 @@ import type {
   GetProjectsFull as GetProjectsFullModel,
   PropertyKeys,
   EntityProperty,
-  PageQuickFilter,
   QuickFilter,
   GetReportsForBoard as GetReportsForBoardModel,
   GetAllSprints as GetAllSprintsModel,
@@ -170,9 +169,9 @@ export function createAgileClient(clientConfig: ClientConfig | Client) {
         backlog.moveIssuesToBacklogForBoard(client, parameters),
     },
     board: {
-      getAllBoards: (parameters?: GetAllBoards): Promise<PageBoard> => board.getAllBoards(client, parameters),
+      getAllBoards: (parameters?: GetAllBoards): Promise<Page<Board>> => board.getAllBoards(client, parameters),
       createBoard: (parameters: CreateBoard): Promise<Board> => board.createBoard(client, parameters),
-      getBoardByFilterId: (parameters: GetBoardByFilterId): Promise<PageBoardFilter> =>
+      getBoardByFilterId: (parameters: GetBoardByFilterId): Promise<Page<BoardFilter>> =>
         board.getBoardByFilterId(client, parameters),
       getBoard: (parameters: GetBoard): Promise<Board> => board.getBoard(client, parameters),
       deleteBoard: (parameters: DeleteBoard): Promise<void> => board.deleteBoard(client, parameters),
@@ -206,7 +205,7 @@ export function createAgileClient(clientConfig: ClientConfig | Client) {
       setBoardProperty: (parameters: SetBoardProperty): Promise<void> => board.setBoardProperty(client, parameters),
       deleteBoardProperty: (parameters: DeleteBoardProperty): Promise<void> =>
         board.deleteBoardProperty(client, parameters),
-      getAllQuickFilters: (parameters: GetAllQuickFilters): Promise<PageQuickFilter> =>
+      getAllQuickFilters: (parameters: GetAllQuickFilters): Promise<Page<QuickFilter>> =>
         board.getAllQuickFilters(client, parameters),
       getQuickFilter: (parameters: GetQuickFilter): Promise<QuickFilter> => board.getQuickFilter(client, parameters),
       getReportsForBoard: (parameters: GetReportsForBoard): Promise<GetReportsForBoardModel> =>

--- a/src/agile/models/index.ts
+++ b/src/agile/models/index.ts
@@ -142,6 +142,8 @@ export * from './moveIssuesToBoard';
 
 export * from './operations';
 
+export * from './page';
+
 export * from './pageBoard';
 
 export * from './pageBoardFilter';

--- a/src/agile/models/page.ts
+++ b/src/agile/models/page.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { apiObject } from '#/core';
+
+export function pageSchema<T extends z.ZodType>(item: T) {
+  return apiObject({
+    isLast: z.boolean().optional(),
+    maxResults: z.number().optional(),
+    startAt: z.number().optional(),
+    total: z.number().optional(),
+    values: z.array(item).optional(),
+  });
+}
+
+export type Page<T> = z.infer<ReturnType<typeof pageSchema<z.ZodType<T>>>>;

--- a/src/agile/models/pageBoard.ts
+++ b/src/agile/models/pageBoard.ts
@@ -1,13 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { BoardSchema } from './board';
+import { pageSchema, type Page } from './page';
+import { BoardSchema, type Board } from './board';
 
-export const PageBoardSchema = apiObject({
-  isLast: z.boolean().optional(),
-  maxResults: z.number().optional(),
-  startAt: z.number().optional(),
-  total: z.number().optional(),
-  values: z.array(BoardSchema).optional(),
-});
+export const PageBoardSchema = pageSchema(BoardSchema);
 
-export type PageBoard = z.infer<typeof PageBoardSchema>;
+/** @deprecated Use `Page<Board>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageBoard = Page<Board>;

--- a/src/agile/models/pageBoardFilter.ts
+++ b/src/agile/models/pageBoardFilter.ts
@@ -1,13 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { BoardFilterSchema } from './boardFilter';
+import { pageSchema, type Page } from './page';
+import { BoardFilterSchema, type BoardFilter } from './boardFilter';
 
-export const PageBoardFilterSchema = apiObject({
-  isLast: z.boolean().optional(),
-  maxResults: z.number().optional(),
-  startAt: z.number().optional(),
-  total: z.number().optional(),
-  values: z.array(BoardFilterSchema).optional(),
-});
+export const PageBoardFilterSchema = pageSchema(BoardFilterSchema);
 
-export type PageBoardFilter = z.infer<typeof PageBoardFilterSchema>;
+/** @deprecated Use `Page<BoardFilter>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageBoardFilter = Page<BoardFilter>;

--- a/src/agile/models/pageQuickFilter.ts
+++ b/src/agile/models/pageQuickFilter.ts
@@ -1,13 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { QuickFilterSchema } from './quickFilter';
+import { pageSchema, type Page } from './page';
+import { QuickFilterSchema, type QuickFilter } from './quickFilter';
 
-export const PageQuickFilterSchema = apiObject({
-  isLast: z.boolean().optional(),
-  maxResults: z.number().optional(),
-  startAt: z.number().optional(),
-  total: z.number().optional(),
-  values: z.array(QuickFilterSchema).optional(),
-});
+export const PageQuickFilterSchema = pageSchema(QuickFilterSchema);
 
-export type PageQuickFilter = z.infer<typeof PageQuickFilterSchema>;
+/** @deprecated Use `Page<QuickFilter>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageQuickFilter = Page<QuickFilter>;

--- a/src/cloud/api/dashboards.ts
+++ b/src/cloud/api/dashboards.ts
@@ -1,8 +1,9 @@
 import { PageOfDashboardsSchema, type PageOfDashboards } from '../models/pageOfDashboards';
-import { PageDashboardSchema, type PageDashboard } from '../models/pageDashboard';
+import { PageDashboardSchema } from '../models/pageDashboard';
+import type { Page } from '../models/page';
+import { DashboardSchema, type Dashboard } from '../models/dashboard';
 import { PropertyKeysSchema, type PropertyKeys } from '../models/propertyKeys';
 import { EntityPropertySchema, type EntityProperty } from '../models/entityProperty';
-import { DashboardSchema, type Dashboard } from '../models/dashboard';
 import type { GetAllDashboards } from '../parameters/getAllDashboards';
 import type { GetDashboardsPaginated } from '../parameters/getDashboardsPaginated';
 import type { GetDashboardItemPropertyKeys } from '../parameters/getDashboardItemPropertyKeys';
@@ -56,8 +57,8 @@ export async function getAllDashboards(client: Client, parameters?: GetAllDashbo
 export async function getDashboardsPaginated(
   client: Client,
   parameters?: GetDashboardsPaginated,
-): Promise<PageDashboard> {
-  const config: SendRequestOptions<PageDashboard> = {
+): Promise<Page<Dashboard>> {
+  const config: SendRequestOptions<Page<Dashboard>> = {
     url: '/rest/api/3/dashboard/search',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/filters.ts
+++ b/src/cloud/api/filters.ts
@@ -1,5 +1,7 @@
 import { FilterSchema, type Filter } from '../models/filter';
-import { PageFilterDetailsSchema, type PageFilterDetails } from '../models/pageFilterDetails';
+import { PageFilterDetailsSchema } from '../models/pageFilterDetails';
+import type { Page } from '../models/page';
+import type { FilterDetails } from '../models/filterDetails';
 import { ColumnItemSchema, type ColumnItem } from '../models/columnItem';
 import type { CreateFilter } from '../parameters/createFilter';
 import type { GetFavouriteFilters } from '../parameters/getFavouriteFilters';
@@ -141,8 +143,8 @@ export async function getMyFilters(client: Client, parameters?: GetMyFilters): P
 export async function getFiltersPaginated(
   client: Client,
   parameters?: GetFiltersPaginated,
-): Promise<PageFilterDetails> {
-  const config: SendRequestOptions<PageFilterDetails> = {
+): Promise<Page<FilterDetails>> {
+  const config: SendRequestOptions<Page<FilterDetails>> = {
     url: '/rest/api/3/filter/search',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/groups.ts
+++ b/src/cloud/api/groups.ts
@@ -1,5 +1,7 @@
 import { GroupSchema, type Group } from '../models/group';
-import { PageUserDetailsSchema, type PageUserDetails } from '../models/pageUserDetails';
+import { PageUserDetailsSchema } from '../models/pageUserDetails';
+import type { Page } from '../models/page';
+import type { UserDetails } from '../models/userDetails';
 import { FoundGroupsSchema, type FoundGroups } from '../models/foundGroups';
 import type { CreateGroup } from '../parameters/createGroup';
 import type { RemoveGroup } from '../parameters/removeGroup';
@@ -60,8 +62,8 @@ export async function removeGroup(client: Client, parameters: RemoveGroup): Prom
  * - _Browse users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getUsersFromGroup(client: Client, parameters?: GetUsersFromGroup): Promise<PageUserDetails> {
-  const config: SendRequestOptions<PageUserDetails> = {
+export async function getUsersFromGroup(client: Client, parameters?: GetUsersFromGroup): Promise<Page<UserDetails>> {
+  const config: SendRequestOptions<Page<UserDetails>> = {
     url: '/rest/api/3/group/member',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueComments.ts
+++ b/src/cloud/api/issueComments.ts
@@ -1,6 +1,7 @@
-import { PageCommentSchema, type PageComment } from '../models/pageComment';
-import { PageOfCommentsSchema, type PageOfComments } from '../models/pageOfComments';
+import { PageCommentSchema } from '../models/pageComment';
+import type { Page } from '../models/page';
 import { CommentSchema, type Comment } from '../models/comment';
+import { PageOfCommentsSchema, type PageOfComments } from '../models/pageOfComments';
 import type { GetCommentsByIds } from '../parameters/getCommentsByIds';
 import type { GetComments } from '../parameters/getComments';
 import type { AddComment } from '../parameters/addComment';
@@ -24,8 +25,8 @@ import type { Client, SendRequestOptions } from '#/core';
  *   to view the issue.
  * - If the comment has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function getCommentsByIds(client: Client, parameters: GetCommentsByIds): Promise<PageComment> {
-  const config: SendRequestOptions<PageComment> = {
+export async function getCommentsByIds(client: Client, parameters: GetCommentsByIds): Promise<Page<Comment>> {
+  const config: SendRequestOptions<Page<Comment>> = {
     url: '/rest/api/3/comment/list',
     method: 'POST',
     searchParams: {

--- a/src/cloud/api/issueCustomFieldConfigurationApps.ts
+++ b/src/cloud/api/issueCustomFieldConfigurationApps.ts
@@ -1,7 +1,6 @@
-import {
-  PageContextualConfigurationSchema,
-  type PageContextualConfiguration,
-} from '../models/pageContextualConfiguration';
+import { PageContextualConfigurationSchema } from '../models/pageContextualConfiguration';
+import type { Page } from '../models/page';
+import type { ContextualConfiguration } from '../models/contextualConfiguration';
 import type { GetCustomFieldConfiguration } from '../parameters/getCustomFieldConfiguration';
 import type { UpdateCustomFieldConfiguration } from '../parameters/updateCustomFieldConfiguration';
 import type { Client, SendRequestOptions } from '#/core';
@@ -28,8 +27,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getCustomFieldConfiguration(
   client: Client,
   parameters: GetCustomFieldConfiguration,
-): Promise<PageContextualConfiguration> {
-  const config: SendRequestOptions<PageContextualConfiguration> = {
+): Promise<Page<ContextualConfiguration>> {
+  const config: SendRequestOptions<Page<ContextualConfiguration>> = {
     url: `/rest/api/3/app/field/${parameters.fieldIdOrKey}/context/configuration`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueCustomFieldContexts.ts
+++ b/src/cloud/api/issueCustomFieldContexts.ts
@@ -1,18 +1,15 @@
-import { PageCustomFieldContextSchema, type PageCustomFieldContext } from '../models/pageCustomFieldContext';
+import { PageCustomFieldContextSchema } from '../models/pageCustomFieldContext';
+import type { Page } from '../models/page';
+import type { CustomFieldContext } from '../models/customFieldContext';
 import { CreateCustomFieldContextSchema, type CreateCustomFieldContext } from '../models/createCustomFieldContext';
-import { PageContextDefaultValuesSchema, type PageContextDefaultValues } from '../models/pageContextDefaultValues';
-import {
-  PageIssueTypeToContextMappingSchema,
-  type PageIssueTypeToContextMapping,
-} from '../models/pageIssueTypeToContextMapping';
-import {
-  PageContextForProjectAndIssueTypeSchema,
-  type PageContextForProjectAndIssueType,
-} from '../models/pageContextForProjectAndIssueType';
-import {
-  PageCustomFieldContextProjectMappingSchema,
-  type PageCustomFieldContextProjectMapping,
-} from '../models/pageCustomFieldContextProjectMapping';
+import { PageContextDefaultValuesSchema } from '../models/pageContextDefaultValues';
+import type { ContextDefaultValues } from '../models/contextDefaultValues';
+import { PageIssueTypeToContextMappingSchema } from '../models/pageIssueTypeToContextMapping';
+import type { IssueTypeToContextMapping } from '../models/issueTypeToContextMapping';
+import { PageContextForProjectAndIssueTypeSchema } from '../models/pageContextForProjectAndIssueType';
+import type { ContextForProjectAndIssueType } from '../models/contextForProjectAndIssueType';
+import { PageCustomFieldContextProjectMappingSchema } from '../models/pageCustomFieldContextProjectMapping';
+import type { CustomFieldContextProjectMapping } from '../models/customFieldContextProjectMapping';
 import type { GetContextsForField } from '../parameters/getContextsForField';
 import type { CreateCustomFieldContext as CreateCustomFieldContextParameters } from '../parameters/createCustomFieldContext';
 import type { GetContextDefaultValues } from '../parameters/getContextDefaultValues';
@@ -46,8 +43,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getContextsForField(
   client: Client,
   parameters: GetContextsForField,
-): Promise<PageCustomFieldContext> {
-  const config: SendRequestOptions<PageCustomFieldContext> = {
+): Promise<Page<CustomFieldContext>> {
+  const config: SendRequestOptions<Page<CustomFieldContext>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context`,
     method: 'GET',
     searchParams: {
@@ -114,8 +111,8 @@ export async function createCustomFieldContext(
 export async function getContextDefaultValues(
   client: Client,
   parameters: GetContextDefaultValues,
-): Promise<PageContextDefaultValues> {
-  const config: SendRequestOptions<PageContextDefaultValues> = {
+): Promise<Page<ContextDefaultValues>> {
+  const config: SendRequestOptions<Page<ContextDefaultValues>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/defaultValues`,
     method: 'GET',
     searchParams: {
@@ -141,8 +138,8 @@ export async function getContextDefaultValues(
 export async function getIssueTypeMappingsForContexts(
   client: Client,
   parameters: GetIssueTypeMappingsForContexts,
-): Promise<PageIssueTypeToContextMapping> {
-  const config: SendRequestOptions<PageIssueTypeToContextMapping> = {
+): Promise<Page<IssueTypeToContextMapping>> {
+  const config: SendRequestOptions<Page<IssueTypeToContextMapping>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/issuetypemapping`,
     method: 'GET',
     searchParams: {
@@ -175,8 +172,8 @@ export async function getIssueTypeMappingsForContexts(
 export async function getCustomFieldContextsForProjectsAndIssueTypes(
   client: Client,
   parameters: GetCustomFieldContextsForProjectsAndIssueTypes,
-): Promise<PageContextForProjectAndIssueType> {
-  const config: SendRequestOptions<PageContextForProjectAndIssueType> = {
+): Promise<Page<ContextForProjectAndIssueType>> {
+  const config: SendRequestOptions<Page<ContextForProjectAndIssueType>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/mapping`,
     method: 'POST',
     searchParams: {
@@ -203,8 +200,8 @@ export async function getCustomFieldContextsForProjectsAndIssueTypes(
 export async function getProjectContextMapping(
   client: Client,
   parameters: GetProjectContextMapping,
-): Promise<PageCustomFieldContextProjectMapping> {
-  const config: SendRequestOptions<PageCustomFieldContextProjectMapping> = {
+): Promise<Page<CustomFieldContextProjectMapping>> {
+  const config: SendRequestOptions<Page<CustomFieldContextProjectMapping>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/projectmapping`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueCustomFieldOptions.ts
+++ b/src/cloud/api/issueCustomFieldOptions.ts
@@ -1,8 +1,7 @@
 import { CustomFieldOptionSchema, type CustomFieldOption } from '../models/customFieldOption';
-import {
-  PageCustomFieldContextOptionSchema,
-  type PageCustomFieldContextOption,
-} from '../models/pageCustomFieldContextOption';
+import { PageCustomFieldContextOptionSchema } from '../models/pageCustomFieldContextOption';
+import type { Page } from '../models/page';
+import type { CustomFieldContextOption } from '../models/customFieldContextOption';
 import {
   CustomFieldCreatedContextOptionsListSchema,
   type CustomFieldCreatedContextOptionsList,
@@ -72,8 +71,8 @@ export async function getCustomFieldOption(
 export async function getOptionsForContext(
   client: Client,
   parameters: GetOptionsForContext,
-): Promise<PageCustomFieldContextOption> {
-  const config: SendRequestOptions<PageCustomFieldContextOption> = {
+): Promise<Page<CustomFieldContextOption>> {
+  const config: SendRequestOptions<Page<CustomFieldContextOption>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/option`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueCustomFieldOptionsApps.ts
+++ b/src/cloud/api/issueCustomFieldOptionsApps.ts
@@ -1,4 +1,5 @@
-import { PageIssueFieldOptionSchema, type PageIssueFieldOption } from '../models/pageIssueFieldOption';
+import { PageIssueFieldOptionSchema } from '../models/pageIssueFieldOption';
+import type { Page } from '../models/page';
 import { IssueFieldOptionSchema, type IssueFieldOption } from '../models/issueFieldOption';
 import {
   TaskProgressRemoveOptionFromIssuesResultSchema,
@@ -32,8 +33,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getAllIssueFieldOptions(
   client: Client,
   parameters: GetAllIssueFieldOptions,
-): Promise<PageIssueFieldOption> {
-  const config: SendRequestOptions<PageIssueFieldOption> = {
+): Promise<Page<IssueFieldOption>> {
+  const config: SendRequestOptions<Page<IssueFieldOption>> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option`,
     method: 'GET',
     searchParams: {
@@ -93,8 +94,8 @@ export async function createIssueFieldOption(
 export async function getSelectableIssueFieldOptions(
   client: Client,
   parameters: GetSelectableIssueFieldOptions,
-): Promise<PageIssueFieldOption> {
-  const config: SendRequestOptions<PageIssueFieldOption> = {
+): Promise<Page<IssueFieldOption>> {
+  const config: SendRequestOptions<Page<IssueFieldOption>> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option/suggestions/edit`,
     method: 'GET',
     searchParams: {
@@ -123,8 +124,8 @@ export async function getSelectableIssueFieldOptions(
 export async function getVisibleIssueFieldOptions(
   client: Client,
   parameters: GetVisibleIssueFieldOptions,
-): Promise<PageIssueFieldOption> {
-  const config: SendRequestOptions<PageIssueFieldOption> = {
+): Promise<Page<IssueFieldOption>> {
+  const config: SendRequestOptions<Page<IssueFieldOption>> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option/suggestions/search`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueFields.ts
+++ b/src/cloud/api/issueFields.ts
@@ -1,5 +1,7 @@
 import { FieldDetailsSchema, type FieldDetails } from '../models/fieldDetails';
-import { PageFieldSchema, type PageField } from '../models/pageField';
+import { PageFieldSchema } from '../models/pageField';
+import type { Page } from '../models/page';
+import type { Field } from '../models/field';
 import { TaskProgressObjectSchema, type TaskProgressObject } from '../models/taskProgressObject';
 import type { CreateCustomField } from '../parameters/createCustomField';
 import type { GetFieldsPaginated } from '../parameters/getFieldsPaginated';
@@ -73,8 +75,8 @@ export async function createCustomField(client: Client, parameters: CreateCustom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getFieldsPaginated(client: Client, parameters?: GetFieldsPaginated): Promise<PageField> {
-  const config: SendRequestOptions<PageField> = {
+export async function getFieldsPaginated(client: Client, parameters?: GetFieldsPaginated): Promise<Page<Field>> {
+  const config: SendRequestOptions<Page<Field>> = {
     url: '/rest/api/3/field/search',
     method: 'GET',
     searchParams: {
@@ -105,8 +107,8 @@ export async function getFieldsPaginated(client: Client, parameters?: GetFieldsP
 export async function getTrashedFieldsPaginated(
   client: Client,
   parameters?: GetTrashedFieldsPaginated,
-): Promise<PageField> {
-  const config: SendRequestOptions<PageField> = {
+): Promise<Page<Field>> {
+  const config: SendRequestOptions<Page<Field>> = {
     url: '/rest/api/3/field/search/trashed',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueNotificationSchemes.ts
+++ b/src/cloud/api/issueNotificationSchemes.ts
@@ -1,9 +1,8 @@
-import { PageNotificationSchemeSchema, type PageNotificationScheme } from '../models/pageNotificationScheme';
-import {
-  NotificationSchemeAndProjectMappingPageSchema,
-  type NotificationSchemeAndProjectMappingPage,
-} from '../models/notificationSchemeAndProjectMappingPage';
+import { PageNotificationSchemeSchema } from '../models/pageNotificationScheme';
+import type { Page } from '../models/page';
 import { NotificationSchemeSchema, type NotificationScheme } from '../models/notificationScheme';
+import { NotificationSchemeAndProjectMappingPageSchema } from '../models/notificationSchemeAndProjectMappingPage';
+import type { NotificationSchemeAndProjectMappingJson } from '../models/notificationSchemeAndProjectMappingJson';
 import type { GetNotificationSchemes } from '../parameters/getNotificationSchemes';
 import type { GetNotificationSchemeToProjectMappings } from '../parameters/getNotificationSchemeToProjectMappings';
 import type { GetNotificationScheme } from '../parameters/getNotificationScheme';
@@ -24,8 +23,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getNotificationSchemes(
   client: Client,
   parameters?: GetNotificationSchemes,
-): Promise<PageNotificationScheme> {
-  const config: SendRequestOptions<PageNotificationScheme> = {
+): Promise<Page<NotificationScheme>> {
+  const config: SendRequestOptions<Page<NotificationScheme>> = {
     url: '/rest/api/3/notificationscheme',
     method: 'GET',
     searchParams: {
@@ -55,8 +54,8 @@ export async function getNotificationSchemes(
 export async function getNotificationSchemeToProjectMappings(
   client: Client,
   parameters?: GetNotificationSchemeToProjectMappings,
-): Promise<NotificationSchemeAndProjectMappingPage> {
-  const config: SendRequestOptions<NotificationSchemeAndProjectMappingPage> = {
+): Promise<Page<NotificationSchemeAndProjectMappingJson>> {
+  const config: SendRequestOptions<Page<NotificationSchemeAndProjectMappingJson>> = {
     url: '/rest/api/3/notificationscheme/project',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issuePriorities.ts
+++ b/src/cloud/api/issuePriorities.ts
@@ -1,5 +1,6 @@
 import { PriorityIdSchema, type PriorityId } from '../models/priorityId';
-import { PagePrioritySchema, type PagePriority } from '../models/pagePriority';
+import { PagePrioritySchema } from '../models/pagePriority';
+import type { Page } from '../models/page';
 import { PrioritySchema, type Priority } from '../models/priority';
 import { TaskProgressObjectSchema, type TaskProgressObject } from '../models/taskProgressObject';
 import type { CreatePriority } from '../parameters/createPriority';
@@ -94,8 +95,8 @@ export async function movePriorities(client: Client, parameters: MovePriorities)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function searchPriorities(client: Client, parameters?: SearchPriorities): Promise<PagePriority> {
-  const config: SendRequestOptions<PagePriority> = {
+export async function searchPriorities(client: Client, parameters?: SearchPriorities): Promise<Page<Priority>> {
+  const config: SendRequestOptions<Page<Priority>> = {
     url: '/rest/api/3/priority/search',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueSecurityLevel.ts
+++ b/src/cloud/api/issueSecurityLevel.ts
@@ -1,7 +1,6 @@
-import {
-  PageIssueSecurityLevelMemberSchema,
-  type PageIssueSecurityLevelMember,
-} from '../models/pageIssueSecurityLevelMember';
+import { PageIssueSecurityLevelMemberSchema } from '../models/pageIssueSecurityLevelMember';
+import type { Page } from '../models/page';
+import type { IssueSecurityLevelMember } from '../models/issueSecurityLevelMember';
 import { SecurityLevelSchema, type SecurityLevel } from '../models/securityLevel';
 import type { GetIssueSecurityLevelMembers } from '../parameters/getIssueSecurityLevelMembers';
 import type { GetIssueSecurityLevel } from '../parameters/getIssueSecurityLevel';
@@ -18,8 +17,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getIssueSecurityLevelMembers(
   client: Client,
   parameters: GetIssueSecurityLevelMembers,
-): Promise<PageIssueSecurityLevelMember> {
-  const config: SendRequestOptions<PageIssueSecurityLevelMember> = {
+): Promise<Page<IssueSecurityLevelMember>> {
+  const config: SendRequestOptions<Page<IssueSecurityLevelMember>> = {
     url: `/rest/api/3/issuesecurityschemes/${parameters.issueSecuritySchemeId}/members`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueTypeSchemes.ts
+++ b/src/cloud/api/issueTypeSchemes.ts
@@ -1,13 +1,11 @@
-import { PageIssueTypeSchemeSchema, type PageIssueTypeScheme } from '../models/pageIssueTypeScheme';
+import { PageIssueTypeSchemeSchema } from '../models/pageIssueTypeScheme';
+import type { Page } from '../models/page';
+import type { IssueTypeScheme } from '../models/issueTypeScheme';
 import { IssueTypeSchemeIDSchema, type IssueTypeSchemeID } from '../models/issueTypeSchemeID';
-import {
-  PageIssueTypeSchemeMappingSchema,
-  type PageIssueTypeSchemeMapping,
-} from '../models/pageIssueTypeSchemeMapping';
-import {
-  PageIssueTypeSchemeProjectsSchema,
-  type PageIssueTypeSchemeProjects,
-} from '../models/pageIssueTypeSchemeProjects';
+import { PageIssueTypeSchemeMappingSchema } from '../models/pageIssueTypeSchemeMapping';
+import type { IssueTypeSchemeMapping } from '../models/issueTypeSchemeMapping';
+import { PageIssueTypeSchemeProjectsSchema } from '../models/pageIssueTypeSchemeProjects';
+import type { IssueTypeSchemeProjects } from '../models/issueTypeSchemeProjects';
 import type { GetAllIssueTypeSchemes } from '../parameters/getAllIssueTypeSchemes';
 import type { CreateIssueTypeScheme } from '../parameters/createIssueTypeScheme';
 import type { GetIssueTypeSchemesMapping } from '../parameters/getIssueTypeSchemesMapping';
@@ -32,8 +30,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getAllIssueTypeSchemes(
   client: Client,
   parameters?: GetAllIssueTypeSchemes,
-): Promise<PageIssueTypeScheme> {
-  const config: SendRequestOptions<PageIssueTypeScheme> = {
+): Promise<Page<IssueTypeScheme>> {
+  const config: SendRequestOptions<Page<IssueTypeScheme>> = {
     url: '/rest/api/3/issuetypescheme',
     method: 'GET',
     searchParams: {
@@ -87,8 +85,8 @@ export async function createIssueTypeScheme(
 export async function getIssueTypeSchemesMapping(
   client: Client,
   parameters?: GetIssueTypeSchemesMapping,
-): Promise<PageIssueTypeSchemeMapping> {
-  const config: SendRequestOptions<PageIssueTypeSchemeMapping> = {
+): Promise<Page<IssueTypeSchemeMapping>> {
+  const config: SendRequestOptions<Page<IssueTypeSchemeMapping>> = {
     url: '/rest/api/3/issuetypescheme/mapping',
     method: 'GET',
     searchParams: {
@@ -114,8 +112,8 @@ export async function getIssueTypeSchemesMapping(
 export async function getIssueTypeSchemeForProjects(
   client: Client,
   parameters: GetIssueTypeSchemeForProjects,
-): Promise<PageIssueTypeSchemeProjects> {
-  const config: SendRequestOptions<PageIssueTypeSchemeProjects> = {
+): Promise<Page<IssueTypeSchemeProjects>> {
+  const config: SendRequestOptions<Page<IssueTypeSchemeProjects>> = {
     url: '/rest/api/3/issuetypescheme/project',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issueTypeScreenSchemes.ts
+++ b/src/cloud/api/issueTypeScreenSchemes.ts
@@ -1,14 +1,13 @@
-import { PageIssueTypeScreenSchemeSchema, type PageIssueTypeScreenScheme } from '../models/pageIssueTypeScreenScheme';
+import { PageIssueTypeScreenSchemeSchema } from '../models/pageIssueTypeScreenScheme';
+import type { Page } from '../models/page';
+import type { IssueTypeScreenScheme } from '../models/issueTypeScreenScheme';
 import { IssueTypeScreenSchemeIdSchema, type IssueTypeScreenSchemeId } from '../models/issueTypeScreenSchemeId';
-import {
-  PageIssueTypeScreenSchemeItemSchema,
-  type PageIssueTypeScreenSchemeItem,
-} from '../models/pageIssueTypeScreenSchemeItem';
-import {
-  PageIssueTypeScreenSchemesProjectsSchema,
-  type PageIssueTypeScreenSchemesProjects,
-} from '../models/pageIssueTypeScreenSchemesProjects';
-import { PageProjectDetailsSchema, type PageProjectDetails } from '../models/pageProjectDetails';
+import { PageIssueTypeScreenSchemeItemSchema } from '../models/pageIssueTypeScreenSchemeItem';
+import type { IssueTypeScreenSchemeItem } from '../models/issueTypeScreenSchemeItem';
+import { PageIssueTypeScreenSchemesProjectsSchema } from '../models/pageIssueTypeScreenSchemesProjects';
+import type { IssueTypeScreenSchemesProjects } from '../models/issueTypeScreenSchemesProjects';
+import { PageProjectDetailsSchema } from '../models/pageProjectDetails';
+import type { ProjectDetails } from '../models/projectDetails';
 import type { GetIssueTypeScreenSchemes } from '../parameters/getIssueTypeScreenSchemes';
 import type { CreateIssueTypeScreenScheme } from '../parameters/createIssueTypeScreenScheme';
 import type { GetIssueTypeScreenSchemeMappings } from '../parameters/getIssueTypeScreenSchemeMappings';
@@ -34,8 +33,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getIssueTypeScreenSchemes(
   client: Client,
   parameters?: GetIssueTypeScreenSchemes,
-): Promise<PageIssueTypeScreenScheme> {
-  const config: SendRequestOptions<PageIssueTypeScreenScheme> = {
+): Promise<Page<IssueTypeScreenScheme>> {
+  const config: SendRequestOptions<Page<IssueTypeScreenScheme>> = {
     url: '/rest/api/3/issuetypescreenscheme',
     method: 'GET',
     searchParams: {
@@ -88,8 +87,8 @@ export async function createIssueTypeScreenScheme(
 export async function getIssueTypeScreenSchemeMappings(
   client: Client,
   parameters?: GetIssueTypeScreenSchemeMappings,
-): Promise<PageIssueTypeScreenSchemeItem> {
-  const config: SendRequestOptions<PageIssueTypeScreenSchemeItem> = {
+): Promise<Page<IssueTypeScreenSchemeItem>> {
+  const config: SendRequestOptions<Page<IssueTypeScreenSchemeItem>> = {
     url: '/rest/api/3/issuetypescreenscheme/mapping',
     method: 'GET',
     searchParams: {
@@ -115,8 +114,8 @@ export async function getIssueTypeScreenSchemeMappings(
 export async function getIssueTypeScreenSchemeProjectAssociations(
   client: Client,
   parameters: GetIssueTypeScreenSchemeProjectAssociations,
-): Promise<PageIssueTypeScreenSchemesProjects> {
-  const config: SendRequestOptions<PageIssueTypeScreenSchemesProjects> = {
+): Promise<Page<IssueTypeScreenSchemesProjects>> {
+  const config: SendRequestOptions<Page<IssueTypeScreenSchemesProjects>> = {
     url: '/rest/api/3/issuetypescreenscheme/project',
     method: 'GET',
     searchParams: {
@@ -267,8 +266,8 @@ export async function removeMappingsFromIssueTypeScreenScheme(
 export async function getProjectsForIssueTypeScreenScheme(
   client: Client,
   parameters: GetProjectsForIssueTypeScreenScheme,
-): Promise<PageProjectDetails> {
-  const config: SendRequestOptions<PageProjectDetails> = {
+): Promise<Page<ProjectDetails>> {
+  const config: SendRequestOptions<Page<ProjectDetails>> = {
     url: `/rest/api/3/issuetypescreenscheme/${parameters.issueTypeScreenSchemeId}/project`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/issues.ts
+++ b/src/cloud/api/issues.ts
@@ -11,7 +11,9 @@ import {
   type PageOfCreateMetaIssueTypeWithField,
 } from '../models/pageOfCreateMetaIssueTypeWithField';
 import { IssueSchema, type Issue } from '../models/issue';
-import { PageChangelogSchema, type PageChangelog } from '../models/pageChangelog';
+import { PageChangelogSchema } from '../models/pageChangelog';
+import type { Page } from '../models/page';
+import type { Changelog } from '../models/changelog';
 import { PageOfChangelogsSchema, type PageOfChangelogs } from '../models/pageOfChangelogs';
 import { IssueUpdateMetadataSchema, type IssueUpdateMetadata } from '../models/issueUpdateMetadata';
 import { TransitionsSchema, type Transitions } from '../models/transitions';
@@ -428,8 +430,8 @@ export async function assignIssue(client: Client, parameters: AssignIssue): Prom
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function getChangeLogs(client: Client, parameters: GetChangeLogs): Promise<PageChangelog> {
-  const config: SendRequestOptions<PageChangelog> = {
+export async function getChangeLogs(client: Client, parameters: GetChangeLogs): Promise<Page<Changelog>> {
+  const config: SendRequestOptions<Page<Changelog>> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/changelog`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/jqlFunctionsApps.ts
+++ b/src/cloud/api/jqlFunctionsApps.ts
@@ -1,7 +1,6 @@
-import {
-  PageJqlFunctionPrecomputationSchema,
-  type PageJqlFunctionPrecomputation,
-} from '../models/pageJqlFunctionPrecomputation';
+import { PageJqlFunctionPrecomputationSchema } from '../models/pageJqlFunctionPrecomputation';
+import type { Page } from '../models/page';
+import type { JqlFunctionPrecomputation } from '../models/jqlFunctionPrecomputation';
 import {
   JqlFunctionPrecomputationGetByIdResponseSchema,
   type JqlFunctionPrecomputationGetByIdResponse,
@@ -24,8 +23,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getPrecomputations(
   client: Client,
   parameters?: GetPrecomputations,
-): Promise<PageJqlFunctionPrecomputation> {
-  const config: SendRequestOptions<PageJqlFunctionPrecomputation> = {
+): Promise<Page<JqlFunctionPrecomputation>> {
+  const config: SendRequestOptions<Page<JqlFunctionPrecomputation>> = {
     url: '/rest/api/3/jql/function/computation',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/projectComponents.ts
+++ b/src/cloud/api/projectComponents.ts
@@ -1,10 +1,10 @@
-import { Page2ComponentJsonSchema, type Page2ComponentJson } from '../models/page2ComponentJson';
+import { Page2ComponentJsonSchema } from '../models/page2ComponentJson';
+import type { Page } from '../models/page';
+import type { ComponentJson } from '../models/componentJson';
 import { ProjectComponentSchema, type ProjectComponent } from '../models/projectComponent';
 import { ComponentIssuesCountSchema, type ComponentIssuesCount } from '../models/componentIssuesCount';
-import {
-  PageComponentWithIssueCountSchema,
-  type PageComponentWithIssueCount,
-} from '../models/pageComponentWithIssueCount';
+import { PageComponentWithIssueCountSchema } from '../models/pageComponentWithIssueCount';
+import type { ComponentWithIssueCount } from '../models/componentWithIssueCount';
 import type { FindComponentsForProjects } from '../parameters/findComponentsForProjects';
 import type { CreateComponent } from '../parameters/createComponent';
 import type { GetComponent } from '../parameters/getComponent';
@@ -28,8 +28,8 @@ import { z } from 'zod';
 export async function findComponentsForProjects(
   client: Client,
   parameters?: FindComponentsForProjects,
-): Promise<Page2ComponentJson> {
-  const config: SendRequestOptions<Page2ComponentJson> = {
+): Promise<Page<ComponentJson>> {
+  const config: SendRequestOptions<Page<ComponentJson>> = {
     url: '/rest/api/3/component',
     method: 'GET',
     searchParams: {
@@ -184,8 +184,8 @@ export async function getComponentRelatedIssues(
 export async function getProjectComponentsPaginated(
   client: Client,
   parameters: GetProjectComponentsPaginated,
-): Promise<PageComponentWithIssueCount> {
-  const config: SendRequestOptions<PageComponentWithIssueCount> = {
+): Promise<Page<ComponentWithIssueCount>> {
+  const config: SendRequestOptions<Page<ComponentWithIssueCount>> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/component`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/projectVersions.ts
+++ b/src/cloud/api/projectVersions.ts
@@ -1,4 +1,5 @@
-import { PageVersionSchema, type PageVersion } from '../models/pageVersion';
+import { PageVersionSchema } from '../models/pageVersion';
+import type { Page } from '../models/page';
 import { VersionSchema, type Version } from '../models/version';
 import { VersionIssueCountsSchema, type VersionIssueCounts } from '../models/versionIssueCounts';
 import { VersionRelatedWorkSchema, type VersionRelatedWork } from '../models/versionRelatedWork';
@@ -37,8 +38,8 @@ import { z } from 'zod';
 export async function getProjectVersionsPaginated(
   client: Client,
   parameters: GetProjectVersionsPaginated,
-): Promise<PageVersion> {
-  const config: SendRequestOptions<PageVersion> = {
+): Promise<Page<Version>> {
+  const config: SendRequestOptions<Page<Version>> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/version`,
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/projects.ts
+++ b/src/cloud/api/projects.ts
@@ -1,5 +1,6 @@
 import { ProjectIdentifiersSchema, type ProjectIdentifiers } from '../models/projectIdentifiers';
-import { PageProjectSchema, type PageProject } from '../models/pageProject';
+import { PageProjectSchema } from '../models/pageProject';
+import type { Page } from '../models/page';
 import { ProjectSchema, type Project } from '../models/project';
 import { IssueTypeWithStatusSchema, type IssueTypeWithStatus } from '../models/issueTypeWithStatus';
 import { ProjectIssueTypeHierarchySchema, type ProjectIssueTypeHierarchy } from '../models/projectIssueTypeHierarchy';
@@ -81,8 +82,8 @@ export async function createProject(client: Client, parameters: CreateProject): 
  * - _Administer Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project.
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function searchProjects(client: Client, parameters?: SearchProjects): Promise<PageProject> {
-  const config: SendRequestOptions<PageProject> = {
+export async function searchProjects(client: Client, parameters?: SearchProjects): Promise<Page<Project>> {
+  const config: SendRequestOptions<Page<Project>> = {
     url: '/rest/api/3/project/search',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/screenSchemes.ts
+++ b/src/cloud/api/screenSchemes.ts
@@ -1,4 +1,6 @@
-import { PageScreenSchemeSchema, type PageScreenScheme } from '../models/pageScreenScheme';
+import { PageScreenSchemeSchema } from '../models/pageScreenScheme';
+import type { Page } from '../models/page';
+import type { ScreenScheme } from '../models/screenScheme';
 import { ScreenSchemeIdSchema, type ScreenSchemeId } from '../models/screenSchemeId';
 import type { GetScreenSchemes } from '../parameters/getScreenSchemes';
 import type { CreateScreenScheme } from '../parameters/createScreenScheme';
@@ -15,8 +17,8 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getScreenSchemes(client: Client, parameters?: GetScreenSchemes): Promise<PageScreenScheme> {
-  const config: SendRequestOptions<PageScreenScheme> = {
+export async function getScreenSchemes(client: Client, parameters?: GetScreenSchemes): Promise<Page<ScreenScheme>> {
+  const config: SendRequestOptions<Page<ScreenScheme>> = {
     url: '/rest/api/3/screenscheme',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/screens.ts
+++ b/src/cloud/api/screens.ts
@@ -1,5 +1,8 @@
-import { PageScreenWithTabSchema, type PageScreenWithTab } from '../models/pageScreenWithTab';
-import { PageScreenSchema, type PageScreen } from '../models/pageScreen';
+import { PageScreenWithTabSchema } from '../models/pageScreenWithTab';
+import type { Page } from '../models/page';
+import type { ScreenWithTab } from '../models/screenWithTab';
+import { PageScreenSchema } from '../models/pageScreen';
+import type { Screen } from '../models/screen';
 import { ScreenableFieldSchema, type ScreenableField } from '../models/screenableField';
 import type { GetScreensForField } from '../parameters/getScreensForField';
 import type { GetScreens } from '../parameters/getScreens';
@@ -15,8 +18,8 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getScreensForField(client: Client, parameters: GetScreensForField): Promise<PageScreenWithTab> {
-  const config: SendRequestOptions<PageScreenWithTab> = {
+export async function getScreensForField(client: Client, parameters: GetScreensForField): Promise<Page<ScreenWithTab>> {
+  const config: SendRequestOptions<Page<ScreenWithTab>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/screens`,
     method: 'GET',
     searchParams: {
@@ -37,8 +40,8 @@ export async function getScreensForField(client: Client, parameters: GetScreensF
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getScreens(client: Client, parameters?: GetScreens): Promise<PageScreen> {
-  const config: SendRequestOptions<PageScreen> = {
+export async function getScreens(client: Client, parameters?: GetScreens): Promise<Page<Screen>> {
+  const config: SendRequestOptions<Page<Screen>> = {
     url: '/rest/api/3/screens',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/uiModificationsApps.ts
+++ b/src/cloud/api/uiModificationsApps.ts
@@ -1,4 +1,6 @@
-import { PageUiModificationDetailsSchema, type PageUiModificationDetails } from '../models/pageUiModificationDetails';
+import { PageUiModificationDetailsSchema } from '../models/pageUiModificationDetails';
+import type { Page } from '../models/page';
+import type { UiModificationDetails } from '../models/uiModificationDetails';
 import { UiModificationIdentifiersSchema, type UiModificationIdentifiers } from '../models/uiModificationIdentifiers';
 import type { GetUiModifications } from '../parameters/getUiModifications';
 import type { CreateUiModification } from '../parameters/createUiModification';
@@ -17,8 +19,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getUiModifications(
   client: Client,
   parameters?: GetUiModifications,
-): Promise<PageUiModificationDetails> {
-  const config: SendRequestOptions<PageUiModificationDetails> = {
+): Promise<Page<UiModificationDetails>> {
+  const config: SendRequestOptions<Page<UiModificationDetails>> = {
     url: '/rest/api/3/uiModifications',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/userSearch.ts
+++ b/src/cloud/api/userSearch.ts
@@ -1,7 +1,9 @@
 import { DashboardUserSchema, type DashboardUser } from '../models/dashboardUser';
 import { FoundUsersSchema, type FoundUsers } from '../models/foundUsers';
-import { PageUserSchema, type PageUser } from '../models/pageUser';
-import { PageUserKeySchema, type PageUserKey } from '../models/pageUserKey';
+import { PageUserSchema } from '../models/pageUser';
+import type { Page } from '../models/page';
+import { PageUserKeySchema } from '../models/pageUserKey';
+import type { UserKey } from '../models/userKey';
 import type { FindBulkAssignableUsers } from '../parameters/findBulkAssignableUsers';
 import type { FindAssignableUsers } from '../parameters/findAssignableUsers';
 import type { FindUsersWithAllPermissions } from '../parameters/findUsersWithAllPermissions';
@@ -262,8 +264,8 @@ export async function findUsers(client: Client, parameters?: FindUsers): Promise
  *
  * `is assignee of PROJ AND [propertyKey].entity.property.path is "property value"`
  */
-export async function findUsersByQuery(client: Client, parameters: FindUsersByQuery): Promise<PageUser> {
-  const config: SendRequestOptions<PageUser> = {
+export async function findUsersByQuery(client: Client, parameters: FindUsersByQuery): Promise<Page<DashboardUser>> {
+  const config: SendRequestOptions<Page<DashboardUser>> = {
     url: '/rest/api/3/user/search/query',
     method: 'GET',
     searchParams: {
@@ -308,8 +310,8 @@ export async function findUsersByQuery(client: Client, parameters: FindUsersByQu
  *
  * `is assignee of PROJ AND [propertyKey].entity.property.path is "property value"`
  */
-export async function findUserKeysByQuery(client: Client, parameters: FindUserKeysByQuery): Promise<PageUserKey> {
-  const config: SendRequestOptions<PageUserKey> = {
+export async function findUserKeysByQuery(client: Client, parameters: FindUserKeysByQuery): Promise<Page<UserKey>> {
+  const config: SendRequestOptions<Page<UserKey>> = {
     url: '/rest/api/3/user/search/query/key',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/webhooks.ts
+++ b/src/cloud/api/webhooks.ts
@@ -1,4 +1,6 @@
-import { PageWebhookSchema, type PageWebhook } from '../models/pageWebhook';
+import { PageWebhookSchema } from '../models/pageWebhook';
+import type { Page } from '../models/page';
+import type { Webhook } from '../models/webhook';
 import {
   ContainerForRegisteredWebhooksSchema,
   type ContainerForRegisteredWebhooks,
@@ -21,8 +23,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getDynamicWebhooksForApp(
   client: Client,
   parameters?: GetDynamicWebhooksForApp,
-): Promise<PageWebhook> {
-  const config: SendRequestOptions<PageWebhook> = {
+): Promise<Page<Webhook>> {
+  const config: SendRequestOptions<Page<Webhook>> = {
     url: '/rest/api/3/webhook',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/workflowSchemes.ts
+++ b/src/cloud/api/workflowSchemes.ts
@@ -1,4 +1,5 @@
-import { PageWorkflowSchemeSchema, type PageWorkflowScheme } from '../models/pageWorkflowScheme';
+import { PageWorkflowSchemeSchema } from '../models/pageWorkflowScheme';
+import type { Page } from '../models/page';
 import { WorkflowSchemeSchema, type WorkflowScheme } from '../models/workflowScheme';
 import {
   WorkflowSchemeReadResponseSchema,
@@ -47,8 +48,8 @@ import { z } from 'zod';
 export async function getAllWorkflowSchemes(
   client: Client,
   parameters?: GetAllWorkflowSchemes,
-): Promise<PageWorkflowScheme> {
-  const config: SendRequestOptions<PageWorkflowScheme> = {
+): Promise<Page<WorkflowScheme>> {
+  const config: SendRequestOptions<Page<WorkflowScheme>> = {
     url: '/rest/api/3/workflowscheme',
     method: 'GET',
     searchParams: {

--- a/src/cloud/api/workflowTransitionRules.ts
+++ b/src/cloud/api/workflowTransitionRules.ts
@@ -1,7 +1,6 @@
-import {
-  PageWorkflowTransitionRulesSchema,
-  type PageWorkflowTransitionRules,
-} from '../models/pageWorkflowTransitionRules';
+import { PageWorkflowTransitionRulesSchema } from '../models/pageWorkflowTransitionRules';
+import type { Page } from '../models/page';
+import type { WorkflowTransitionRules } from '../models/workflowTransitionRules';
 import {
   WorkflowTransitionRulesUpdateErrorsSchema,
   type WorkflowTransitionRulesUpdateErrors,
@@ -33,8 +32,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getWorkflowTransitionRuleConfigurations(
   client: Client,
   parameters: GetWorkflowTransitionRuleConfigurations,
-): Promise<PageWorkflowTransitionRules> {
-  const config: SendRequestOptions<PageWorkflowTransitionRules> = {
+): Promise<Page<WorkflowTransitionRules>> {
+  const config: SendRequestOptions<Page<WorkflowTransitionRules>> = {
     url: '/rest/api/3/workflow/rule/config',
     method: 'GET',
     searchParams: {

--- a/src/cloud/createCloudClient.ts
+++ b/src/cloud/createCloudClient.ts
@@ -538,7 +538,8 @@ import type {
 } from './parameters';
 import type {
   AnnouncementBannerConfiguration,
-  PageContextualConfiguration,
+  Page,
+  ContextualConfiguration,
   ApplicationProperty,
   Configuration,
   ApplicationRole,
@@ -560,55 +561,52 @@ import type {
   PageOfCreateMetaIssueTypes,
   PageOfCreateMetaIssueTypeWithField,
   Issue,
-  PageChangelog,
+  Changelog,
   PageOfChangelogs,
   IssueUpdateMetadata,
   Transitions,
-  PageComment,
-  PageOfComments,
   Comment,
+  PageOfComments,
   PropertyKeys,
   EntityProperty,
-  Page2ComponentJson,
+  ComponentJson,
   ProjectComponent,
   ComponentIssuesCount,
-  PageComponentWithIssueCount,
+  ComponentWithIssueCount,
   TimeTrackingProvider,
   TimeTrackingConfiguration,
   CustomFieldOption,
-  PageCustomFieldContextOption,
+  CustomFieldContextOption,
   CustomFieldCreatedContextOptionsList,
   CustomFieldUpdatedContextOptionsList,
   TaskProgressRemoveOptionFromIssuesResult,
   PageOfDashboards,
-  PageDashboard,
   Dashboard,
   WorkspaceDataPolicy,
   ProjectDataPolicies,
   JiraExpressionsAnalysis,
   JExpEvaluateJiraExpressionResult,
   FieldDetails,
-  PageField,
+  Field,
   TaskProgressObject,
-  PageCustomFieldContext,
+  CustomFieldContext,
   CreateCustomFieldContext as CreateCustomFieldContextModel,
-  PageContextDefaultValues,
-  PageIssueTypeToContextMapping,
-  PageContextForProjectAndIssueType,
-  PageCustomFieldContextProjectMapping,
-  PageScreenWithTab,
-  PageScreen,
+  ContextDefaultValues,
+  IssueTypeToContextMapping,
+  ContextForProjectAndIssueType,
+  CustomFieldContextProjectMapping,
+  ScreenWithTab,
+  Screen,
   ScreenableField,
-  PageIssueFieldOption,
   IssueFieldOption,
   Filter,
-  PageFilterDetails,
+  FilterDetails,
   ColumnItem,
   DefaultShareScope,
   SharePermission,
   ForgePanelProjectPinAsyncResponse,
   Group,
-  PageUserDetails,
+  UserDetails,
   FoundGroups,
   FoundUsersAndGroups,
   IssuePickerSuggestions,
@@ -629,23 +627,23 @@ import type {
   IssueLinkType,
   SecuritySchemes,
   SecurityScheme,
-  PageIssueSecurityLevelMember,
+  IssueSecurityLevelMember,
   SecurityLevel,
   IssueTypeDetails,
-  PageIssueTypeScheme,
+  IssueTypeScheme,
   IssueTypeSchemeID,
-  PageIssueTypeSchemeMapping,
-  PageIssueTypeSchemeProjects,
-  PageIssueTypeScreenScheme,
+  IssueTypeSchemeMapping,
+  IssueTypeSchemeProjects,
+  IssueTypeScreenScheme,
   IssueTypeScreenSchemeId,
-  PageIssueTypeScreenSchemeItem,
-  PageIssueTypeScreenSchemesProjects,
-  PageProjectDetails,
+  IssueTypeScreenSchemeItem,
+  IssueTypeScreenSchemesProjects,
+  ProjectDetails,
   JQLReferenceData,
   AutoCompleteSuggestions,
   ParsedJqlQueries,
   ConvertedJQLQueries,
-  PageJqlFunctionPrecomputation,
+  JqlFunctionPrecomputation,
   JqlFunctionPrecomputationGetByIdResponse,
   PageString,
   Permissions,
@@ -653,18 +651,15 @@ import type {
   PermittedProjects,
   Locale,
   DashboardUser,
-  PageNotificationScheme,
-  NotificationSchemeAndProjectMappingPage,
   NotificationScheme,
+  NotificationSchemeAndProjectMappingJson,
   PermissionSchemes,
   PermissionScheme,
   PermissionGrants,
   PermissionGrant,
   PriorityId,
-  PagePriority,
   Priority,
   ProjectIdentifiers,
-  PageProject,
   Project,
   IssueTypeWithStatus,
   ProjectIssueTypeHierarchy,
@@ -674,7 +669,6 @@ import type {
   GetProjectRoles as GetProjectRolesModel,
   ProjectRole,
   ProjectRoleDetails,
-  PageVersion,
   Version,
   VersionIssueCounts,
   VersionRelatedWork,
@@ -687,7 +681,7 @@ import type {
   RedactionJobStatusResponse,
   Resolution,
   ScreenableTab,
-  PageScreenScheme,
+  ScreenScheme,
   ScreenSchemeId,
   ServerInformation,
   StatusDetails,
@@ -697,14 +691,13 @@ import type {
   StatusProjectIssueTypeUsageDTO,
   StatusProjectUsageDTO,
   StatusWorkflowUsageDTO,
-  PageUiModificationDetails,
+  UiModificationDetails,
   UiModificationIdentifiers,
   UnrestrictedUserEmail,
   GroupName,
   FoundUsers,
-  PageUser,
-  PageUserKey,
-  PageWebhook,
+  UserKey,
+  Webhook,
   ContainerForRegisteredWebhooks,
   WebhooksExpirationDate,
   WorkflowHistoryReadResponseDTO,
@@ -720,9 +713,8 @@ import type {
   WorkflowPreviewResponse,
   WorkflowSearchResponse,
   WorkflowUpdateResponse,
-  PageWorkflowTransitionRules,
+  WorkflowTransitionRules,
   WorkflowTransitionRulesUpdateErrors,
-  PageWorkflowScheme,
   WorkflowScheme,
   WorkflowSchemeReadResponse,
   WorkflowSchemeUpdateRequiredMappingsResponse,
@@ -755,7 +747,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         issueCustomFieldValuesApps.updateCustomFieldValue(client, parameters),
     },
     issueCustomFieldConfigurationApps: {
-      getCustomFieldConfiguration: (parameters: GetCustomFieldConfiguration): Promise<PageContextualConfiguration> =>
+      getCustomFieldConfiguration: (parameters: GetCustomFieldConfiguration): Promise<Page<ContextualConfiguration>> =>
         issueCustomFieldConfigurationApps.getCustomFieldConfiguration(client, parameters),
       updateCustomFieldConfiguration: (parameters: UpdateCustomFieldConfiguration): Promise<void> =>
         issueCustomFieldConfigurationApps.updateCustomFieldConfiguration(client, parameters),
@@ -839,7 +831,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
       editIssue: (parameters: EditIssue): Promise<void> => issues.editIssue(client, parameters),
       deleteIssue: (parameters: DeleteIssue): Promise<void> => issues.deleteIssue(client, parameters),
       assignIssue: (parameters: AssignIssue): Promise<void> => issues.assignIssue(client, parameters),
-      getChangeLogs: (parameters: GetChangeLogs): Promise<PageChangelog> => issues.getChangeLogs(client, parameters),
+      getChangeLogs: (parameters: GetChangeLogs): Promise<Page<Changelog>> => issues.getChangeLogs(client, parameters),
       getChangeLogsByIds: (parameters: GetChangeLogsByIds): Promise<PageOfChangelogs> =>
         issues.getChangeLogsByIds(client, parameters),
       getEditIssueMeta: (parameters: GetEditIssueMeta): Promise<IssueUpdateMetadata> =>
@@ -849,7 +841,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
       doTransition: (parameters: DoTransition): Promise<void> => issues.doTransition(client, parameters),
     },
     issueComments: {
-      getCommentsByIds: (parameters: GetCommentsByIds): Promise<PageComment> =>
+      getCommentsByIds: (parameters: GetCommentsByIds): Promise<Page<Comment>> =>
         issueComments.getCommentsByIds(client, parameters),
       getComments: (parameters: GetComments): Promise<PageOfComments> => issueComments.getComments(client, parameters),
       addComment: (parameters: AddComment): Promise<Comment> => issueComments.addComment(client, parameters),
@@ -868,7 +860,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         issueCommentProperties.deleteCommentProperty(client, parameters),
     },
     projectComponents: {
-      findComponentsForProjects: (parameters?: FindComponentsForProjects): Promise<Page2ComponentJson> =>
+      findComponentsForProjects: (parameters?: FindComponentsForProjects): Promise<Page<ComponentJson>> =>
         projectComponents.findComponentsForProjects(client, parameters),
       createComponent: (parameters: CreateComponent): Promise<ProjectComponent> =>
         projectComponents.createComponent(client, parameters),
@@ -882,7 +874,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         projectComponents.getComponentRelatedIssues(client, parameters),
       getProjectComponentsPaginated: (
         parameters: GetProjectComponentsPaginated,
-      ): Promise<PageComponentWithIssueCount> => projectComponents.getProjectComponentsPaginated(client, parameters),
+      ): Promise<Page<ComponentWithIssueCount>> => projectComponents.getProjectComponentsPaginated(client, parameters),
       getProjectComponents: (parameters: GetProjectComponents): Promise<ProjectComponent[]> =>
         projectComponents.getProjectComponents(client, parameters),
     },
@@ -902,7 +894,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
     issueCustomFieldOptions: {
       getCustomFieldOption: (parameters: GetCustomFieldOption): Promise<CustomFieldOption> =>
         issueCustomFieldOptions.getCustomFieldOption(client, parameters),
-      getOptionsForContext: (parameters: GetOptionsForContext): Promise<PageCustomFieldContextOption> =>
+      getOptionsForContext: (parameters: GetOptionsForContext): Promise<Page<CustomFieldContextOption>> =>
         issueCustomFieldOptions.getOptionsForContext(client, parameters),
       createCustomFieldOption: (parameters: CreateCustomFieldOption): Promise<CustomFieldCreatedContextOptionsList> =>
         issueCustomFieldOptions.createCustomFieldOption(client, parameters),
@@ -920,7 +912,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
     dashboards: {
       getAllDashboards: (parameters?: GetAllDashboards): Promise<PageOfDashboards> =>
         dashboards.getAllDashboards(client, parameters),
-      getDashboardsPaginated: (parameters?: GetDashboardsPaginated): Promise<PageDashboard> =>
+      getDashboardsPaginated: (parameters?: GetDashboardsPaginated): Promise<Page<Dashboard>> =>
         dashboards.getDashboardsPaginated(client, parameters),
       getDashboardItemPropertyKeys: (parameters: GetDashboardItemPropertyKeys): Promise<PropertyKeys> =>
         dashboards.getDashboardItemPropertyKeys(client, parameters),
@@ -947,9 +939,9 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
       getFields: (): Promise<FieldDetails[]> => issueFields.getFields(client),
       createCustomField: (parameters: CreateCustomField): Promise<FieldDetails> =>
         issueFields.createCustomField(client, parameters),
-      getFieldsPaginated: (parameters?: GetFieldsPaginated): Promise<PageField> =>
+      getFieldsPaginated: (parameters?: GetFieldsPaginated): Promise<Page<Field>> =>
         issueFields.getFieldsPaginated(client, parameters),
-      getTrashedFieldsPaginated: (parameters?: GetTrashedFieldsPaginated): Promise<PageField> =>
+      getTrashedFieldsPaginated: (parameters?: GetTrashedFieldsPaginated): Promise<Page<Field>> =>
         issueFields.getTrashedFieldsPaginated(client, parameters),
       updateCustomField: (parameters: UpdateCustomField): Promise<void> =>
         issueFields.updateCustomField(client, parameters),
@@ -967,21 +959,23 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         issueCustomFieldAssociations.removeAssociations(client, parameters),
     },
     issueCustomFieldContexts: {
-      getContextsForField: (parameters: GetContextsForField): Promise<PageCustomFieldContext> =>
+      getContextsForField: (parameters: GetContextsForField): Promise<Page<CustomFieldContext>> =>
         issueCustomFieldContexts.getContextsForField(client, parameters),
       createCustomFieldContext: (parameters: CreateCustomFieldContext): Promise<CreateCustomFieldContextModel> =>
         issueCustomFieldContexts.createCustomFieldContext(client, parameters),
-      getContextDefaultValues: (parameters: GetContextDefaultValues): Promise<PageContextDefaultValues> =>
+      getContextDefaultValues: (parameters: GetContextDefaultValues): Promise<Page<ContextDefaultValues>> =>
         issueCustomFieldContexts.getContextDefaultValues(client, parameters),
       getIssueTypeMappingsForContexts: (
         parameters: GetIssueTypeMappingsForContexts,
-      ): Promise<PageIssueTypeToContextMapping> =>
+      ): Promise<Page<IssueTypeToContextMapping>> =>
         issueCustomFieldContexts.getIssueTypeMappingsForContexts(client, parameters),
       getCustomFieldContextsForProjectsAndIssueTypes: (
         parameters: GetCustomFieldContextsForProjectsAndIssueTypes,
-      ): Promise<PageContextForProjectAndIssueType> =>
+      ): Promise<Page<ContextForProjectAndIssueType>> =>
         issueCustomFieldContexts.getCustomFieldContextsForProjectsAndIssueTypes(client, parameters),
-      getProjectContextMapping: (parameters: GetProjectContextMapping): Promise<PageCustomFieldContextProjectMapping> =>
+      getProjectContextMapping: (
+        parameters: GetProjectContextMapping,
+      ): Promise<Page<CustomFieldContextProjectMapping>> =>
         issueCustomFieldContexts.getProjectContextMapping(client, parameters),
       updateCustomFieldContext: (parameters: UpdateCustomFieldContext): Promise<void> =>
         issueCustomFieldContexts.updateCustomFieldContext(client, parameters),
@@ -997,22 +991,22 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         issueCustomFieldContexts.removeCustomFieldContextFromProjects(client, parameters),
     },
     screens: {
-      getScreensForField: (parameters: GetScreensForField): Promise<PageScreenWithTab> =>
+      getScreensForField: (parameters: GetScreensForField): Promise<Page<ScreenWithTab>> =>
         screens.getScreensForField(client, parameters),
-      getScreens: (parameters?: GetScreens): Promise<PageScreen> => screens.getScreens(client, parameters),
+      getScreens: (parameters?: GetScreens): Promise<Page<Screen>> => screens.getScreens(client, parameters),
       addFieldToDefaultScreen: (parameters: AddFieldToDefaultScreen): Promise<void> =>
         screens.addFieldToDefaultScreen(client, parameters),
       getAvailableScreenFields: (parameters: GetAvailableScreenFields): Promise<ScreenableField[]> =>
         screens.getAvailableScreenFields(client, parameters),
     },
     issueCustomFieldOptionsApps: {
-      getAllIssueFieldOptions: (parameters: GetAllIssueFieldOptions): Promise<PageIssueFieldOption> =>
+      getAllIssueFieldOptions: (parameters: GetAllIssueFieldOptions): Promise<Page<IssueFieldOption>> =>
         issueCustomFieldOptionsApps.getAllIssueFieldOptions(client, parameters),
       createIssueFieldOption: (parameters: CreateIssueFieldOption): Promise<IssueFieldOption> =>
         issueCustomFieldOptionsApps.createIssueFieldOption(client, parameters),
-      getSelectableIssueFieldOptions: (parameters: GetSelectableIssueFieldOptions): Promise<PageIssueFieldOption> =>
+      getSelectableIssueFieldOptions: (parameters: GetSelectableIssueFieldOptions): Promise<Page<IssueFieldOption>> =>
         issueCustomFieldOptionsApps.getSelectableIssueFieldOptions(client, parameters),
-      getVisibleIssueFieldOptions: (parameters: GetVisibleIssueFieldOptions): Promise<PageIssueFieldOption> =>
+      getVisibleIssueFieldOptions: (parameters: GetVisibleIssueFieldOptions): Promise<Page<IssueFieldOption>> =>
         issueCustomFieldOptionsApps.getVisibleIssueFieldOptions(client, parameters),
       getIssueFieldOption: (parameters: GetIssueFieldOption): Promise<IssueFieldOption> =>
         issueCustomFieldOptionsApps.getIssueFieldOption(client, parameters),
@@ -1030,7 +1024,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
       getFavouriteFilters: (parameters?: GetFavouriteFilters): Promise<Filter[]> =>
         filters.getFavouriteFilters(client, parameters),
       getMyFilters: (parameters?: GetMyFilters): Promise<Filter[]> => filters.getMyFilters(client, parameters),
-      getFiltersPaginated: (parameters?: GetFiltersPaginated): Promise<PageFilterDetails> =>
+      getFiltersPaginated: (parameters?: GetFiltersPaginated): Promise<Page<FilterDetails>> =>
         filters.getFiltersPaginated(client, parameters),
       getFilter: (parameters: GetFilter): Promise<Filter> => filters.getFilter(client, parameters),
       updateFilter: (parameters: UpdateFilter): Promise<Filter> => filters.updateFilter(client, parameters),
@@ -1063,7 +1057,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
     groups: {
       createGroup: (parameters: CreateGroup): Promise<Group> => groups.createGroup(client, parameters),
       removeGroup: (parameters: RemoveGroup): Promise<void> => groups.removeGroup(client, parameters),
-      getUsersFromGroup: (parameters?: GetUsersFromGroup): Promise<PageUserDetails> =>
+      getUsersFromGroup: (parameters?: GetUsersFromGroup): Promise<Page<UserDetails>> =>
         groups.getUsersFromGroup(client, parameters),
       addUserToGroup: (parameters: AddUserToGroup): Promise<Group> => groups.addUserToGroup(client, parameters),
       removeUserFromGroup: (parameters: RemoveUserFromGroup): Promise<void> =>
@@ -1177,8 +1171,9 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         issueSecuritySchemes.getIssueSecurityScheme(client, parameters),
     },
     issueSecurityLevel: {
-      getIssueSecurityLevelMembers: (parameters: GetIssueSecurityLevelMembers): Promise<PageIssueSecurityLevelMember> =>
-        issueSecurityLevel.getIssueSecurityLevelMembers(client, parameters),
+      getIssueSecurityLevelMembers: (
+        parameters: GetIssueSecurityLevelMembers,
+      ): Promise<Page<IssueSecurityLevelMember>> => issueSecurityLevel.getIssueSecurityLevelMembers(client, parameters),
       getIssueSecurityLevel: (parameters: GetIssueSecurityLevel): Promise<SecurityLevel> =>
         issueSecurityLevel.getIssueSecurityLevel(client, parameters),
     },
@@ -1207,15 +1202,15 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         issueTypeProperties.deleteIssueTypeProperty(client, parameters),
     },
     issueTypeSchemes: {
-      getAllIssueTypeSchemes: (parameters?: GetAllIssueTypeSchemes): Promise<PageIssueTypeScheme> =>
+      getAllIssueTypeSchemes: (parameters?: GetAllIssueTypeSchemes): Promise<Page<IssueTypeScheme>> =>
         issueTypeSchemes.getAllIssueTypeSchemes(client, parameters),
       createIssueTypeScheme: (parameters: CreateIssueTypeScheme): Promise<IssueTypeSchemeID> =>
         issueTypeSchemes.createIssueTypeScheme(client, parameters),
-      getIssueTypeSchemesMapping: (parameters?: GetIssueTypeSchemesMapping): Promise<PageIssueTypeSchemeMapping> =>
+      getIssueTypeSchemesMapping: (parameters?: GetIssueTypeSchemesMapping): Promise<Page<IssueTypeSchemeMapping>> =>
         issueTypeSchemes.getIssueTypeSchemesMapping(client, parameters),
       getIssueTypeSchemeForProjects: (
         parameters: GetIssueTypeSchemeForProjects,
-      ): Promise<PageIssueTypeSchemeProjects> => issueTypeSchemes.getIssueTypeSchemeForProjects(client, parameters),
+      ): Promise<Page<IssueTypeSchemeProjects>> => issueTypeSchemes.getIssueTypeSchemeForProjects(client, parameters),
       assignIssueTypeSchemeToProject: (parameters: AssignIssueTypeSchemeToProject): Promise<void> =>
         issueTypeSchemes.assignIssueTypeSchemeToProject(client, parameters),
       updateIssueTypeScheme: (parameters: UpdateIssueTypeScheme): Promise<void> =>
@@ -1230,17 +1225,17 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         issueTypeSchemes.removeIssueTypeFromIssueTypeScheme(client, parameters),
     },
     issueTypeScreenSchemes: {
-      getIssueTypeScreenSchemes: (parameters?: GetIssueTypeScreenSchemes): Promise<PageIssueTypeScreenScheme> =>
+      getIssueTypeScreenSchemes: (parameters?: GetIssueTypeScreenSchemes): Promise<Page<IssueTypeScreenScheme>> =>
         issueTypeScreenSchemes.getIssueTypeScreenSchemes(client, parameters),
       createIssueTypeScreenScheme: (parameters: CreateIssueTypeScreenScheme): Promise<IssueTypeScreenSchemeId> =>
         issueTypeScreenSchemes.createIssueTypeScreenScheme(client, parameters),
       getIssueTypeScreenSchemeMappings: (
         parameters?: GetIssueTypeScreenSchemeMappings,
-      ): Promise<PageIssueTypeScreenSchemeItem> =>
+      ): Promise<Page<IssueTypeScreenSchemeItem>> =>
         issueTypeScreenSchemes.getIssueTypeScreenSchemeMappings(client, parameters),
       getIssueTypeScreenSchemeProjectAssociations: (
         parameters: GetIssueTypeScreenSchemeProjectAssociations,
-      ): Promise<PageIssueTypeScreenSchemesProjects> =>
+      ): Promise<Page<IssueTypeScreenSchemesProjects>> =>
         issueTypeScreenSchemes.getIssueTypeScreenSchemeProjectAssociations(client, parameters),
       assignIssueTypeScreenSchemeToProject: (parameters: AssignIssueTypeScreenSchemeToProject): Promise<void> =>
         issueTypeScreenSchemes.assignIssueTypeScreenSchemeToProject(client, parameters),
@@ -1256,7 +1251,8 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         issueTypeScreenSchemes.removeMappingsFromIssueTypeScreenScheme(client, parameters),
       getProjectsForIssueTypeScreenScheme: (
         parameters: GetProjectsForIssueTypeScreenScheme,
-      ): Promise<PageProjectDetails> => issueTypeScreenSchemes.getProjectsForIssueTypeScreenScheme(client, parameters),
+      ): Promise<Page<ProjectDetails>> =>
+        issueTypeScreenSchemes.getProjectsForIssueTypeScreenScheme(client, parameters),
     },
     jql: {
       getAutoComplete: (): Promise<JQLReferenceData> => jql.getAutoComplete(client),
@@ -1271,7 +1267,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         jql.migrateQueries(client, parameters),
     },
     jqlFunctionsApps: {
-      getPrecomputations: (parameters?: GetPrecomputations): Promise<PageJqlFunctionPrecomputation> =>
+      getPrecomputations: (parameters?: GetPrecomputations): Promise<Page<JqlFunctionPrecomputation>> =>
         jqlFunctionsApps.getPrecomputations(client, parameters),
       updatePrecomputations: (parameters: UpdatePrecomputations): Promise<void> =>
         jqlFunctionsApps.updatePrecomputations(client, parameters),
@@ -1299,11 +1295,11 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         myself.getCurrentUser(client, parameters),
     },
     issueNotificationSchemes: {
-      getNotificationSchemes: (parameters?: GetNotificationSchemes): Promise<PageNotificationScheme> =>
+      getNotificationSchemes: (parameters?: GetNotificationSchemes): Promise<Page<NotificationScheme>> =>
         issueNotificationSchemes.getNotificationSchemes(client, parameters),
       getNotificationSchemeToProjectMappings: (
         parameters?: GetNotificationSchemeToProjectMappings,
-      ): Promise<NotificationSchemeAndProjectMappingPage> =>
+      ): Promise<Page<NotificationSchemeAndProjectMappingJson>> =>
         issueNotificationSchemes.getNotificationSchemeToProjectMappings(client, parameters),
       getNotificationScheme: (parameters: GetNotificationScheme): Promise<NotificationScheme> =>
         issueNotificationSchemes.getNotificationScheme(client, parameters),
@@ -1338,7 +1334,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
       setDefaultPriority: (parameters: SetDefaultPriority): Promise<void> =>
         issuePriorities.setDefaultPriority(client, parameters),
       movePriorities: (parameters: MovePriorities): Promise<void> => issuePriorities.movePriorities(client, parameters),
-      searchPriorities: (parameters?: SearchPriorities): Promise<PagePriority> =>
+      searchPriorities: (parameters?: SearchPriorities): Promise<Page<Priority>> =>
         issuePriorities.searchPriorities(client, parameters),
       getPriority: (parameters: GetPriority): Promise<Priority> => issuePriorities.getPriority(client, parameters),
       updatePriority: (parameters: UpdatePriority): Promise<void> => issuePriorities.updatePriority(client, parameters),
@@ -1348,7 +1344,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
     projects: {
       createProject: (parameters: CreateProject): Promise<ProjectIdentifiers> =>
         projects.createProject(client, parameters),
-      searchProjects: (parameters?: SearchProjects): Promise<PageProject> =>
+      searchProjects: (parameters?: SearchProjects): Promise<Page<Project>> =>
         projects.searchProjects(client, parameters),
       getProject: (parameters: GetProject): Promise<Project> => projects.getProject(client, parameters),
       updateProject: (parameters: UpdateProject): Promise<Project> => projects.updateProject(client, parameters),
@@ -1431,7 +1427,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         projectRoleActors.deleteProjectRoleActorsFromRole(client, parameters),
     },
     projectVersions: {
-      getProjectVersionsPaginated: (parameters: GetProjectVersionsPaginated): Promise<PageVersion> =>
+      getProjectVersionsPaginated: (parameters: GetProjectVersionsPaginated): Promise<Page<Version>> =>
         projectVersions.getProjectVersionsPaginated(client, parameters),
       getProjectVersions: (parameters: GetProjectVersions): Promise<Version[]> =>
         projectVersions.getProjectVersions(client, parameters),
@@ -1519,7 +1515,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         screenTabFields.moveScreenTabField(client, parameters),
     },
     screenSchemes: {
-      getScreenSchemes: (parameters?: GetScreenSchemes): Promise<PageScreenScheme> =>
+      getScreenSchemes: (parameters?: GetScreenSchemes): Promise<Page<ScreenScheme>> =>
         screenSchemes.getScreenSchemes(client, parameters),
       createScreenScheme: (parameters: CreateScreenScheme): Promise<ScreenSchemeId> =>
         screenSchemes.createScreenScheme(client, parameters),
@@ -1568,7 +1564,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
       getTask: (parameters: GetTask): Promise<TaskProgressObject> => tasks.getTask(client, parameters),
     },
     uiModificationsApps: {
-      getUiModifications: (parameters?: GetUiModifications): Promise<PageUiModificationDetails> =>
+      getUiModifications: (parameters?: GetUiModifications): Promise<Page<UiModificationDetails>> =>
         uiModificationsApps.getUiModifications(client, parameters),
       createUiModification: (parameters: CreateUiModification): Promise<UiModificationIdentifiers> =>
         uiModificationsApps.createUiModification(client, parameters),
@@ -1604,9 +1600,9 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
       findUsersForPicker: (parameters: FindUsersForPicker): Promise<FoundUsers> =>
         userSearch.findUsersForPicker(client, parameters),
       findUsers: (parameters?: FindUsers): Promise<DashboardUser[]> => userSearch.findUsers(client, parameters),
-      findUsersByQuery: (parameters: FindUsersByQuery): Promise<PageUser> =>
+      findUsersByQuery: (parameters: FindUsersByQuery): Promise<Page<DashboardUser>> =>
         userSearch.findUsersByQuery(client, parameters),
-      findUserKeysByQuery: (parameters: FindUserKeysByQuery): Promise<PageUserKey> =>
+      findUserKeysByQuery: (parameters: FindUserKeysByQuery): Promise<Page<UserKey>> =>
         userSearch.findUserKeysByQuery(client, parameters),
       findUsersWithBrowsePermission: (parameters?: FindUsersWithBrowsePermission): Promise<DashboardUser[]> =>
         userSearch.findUsersWithBrowsePermission(client, parameters),
@@ -1622,7 +1618,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         userProperties.deleteUserProperty(client, parameters),
     },
     webhooks: {
-      getDynamicWebhooksForApp: (parameters?: GetDynamicWebhooksForApp): Promise<PageWebhook> =>
+      getDynamicWebhooksForApp: (parameters?: GetDynamicWebhooksForApp): Promise<Page<Webhook>> =>
         webhooks.getDynamicWebhooksForApp(client, parameters),
       registerDynamicWebhooks: (parameters: RegisterDynamicWebhooks): Promise<ContainerForRegisteredWebhooks> =>
         webhooks.registerDynamicWebhooks(client, parameters),
@@ -1667,7 +1663,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
     workflowTransitionRules: {
       getWorkflowTransitionRuleConfigurations: (
         parameters: GetWorkflowTransitionRuleConfigurations,
-      ): Promise<PageWorkflowTransitionRules> =>
+      ): Promise<Page<WorkflowTransitionRules>> =>
         workflowTransitionRules.getWorkflowTransitionRuleConfigurations(client, parameters),
       updateWorkflowTransitionRuleConfigurations: (
         parameters: UpdateWorkflowTransitionRuleConfigurations,
@@ -1679,7 +1675,7 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
         workflowTransitionRules.deleteWorkflowTransitionRuleConfigurations(client, parameters),
     },
     workflowSchemes: {
-      getAllWorkflowSchemes: (parameters?: GetAllWorkflowSchemes): Promise<PageWorkflowScheme> =>
+      getAllWorkflowSchemes: (parameters?: GetAllWorkflowSchemes): Promise<Page<WorkflowScheme>> =>
         workflowSchemes.getAllWorkflowSchemes(client, parameters),
       createWorkflowScheme: (parameters: CreateWorkflowScheme): Promise<WorkflowScheme> =>
         workflowSchemes.createWorkflowScheme(client, parameters),

--- a/src/cloud/models/index.ts
+++ b/src/cloud/models/index.ts
@@ -1070,6 +1070,8 @@ export * from './orderOfCustomFieldOptions';
 
 export * from './orderOfIssueTypes';
 
+export * from './page';
+
 export * from './page2ComponentJson';
 
 export * from './page2FieldAssociationSchemeFieldSearchResult';

--- a/src/cloud/models/notificationSchemeAndProjectMappingPage.ts
+++ b/src/cloud/models/notificationSchemeAndProjectMappingPage.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { NotificationSchemeAndProjectMappingJsonSchema } from './notificationSchemeAndProjectMappingJson';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  NotificationSchemeAndProjectMappingJsonSchema,
+  type NotificationSchemeAndProjectMappingJson,
+} from './notificationSchemeAndProjectMappingJson';
 
-export const NotificationSchemeAndProjectMappingPageSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(NotificationSchemeAndProjectMappingJsonSchema).optional(),
-});
+export const NotificationSchemeAndProjectMappingPageSchema = pageSchema(NotificationSchemeAndProjectMappingJsonSchema);
 
-export type NotificationSchemeAndProjectMappingPage = z.infer<typeof NotificationSchemeAndProjectMappingPageSchema>;
+/**
+ * @deprecated Use `Page<NotificationSchemeAndProjectMappingJson>`, which describes the same shape. This alias is
+ *   removed in the next major version.
+ */
+export type NotificationSchemeAndProjectMappingPage = Page<NotificationSchemeAndProjectMappingJson>;

--- a/src/cloud/models/page.ts
+++ b/src/cloud/models/page.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { apiObject } from '#/core';
+
+/** A page of items. */
+export function pageSchema<T extends z.ZodType>(item: T) {
+  return apiObject({
+    /** Whether this is the last page. */
+    isLast: z.boolean().optional(),
+    /** The maximum number of items that could be returned. */
+    maxResults: z.number().optional(),
+    /** If there is another page of results, the URL of the next page. */
+    nextPage: z.url().optional(),
+    /** The URL of the page. */
+    self: z.url().optional(),
+    /** The index of the first item returned. */
+    startAt: z.number().optional(),
+    /** The number of items returned. */
+    total: z.number().optional(),
+    /** The list of items. */
+    values: z.array(item).optional(),
+  });
+}
+
+export type Page<T> = z.infer<ReturnType<typeof pageSchema<z.ZodType<T>>>>;

--- a/src/cloud/models/page2ComponentJson.ts
+++ b/src/cloud/models/page2ComponentJson.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ComponentJsonSchema } from './componentJson';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ComponentJsonSchema, type ComponentJson } from './componentJson';
 
-export const Page2ComponentJsonSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ComponentJsonSchema).optional(),
-});
+export const Page2ComponentJsonSchema = pageSchema(ComponentJsonSchema);
 
-export type Page2ComponentJson = z.infer<typeof Page2ComponentJsonSchema>;
+/**
+ * @deprecated Use `Page<ComponentJson>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type Page2ComponentJson = Page<ComponentJson>;

--- a/src/cloud/models/page2FieldAssociationSchemeFieldSearchResult.ts
+++ b/src/cloud/models/page2FieldAssociationSchemeFieldSearchResult.ts
@@ -1,25 +1,15 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldAssociationSchemeFieldSearchResultSchema } from './fieldAssociationSchemeFieldSearchResult';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  FieldAssociationSchemeFieldSearchResultSchema,
+  type FieldAssociationSchemeFieldSearchResult,
+} from './fieldAssociationSchemeFieldSearchResult';
 
-export const Page2FieldAssociationSchemeFieldSearchResultSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldAssociationSchemeFieldSearchResultSchema).optional(),
-});
+export const Page2FieldAssociationSchemeFieldSearchResultSchema = pageSchema(
+  FieldAssociationSchemeFieldSearchResultSchema,
+);
 
-export type Page2FieldAssociationSchemeFieldSearchResult = z.infer<
-  typeof Page2FieldAssociationSchemeFieldSearchResultSchema
->;
+/**
+ * @deprecated Use `Page<FieldAssociationSchemeFieldSearchResult>`, which describes the same shape. This alias is
+ *   removed in the next major version.
+ */
+export type Page2FieldAssociationSchemeFieldSearchResult = Page<FieldAssociationSchemeFieldSearchResult>;

--- a/src/cloud/models/page2FieldAssociationSchemeProjectSearchResult.ts
+++ b/src/cloud/models/page2FieldAssociationSchemeProjectSearchResult.ts
@@ -1,25 +1,15 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldAssociationSchemeProjectSearchResultSchema } from './fieldAssociationSchemeProjectSearchResult';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  FieldAssociationSchemeProjectSearchResultSchema,
+  type FieldAssociationSchemeProjectSearchResult,
+} from './fieldAssociationSchemeProjectSearchResult';
 
-export const Page2FieldAssociationSchemeProjectSearchResultSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldAssociationSchemeProjectSearchResultSchema).optional(),
-});
+export const Page2FieldAssociationSchemeProjectSearchResultSchema = pageSchema(
+  FieldAssociationSchemeProjectSearchResultSchema,
+);
 
-export type Page2FieldAssociationSchemeProjectSearchResult = z.infer<
-  typeof Page2FieldAssociationSchemeProjectSearchResultSchema
->;
+/**
+ * @deprecated Use `Page<FieldAssociationSchemeProjectSearchResult>`, which describes the same shape. This alias is
+ *   removed in the next major version.
+ */
+export type Page2FieldAssociationSchemeProjectSearchResult = Page<FieldAssociationSchemeProjectSearchResult>;

--- a/src/cloud/models/page2GetFieldAssociationSchemeResponse.ts
+++ b/src/cloud/models/page2GetFieldAssociationSchemeResponse.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { GetFieldAssociationSchemeResponseSchema } from './getFieldAssociationSchemeResponse';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  GetFieldAssociationSchemeResponseSchema,
+  type GetFieldAssociationSchemeResponse,
+} from './getFieldAssociationSchemeResponse';
 
-export const Page2GetFieldAssociationSchemeResponseSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(GetFieldAssociationSchemeResponseSchema).optional(),
-});
+export const Page2GetFieldAssociationSchemeResponseSchema = pageSchema(GetFieldAssociationSchemeResponseSchema);
 
-export type Page2GetFieldAssociationSchemeResponse = z.infer<typeof Page2GetFieldAssociationSchemeResponseSchema>;
+/**
+ * @deprecated Use `Page<GetFieldAssociationSchemeResponse>`, which describes the same shape. This alias is removed in
+ *   the next major version.
+ */
+export type Page2GetFieldAssociationSchemeResponse = Page<GetFieldAssociationSchemeResponse>;

--- a/src/cloud/models/page2GetProjectsWithFieldSchemesResponse.ts
+++ b/src/cloud/models/page2GetProjectsWithFieldSchemesResponse.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { GetProjectsWithFieldSchemesResponseSchema } from './getProjectsWithFieldSchemesResponse';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  GetProjectsWithFieldSchemesResponseSchema,
+  type GetProjectsWithFieldSchemesResponse,
+} from './getProjectsWithFieldSchemesResponse';
 
-export const Page2GetProjectsWithFieldSchemesResponseSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(GetProjectsWithFieldSchemesResponseSchema).optional(),
-});
+export const Page2GetProjectsWithFieldSchemesResponseSchema = pageSchema(GetProjectsWithFieldSchemesResponseSchema);
 
-export type Page2GetProjectsWithFieldSchemesResponse = z.infer<typeof Page2GetProjectsWithFieldSchemesResponseSchema>;
+/**
+ * @deprecated Use `Page<GetProjectsWithFieldSchemesResponse>`, which describes the same shape. This alias is removed in
+ *   the next major version.
+ */
+export type Page2GetProjectsWithFieldSchemesResponse = Page<GetProjectsWithFieldSchemesResponse>;

--- a/src/cloud/models/page2ProjectField.ts
+++ b/src/cloud/models/page2ProjectField.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ProjectFieldSchema } from './projectField';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ProjectFieldSchema, type ProjectField } from './projectField';
 
-export const Page2ProjectFieldSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ProjectFieldSchema).optional(),
-});
+export const Page2ProjectFieldSchema = pageSchema(ProjectFieldSchema);
 
-export type Page2ProjectField = z.infer<typeof Page2ProjectFieldSchema>;
+/**
+ * @deprecated Use `Page<ProjectField>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type Page2ProjectField = Page<ProjectField>;

--- a/src/cloud/models/pageBulkContextualConfiguration.ts
+++ b/src/cloud/models/pageBulkContextualConfiguration.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { BulkContextualConfigurationSchema } from './bulkContextualConfiguration';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { BulkContextualConfigurationSchema, type BulkContextualConfiguration } from './bulkContextualConfiguration';
 
-export const PageBulkContextualConfigurationSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(BulkContextualConfigurationSchema).optional(),
-});
+export const PageBulkContextualConfigurationSchema = pageSchema(BulkContextualConfigurationSchema);
 
-export type PageBulkContextualConfiguration = z.infer<typeof PageBulkContextualConfigurationSchema>;
+/**
+ * @deprecated Use `Page<BulkContextualConfiguration>`, which describes the same shape. This alias is removed in the
+ *   next major version.
+ */
+export type PageBulkContextualConfiguration = Page<BulkContextualConfiguration>;

--- a/src/cloud/models/pageChangelog.ts
+++ b/src/cloud/models/pageChangelog.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ChangelogSchema } from './changelog';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ChangelogSchema, type Changelog } from './changelog';
 
-export const PageChangelogSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ChangelogSchema).optional(),
-});
+export const PageChangelogSchema = pageSchema(ChangelogSchema);
 
-export type PageChangelog = z.infer<typeof PageChangelogSchema>;
+/** @deprecated Use `Page<Changelog>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageChangelog = Page<Changelog>;

--- a/src/cloud/models/pageComment.ts
+++ b/src/cloud/models/pageComment.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { CommentSchema } from './comment';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { CommentSchema, type Comment } from './comment';
 
-export const PageCommentSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(CommentSchema).optional(),
-});
+export const PageCommentSchema = pageSchema(CommentSchema);
 
-export type PageComment = z.infer<typeof PageCommentSchema>;
+/** @deprecated Use `Page<Comment>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageComment = Page<Comment>;

--- a/src/cloud/models/pageComponentWithIssueCount.ts
+++ b/src/cloud/models/pageComponentWithIssueCount.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ComponentWithIssueCountSchema } from './componentWithIssueCount';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ComponentWithIssueCountSchema, type ComponentWithIssueCount } from './componentWithIssueCount';
 
-export const PageComponentWithIssueCountSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ComponentWithIssueCountSchema).optional(),
-});
+export const PageComponentWithIssueCountSchema = pageSchema(ComponentWithIssueCountSchema);
 
-export type PageComponentWithIssueCount = z.infer<typeof PageComponentWithIssueCountSchema>;
+/**
+ * @deprecated Use `Page<ComponentWithIssueCount>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageComponentWithIssueCount = Page<ComponentWithIssueCount>;

--- a/src/cloud/models/pageContext.ts
+++ b/src/cloud/models/pageContext.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ContextSchema } from './context';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ContextSchema, type Context } from './context';
 
-export const PageContextSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ContextSchema).optional(),
-});
+export const PageContextSchema = pageSchema(ContextSchema);
 
-export type PageContext = z.infer<typeof PageContextSchema>;
+/** @deprecated Use `Page<Context>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageContext = Page<Context>;

--- a/src/cloud/models/pageContextDefaultValues.ts
+++ b/src/cloud/models/pageContextDefaultValues.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ContextDefaultValuesSchema } from './contextDefaultValues';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ContextDefaultValuesSchema, type ContextDefaultValues } from './contextDefaultValues';
 
-export const PageContextDefaultValuesSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ContextDefaultValuesSchema).optional(),
-});
+export const PageContextDefaultValuesSchema = pageSchema(ContextDefaultValuesSchema);
 
-export type PageContextDefaultValues = z.infer<typeof PageContextDefaultValuesSchema>;
+/**
+ * @deprecated Use `Page<ContextDefaultValues>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageContextDefaultValues = Page<ContextDefaultValues>;

--- a/src/cloud/models/pageContextForProjectAndIssueType.ts
+++ b/src/cloud/models/pageContextForProjectAndIssueType.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ContextForProjectAndIssueTypeSchema } from './contextForProjectAndIssueType';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  ContextForProjectAndIssueTypeSchema,
+  type ContextForProjectAndIssueType,
+} from './contextForProjectAndIssueType';
 
-export const PageContextForProjectAndIssueTypeSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ContextForProjectAndIssueTypeSchema).optional(),
-});
+export const PageContextForProjectAndIssueTypeSchema = pageSchema(ContextForProjectAndIssueTypeSchema);
 
-export type PageContextForProjectAndIssueType = z.infer<typeof PageContextForProjectAndIssueTypeSchema>;
+/**
+ * @deprecated Use `Page<ContextForProjectAndIssueType>`, which describes the same shape. This alias is removed in the
+ *   next major version.
+ */
+export type PageContextForProjectAndIssueType = Page<ContextForProjectAndIssueType>;

--- a/src/cloud/models/pageContextualConfiguration.ts
+++ b/src/cloud/models/pageContextualConfiguration.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ContextualConfigurationSchema } from './contextualConfiguration';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ContextualConfigurationSchema, type ContextualConfiguration } from './contextualConfiguration';
 
-export const PageContextualConfigurationSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ContextualConfigurationSchema).optional(),
-});
+export const PageContextualConfigurationSchema = pageSchema(ContextualConfigurationSchema);
 
-export type PageContextualConfiguration = z.infer<typeof PageContextualConfigurationSchema>;
+/**
+ * @deprecated Use `Page<ContextualConfiguration>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageContextualConfiguration = Page<ContextualConfiguration>;

--- a/src/cloud/models/pageCustomFieldContext.ts
+++ b/src/cloud/models/pageCustomFieldContext.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { CustomFieldContextSchema } from './customFieldContext';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { CustomFieldContextSchema, type CustomFieldContext } from './customFieldContext';
 
-export const PageCustomFieldContextSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(CustomFieldContextSchema).optional(),
-});
+export const PageCustomFieldContextSchema = pageSchema(CustomFieldContextSchema);
 
-export type PageCustomFieldContext = z.infer<typeof PageCustomFieldContextSchema>;
+/**
+ * @deprecated Use `Page<CustomFieldContext>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageCustomFieldContext = Page<CustomFieldContext>;

--- a/src/cloud/models/pageCustomFieldContextDefaultValue.ts
+++ b/src/cloud/models/pageCustomFieldContextDefaultValue.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { CustomFieldContextDefaultValueSchema } from './customFieldContextDefaultValue';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  CustomFieldContextDefaultValueSchema,
+  type CustomFieldContextDefaultValue,
+} from './customFieldContextDefaultValue';
 
-export const PageCustomFieldContextDefaultValueSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(CustomFieldContextDefaultValueSchema).optional(),
-});
+export const PageCustomFieldContextDefaultValueSchema = pageSchema(CustomFieldContextDefaultValueSchema);
 
-export type PageCustomFieldContextDefaultValue = z.infer<typeof PageCustomFieldContextDefaultValueSchema>;
+/**
+ * @deprecated Use `Page<CustomFieldContextDefaultValue>`, which describes the same shape. This alias is removed in the
+ *   next major version.
+ */
+export type PageCustomFieldContextDefaultValue = Page<CustomFieldContextDefaultValue>;

--- a/src/cloud/models/pageCustomFieldContextOption.ts
+++ b/src/cloud/models/pageCustomFieldContextOption.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { CustomFieldContextOptionSchema } from './customFieldContextOption';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { CustomFieldContextOptionSchema, type CustomFieldContextOption } from './customFieldContextOption';
 
-export const PageCustomFieldContextOptionSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(CustomFieldContextOptionSchema).optional(),
-});
+export const PageCustomFieldContextOptionSchema = pageSchema(CustomFieldContextOptionSchema);
 
-export type PageCustomFieldContextOption = z.infer<typeof PageCustomFieldContextOptionSchema>;
+/**
+ * @deprecated Use `Page<CustomFieldContextOption>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageCustomFieldContextOption = Page<CustomFieldContextOption>;

--- a/src/cloud/models/pageCustomFieldContextProjectMapping.ts
+++ b/src/cloud/models/pageCustomFieldContextProjectMapping.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { CustomFieldContextProjectMappingSchema } from './customFieldContextProjectMapping';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  CustomFieldContextProjectMappingSchema,
+  type CustomFieldContextProjectMapping,
+} from './customFieldContextProjectMapping';
 
-export const PageCustomFieldContextProjectMappingSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(CustomFieldContextProjectMappingSchema).optional(),
-});
+export const PageCustomFieldContextProjectMappingSchema = pageSchema(CustomFieldContextProjectMappingSchema);
 
-export type PageCustomFieldContextProjectMapping = z.infer<typeof PageCustomFieldContextProjectMappingSchema>;
+/**
+ * @deprecated Use `Page<CustomFieldContextProjectMapping>`, which describes the same shape. This alias is removed in
+ *   the next major version.
+ */
+export type PageCustomFieldContextProjectMapping = Page<CustomFieldContextProjectMapping>;

--- a/src/cloud/models/pageDashboard.ts
+++ b/src/cloud/models/pageDashboard.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { DashboardSchema } from './dashboard';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { DashboardSchema, type Dashboard } from './dashboard';
 
-export const PageDashboardSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(DashboardSchema).optional(),
-});
+export const PageDashboardSchema = pageSchema(DashboardSchema);
 
-export type PageDashboard = z.infer<typeof PageDashboardSchema>;
+/** @deprecated Use `Page<Dashboard>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageDashboard = Page<Dashboard>;

--- a/src/cloud/models/pageField.ts
+++ b/src/cloud/models/pageField.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldSchema } from './field';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { FieldSchema, type Field } from './field';
 
-export const PageFieldSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldSchema).optional(),
-});
+export const PageFieldSchema = pageSchema(FieldSchema);
 
-export type PageField = z.infer<typeof PageFieldSchema>;
+/** @deprecated Use `Page<Field>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageField = Page<Field>;

--- a/src/cloud/models/pageFieldConfigurationDetails.ts
+++ b/src/cloud/models/pageFieldConfigurationDetails.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldConfigurationDetailsSchema } from './fieldConfigurationDetails';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { FieldConfigurationDetailsSchema, type FieldConfigurationDetails } from './fieldConfigurationDetails';
 
-export const PageFieldConfigurationDetailsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldConfigurationDetailsSchema).optional(),
-});
+export const PageFieldConfigurationDetailsSchema = pageSchema(FieldConfigurationDetailsSchema);
 
-export type PageFieldConfigurationDetails = z.infer<typeof PageFieldConfigurationDetailsSchema>;
+/**
+ * @deprecated Use `Page<FieldConfigurationDetails>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageFieldConfigurationDetails = Page<FieldConfigurationDetails>;

--- a/src/cloud/models/pageFieldConfigurationIssueTypeItem.ts
+++ b/src/cloud/models/pageFieldConfigurationIssueTypeItem.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldConfigurationIssueTypeItemSchema } from './fieldConfigurationIssueTypeItem';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  FieldConfigurationIssueTypeItemSchema,
+  type FieldConfigurationIssueTypeItem,
+} from './fieldConfigurationIssueTypeItem';
 
-export const PageFieldConfigurationIssueTypeItemSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldConfigurationIssueTypeItemSchema).optional(),
-});
+export const PageFieldConfigurationIssueTypeItemSchema = pageSchema(FieldConfigurationIssueTypeItemSchema);
 
-export type PageFieldConfigurationIssueTypeItem = z.infer<typeof PageFieldConfigurationIssueTypeItemSchema>;
+/**
+ * @deprecated Use `Page<FieldConfigurationIssueTypeItem>`, which describes the same shape. This alias is removed in the
+ *   next major version.
+ */
+export type PageFieldConfigurationIssueTypeItem = Page<FieldConfigurationIssueTypeItem>;

--- a/src/cloud/models/pageFieldConfigurationItem.ts
+++ b/src/cloud/models/pageFieldConfigurationItem.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldConfigurationItemSchema } from './fieldConfigurationItem';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { FieldConfigurationItemSchema, type FieldConfigurationItem } from './fieldConfigurationItem';
 
-export const PageFieldConfigurationItemSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldConfigurationItemSchema).optional(),
-});
+export const PageFieldConfigurationItemSchema = pageSchema(FieldConfigurationItemSchema);
 
-export type PageFieldConfigurationItem = z.infer<typeof PageFieldConfigurationItemSchema>;
+/**
+ * @deprecated Use `Page<FieldConfigurationItem>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageFieldConfigurationItem = Page<FieldConfigurationItem>;

--- a/src/cloud/models/pageFieldConfigurationScheme.ts
+++ b/src/cloud/models/pageFieldConfigurationScheme.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldConfigurationSchemeSchema } from './fieldConfigurationScheme';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { FieldConfigurationSchemeSchema, type FieldConfigurationScheme } from './fieldConfigurationScheme';
 
-export const PageFieldConfigurationSchemeSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldConfigurationSchemeSchema).optional(),
-});
+export const PageFieldConfigurationSchemeSchema = pageSchema(FieldConfigurationSchemeSchema);
 
-export type PageFieldConfigurationScheme = z.infer<typeof PageFieldConfigurationSchemeSchema>;
+/**
+ * @deprecated Use `Page<FieldConfigurationScheme>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageFieldConfigurationScheme = Page<FieldConfigurationScheme>;

--- a/src/cloud/models/pageFieldConfigurationSchemeProjects.ts
+++ b/src/cloud/models/pageFieldConfigurationSchemeProjects.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldConfigurationSchemeProjectsSchema } from './fieldConfigurationSchemeProjects';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  FieldConfigurationSchemeProjectsSchema,
+  type FieldConfigurationSchemeProjects,
+} from './fieldConfigurationSchemeProjects';
 
-export const PageFieldConfigurationSchemeProjectsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldConfigurationSchemeProjectsSchema).optional(),
-});
+export const PageFieldConfigurationSchemeProjectsSchema = pageSchema(FieldConfigurationSchemeProjectsSchema);
 
-export type PageFieldConfigurationSchemeProjects = z.infer<typeof PageFieldConfigurationSchemeProjectsSchema>;
+/**
+ * @deprecated Use `Page<FieldConfigurationSchemeProjects>`, which describes the same shape. This alias is removed in
+ *   the next major version.
+ */
+export type PageFieldConfigurationSchemeProjects = Page<FieldConfigurationSchemeProjects>;

--- a/src/cloud/models/pageFieldProjectAssociation.ts
+++ b/src/cloud/models/pageFieldProjectAssociation.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FieldProjectAssociationSchema } from './fieldProjectAssociation';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { FieldProjectAssociationSchema, type FieldProjectAssociation } from './fieldProjectAssociation';
 
-export const PageFieldProjectAssociationSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FieldProjectAssociationSchema).optional(),
-});
+export const PageFieldProjectAssociationSchema = pageSchema(FieldProjectAssociationSchema);
 
-export type PageFieldProjectAssociation = z.infer<typeof PageFieldProjectAssociationSchema>;
+/**
+ * @deprecated Use `Page<FieldProjectAssociation>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageFieldProjectAssociation = Page<FieldProjectAssociation>;

--- a/src/cloud/models/pageFilterDetails.ts
+++ b/src/cloud/models/pageFilterDetails.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { FilterDetailsSchema } from './filterDetails';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { FilterDetailsSchema, type FilterDetails } from './filterDetails';
 
-export const PageFilterDetailsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(FilterDetailsSchema).optional(),
-});
+export const PageFilterDetailsSchema = pageSchema(FilterDetailsSchema);
 
-export type PageFilterDetails = z.infer<typeof PageFilterDetailsSchema>;
+/**
+ * @deprecated Use `Page<FilterDetails>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageFilterDetails = Page<FilterDetails>;

--- a/src/cloud/models/pageGroupDetails.ts
+++ b/src/cloud/models/pageGroupDetails.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { GroupDetailsSchema } from './groupDetails';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { GroupDetailsSchema, type GroupDetails } from './groupDetails';
 
-export const PageGroupDetailsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(GroupDetailsSchema).optional(),
-});
+export const PageGroupDetailsSchema = pageSchema(GroupDetailsSchema);
 
-export type PageGroupDetails = z.infer<typeof PageGroupDetailsSchema>;
+/**
+ * @deprecated Use `Page<GroupDetails>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageGroupDetails = Page<GroupDetails>;

--- a/src/cloud/models/pageIssueFieldOption.ts
+++ b/src/cloud/models/pageIssueFieldOption.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueFieldOptionSchema } from './issueFieldOption';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { IssueFieldOptionSchema, type IssueFieldOption } from './issueFieldOption';
 
-export const PageIssueFieldOptionSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueFieldOptionSchema).optional(),
-});
+export const PageIssueFieldOptionSchema = pageSchema(IssueFieldOptionSchema);
 
-export type PageIssueFieldOption = z.infer<typeof PageIssueFieldOptionSchema>;
+/**
+ * @deprecated Use `Page<IssueFieldOption>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageIssueFieldOption = Page<IssueFieldOption>;

--- a/src/cloud/models/pageIssueSecurityLevelMember.ts
+++ b/src/cloud/models/pageIssueSecurityLevelMember.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueSecurityLevelMemberSchema } from './issueSecurityLevelMember';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { IssueSecurityLevelMemberSchema, type IssueSecurityLevelMember } from './issueSecurityLevelMember';
 
-export const PageIssueSecurityLevelMemberSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueSecurityLevelMemberSchema).optional(),
-});
+export const PageIssueSecurityLevelMemberSchema = pageSchema(IssueSecurityLevelMemberSchema);
 
-export type PageIssueSecurityLevelMember = z.infer<typeof PageIssueSecurityLevelMemberSchema>;
+/**
+ * @deprecated Use `Page<IssueSecurityLevelMember>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageIssueSecurityLevelMember = Page<IssueSecurityLevelMember>;

--- a/src/cloud/models/pageIssueSecuritySchemeToProjectMapping.ts
+++ b/src/cloud/models/pageIssueSecuritySchemeToProjectMapping.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueSecuritySchemeToProjectMappingSchema } from './issueSecuritySchemeToProjectMapping';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  IssueSecuritySchemeToProjectMappingSchema,
+  type IssueSecuritySchemeToProjectMapping,
+} from './issueSecuritySchemeToProjectMapping';
 
-export const PageIssueSecuritySchemeToProjectMappingSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueSecuritySchemeToProjectMappingSchema).optional(),
-});
+export const PageIssueSecuritySchemeToProjectMappingSchema = pageSchema(IssueSecuritySchemeToProjectMappingSchema);
 
-export type PageIssueSecuritySchemeToProjectMapping = z.infer<typeof PageIssueSecuritySchemeToProjectMappingSchema>;
+/**
+ * @deprecated Use `Page<IssueSecuritySchemeToProjectMapping>`, which describes the same shape. This alias is removed in
+ *   the next major version.
+ */
+export type PageIssueSecuritySchemeToProjectMapping = Page<IssueSecuritySchemeToProjectMapping>;

--- a/src/cloud/models/pageIssueTypeScheme.ts
+++ b/src/cloud/models/pageIssueTypeScheme.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueTypeSchemeSchema } from './issueTypeScheme';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { IssueTypeSchemeSchema, type IssueTypeScheme } from './issueTypeScheme';
 
-export const PageIssueTypeSchemeSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueTypeSchemeSchema).optional(),
-});
+export const PageIssueTypeSchemeSchema = pageSchema(IssueTypeSchemeSchema);
 
-export type PageIssueTypeScheme = z.infer<typeof PageIssueTypeSchemeSchema>;
+/**
+ * @deprecated Use `Page<IssueTypeScheme>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageIssueTypeScheme = Page<IssueTypeScheme>;

--- a/src/cloud/models/pageIssueTypeSchemeMapping.ts
+++ b/src/cloud/models/pageIssueTypeSchemeMapping.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueTypeSchemeMappingSchema } from './issueTypeSchemeMapping';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { IssueTypeSchemeMappingSchema, type IssueTypeSchemeMapping } from './issueTypeSchemeMapping';
 
-export const PageIssueTypeSchemeMappingSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueTypeSchemeMappingSchema).optional(),
-});
+export const PageIssueTypeSchemeMappingSchema = pageSchema(IssueTypeSchemeMappingSchema);
 
-export type PageIssueTypeSchemeMapping = z.infer<typeof PageIssueTypeSchemeMappingSchema>;
+/**
+ * @deprecated Use `Page<IssueTypeSchemeMapping>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageIssueTypeSchemeMapping = Page<IssueTypeSchemeMapping>;

--- a/src/cloud/models/pageIssueTypeSchemeProjects.ts
+++ b/src/cloud/models/pageIssueTypeSchemeProjects.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueTypeSchemeProjectsSchema } from './issueTypeSchemeProjects';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { IssueTypeSchemeProjectsSchema, type IssueTypeSchemeProjects } from './issueTypeSchemeProjects';
 
-export const PageIssueTypeSchemeProjectsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueTypeSchemeProjectsSchema).optional(),
-});
+export const PageIssueTypeSchemeProjectsSchema = pageSchema(IssueTypeSchemeProjectsSchema);
 
-export type PageIssueTypeSchemeProjects = z.infer<typeof PageIssueTypeSchemeProjectsSchema>;
+/**
+ * @deprecated Use `Page<IssueTypeSchemeProjects>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageIssueTypeSchemeProjects = Page<IssueTypeSchemeProjects>;

--- a/src/cloud/models/pageIssueTypeScreenScheme.ts
+++ b/src/cloud/models/pageIssueTypeScreenScheme.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueTypeScreenSchemeSchema } from './issueTypeScreenScheme';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { IssueTypeScreenSchemeSchema, type IssueTypeScreenScheme } from './issueTypeScreenScheme';
 
-export const PageIssueTypeScreenSchemeSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueTypeScreenSchemeSchema).optional(),
-});
+export const PageIssueTypeScreenSchemeSchema = pageSchema(IssueTypeScreenSchemeSchema);
 
-export type PageIssueTypeScreenScheme = z.infer<typeof PageIssueTypeScreenSchemeSchema>;
+/**
+ * @deprecated Use `Page<IssueTypeScreenScheme>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageIssueTypeScreenScheme = Page<IssueTypeScreenScheme>;

--- a/src/cloud/models/pageIssueTypeScreenSchemeItem.ts
+++ b/src/cloud/models/pageIssueTypeScreenSchemeItem.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueTypeScreenSchemeItemSchema } from './issueTypeScreenSchemeItem';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { IssueTypeScreenSchemeItemSchema, type IssueTypeScreenSchemeItem } from './issueTypeScreenSchemeItem';
 
-export const PageIssueTypeScreenSchemeItemSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueTypeScreenSchemeItemSchema).optional(),
-});
+export const PageIssueTypeScreenSchemeItemSchema = pageSchema(IssueTypeScreenSchemeItemSchema);
 
-export type PageIssueTypeScreenSchemeItem = z.infer<typeof PageIssueTypeScreenSchemeItemSchema>;
+/**
+ * @deprecated Use `Page<IssueTypeScreenSchemeItem>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageIssueTypeScreenSchemeItem = Page<IssueTypeScreenSchemeItem>;

--- a/src/cloud/models/pageIssueTypeScreenSchemesProjects.ts
+++ b/src/cloud/models/pageIssueTypeScreenSchemesProjects.ts
@@ -1,23 +1,13 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueTypeScreenSchemesProjectsSchema } from './issueTypeScreenSchemesProjects';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  IssueTypeScreenSchemesProjectsSchema,
+  type IssueTypeScreenSchemesProjects,
+} from './issueTypeScreenSchemesProjects';
 
-export const PageIssueTypeScreenSchemesProjectsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueTypeScreenSchemesProjectsSchema).optional(),
-});
+export const PageIssueTypeScreenSchemesProjectsSchema = pageSchema(IssueTypeScreenSchemesProjectsSchema);
 
-export type PageIssueTypeScreenSchemesProjects = z.infer<typeof PageIssueTypeScreenSchemesProjectsSchema>;
+/**
+ * @deprecated Use `Page<IssueTypeScreenSchemesProjects>`, which describes the same shape. This alias is removed in the
+ *   next major version.
+ */
+export type PageIssueTypeScreenSchemesProjects = Page<IssueTypeScreenSchemesProjects>;

--- a/src/cloud/models/pageIssueTypeToContextMapping.ts
+++ b/src/cloud/models/pageIssueTypeToContextMapping.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { IssueTypeToContextMappingSchema } from './issueTypeToContextMapping';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { IssueTypeToContextMappingSchema, type IssueTypeToContextMapping } from './issueTypeToContextMapping';
 
-export const PageIssueTypeToContextMappingSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(IssueTypeToContextMappingSchema).optional(),
-});
+export const PageIssueTypeToContextMappingSchema = pageSchema(IssueTypeToContextMappingSchema);
 
-export type PageIssueTypeToContextMapping = z.infer<typeof PageIssueTypeToContextMappingSchema>;
+/**
+ * @deprecated Use `Page<IssueTypeToContextMapping>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageIssueTypeToContextMapping = Page<IssueTypeToContextMapping>;

--- a/src/cloud/models/pageJqlFunctionPrecomputation.ts
+++ b/src/cloud/models/pageJqlFunctionPrecomputation.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { JqlFunctionPrecomputationSchema } from './jqlFunctionPrecomputation';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { JqlFunctionPrecomputationSchema, type JqlFunctionPrecomputation } from './jqlFunctionPrecomputation';
 
-export const PageJqlFunctionPrecomputationSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(JqlFunctionPrecomputationSchema).optional(),
-});
+export const PageJqlFunctionPrecomputationSchema = pageSchema(JqlFunctionPrecomputationSchema);
 
-export type PageJqlFunctionPrecomputation = z.infer<typeof PageJqlFunctionPrecomputationSchema>;
+/**
+ * @deprecated Use `Page<JqlFunctionPrecomputation>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageJqlFunctionPrecomputation = Page<JqlFunctionPrecomputation>;

--- a/src/cloud/models/pageNotificationScheme.ts
+++ b/src/cloud/models/pageNotificationScheme.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { NotificationSchemeSchema } from './notificationScheme';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { NotificationSchemeSchema, type NotificationScheme } from './notificationScheme';
 
-export const PageNotificationSchemeSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(NotificationSchemeSchema).optional(),
-});
+export const PageNotificationSchemeSchema = pageSchema(NotificationSchemeSchema);
 
-export type PageNotificationScheme = z.infer<typeof PageNotificationSchemeSchema>;
+/**
+ * @deprecated Use `Page<NotificationScheme>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageNotificationScheme = Page<NotificationScheme>;

--- a/src/cloud/models/pagePriority.ts
+++ b/src/cloud/models/pagePriority.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PrioritySchema } from './priority';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { PrioritySchema, type Priority } from './priority';
 
-export const PagePrioritySchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(PrioritySchema).optional(),
-});
+export const PagePrioritySchema = pageSchema(PrioritySchema);
 
-export type PagePriority = z.infer<typeof PagePrioritySchema>;
+/** @deprecated Use `Page<Priority>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagePriority = Page<Priority>;

--- a/src/cloud/models/pagePrioritySchemeWithPaginatedPrioritiesAndProjects.ts
+++ b/src/cloud/models/pagePrioritySchemeWithPaginatedPrioritiesAndProjects.ts
@@ -1,25 +1,16 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PrioritySchemeWithPaginatedPrioritiesAndProjectsSchema } from './prioritySchemeWithPaginatedPrioritiesAndProjects';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import {
+  PrioritySchemeWithPaginatedPrioritiesAndProjectsSchema,
+  type PrioritySchemeWithPaginatedPrioritiesAndProjects,
+} from './prioritySchemeWithPaginatedPrioritiesAndProjects';
 
-export const PagePrioritySchemeWithPaginatedPrioritiesAndProjectsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(PrioritySchemeWithPaginatedPrioritiesAndProjectsSchema).optional(),
-});
+export const PagePrioritySchemeWithPaginatedPrioritiesAndProjectsSchema = pageSchema(
+  PrioritySchemeWithPaginatedPrioritiesAndProjectsSchema,
+);
 
-export type PagePrioritySchemeWithPaginatedPrioritiesAndProjects = z.infer<
-  typeof PagePrioritySchemeWithPaginatedPrioritiesAndProjectsSchema
->;
+/**
+ * @deprecated Use `Page<PrioritySchemeWithPaginatedPrioritiesAndProjects>`, which describes the same shape. This alias
+ *   is removed in the next major version.
+ */
+export type PagePrioritySchemeWithPaginatedPrioritiesAndProjects =
+  Page<PrioritySchemeWithPaginatedPrioritiesAndProjects>;

--- a/src/cloud/models/pagePriorityWithSequence.ts
+++ b/src/cloud/models/pagePriorityWithSequence.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PriorityWithSequenceSchema } from './priorityWithSequence';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { PriorityWithSequenceSchema, type PriorityWithSequence } from './priorityWithSequence';
 
-export const PagePriorityWithSequenceSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(PriorityWithSequenceSchema).optional(),
-});
+export const PagePriorityWithSequenceSchema = pageSchema(PriorityWithSequenceSchema);
 
-export type PagePriorityWithSequence = z.infer<typeof PagePriorityWithSequenceSchema>;
+/**
+ * @deprecated Use `Page<PriorityWithSequence>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PagePriorityWithSequence = Page<PriorityWithSequence>;

--- a/src/cloud/models/pageProject.ts
+++ b/src/cloud/models/pageProject.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ProjectSchema } from './project';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ProjectSchema, type Project } from './project';
 
-export const PageProjectSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ProjectSchema).optional(),
-});
+export const PageProjectSchema = pageSchema(ProjectSchema);
 
-export type PageProject = z.infer<typeof PageProjectSchema>;
+/** @deprecated Use `Page<Project>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageProject = Page<Project>;

--- a/src/cloud/models/pageProjectDetails.ts
+++ b/src/cloud/models/pageProjectDetails.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ProjectDetailsSchema } from './projectDetails';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ProjectDetailsSchema, type ProjectDetails } from './projectDetails';
 
-export const PageProjectDetailsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ProjectDetailsSchema).optional(),
-});
+export const PageProjectDetailsSchema = pageSchema(ProjectDetailsSchema);
 
-export type PageProjectDetails = z.infer<typeof PageProjectDetailsSchema>;
+/**
+ * @deprecated Use `Page<ProjectDetails>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageProjectDetails = Page<ProjectDetails>;

--- a/src/cloud/models/pageResolutionJson.ts
+++ b/src/cloud/models/pageResolutionJson.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ResolutionJsonSchema } from './resolutionJson';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ResolutionJsonSchema, type ResolutionJson } from './resolutionJson';
 
-export const PageResolutionJsonSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ResolutionJsonSchema).optional(),
-});
+export const PageResolutionJsonSchema = pageSchema(ResolutionJsonSchema);
 
-export type PageResolutionJson = z.infer<typeof PageResolutionJsonSchema>;
+/**
+ * @deprecated Use `Page<ResolutionJson>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageResolutionJson = Page<ResolutionJson>;

--- a/src/cloud/models/pageScreen.ts
+++ b/src/cloud/models/pageScreen.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ScreenSchema } from './screen';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ScreenSchema, type Screen } from './screen';
 
-export const PageScreenSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ScreenSchema).optional(),
-});
+export const PageScreenSchema = pageSchema(ScreenSchema);
 
-export type PageScreen = z.infer<typeof PageScreenSchema>;
+/** @deprecated Use `Page<Screen>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageScreen = Page<Screen>;

--- a/src/cloud/models/pageScreenScheme.ts
+++ b/src/cloud/models/pageScreenScheme.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ScreenSchemeSchema } from './screenScheme';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ScreenSchemeSchema, type ScreenScheme } from './screenScheme';
 
-export const PageScreenSchemeSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ScreenSchemeSchema).optional(),
-});
+export const PageScreenSchemeSchema = pageSchema(ScreenSchemeSchema);
 
-export type PageScreenScheme = z.infer<typeof PageScreenSchemeSchema>;
+/**
+ * @deprecated Use `Page<ScreenScheme>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageScreenScheme = Page<ScreenScheme>;

--- a/src/cloud/models/pageScreenWithTab.ts
+++ b/src/cloud/models/pageScreenWithTab.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { ScreenWithTabSchema } from './screenWithTab';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { ScreenWithTabSchema, type ScreenWithTab } from './screenWithTab';
 
-export const PageScreenWithTabSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(ScreenWithTabSchema).optional(),
-});
+export const PageScreenWithTabSchema = pageSchema(ScreenWithTabSchema);
 
-export type PageScreenWithTab = z.infer<typeof PageScreenWithTabSchema>;
+/**
+ * @deprecated Use `Page<ScreenWithTab>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageScreenWithTab = Page<ScreenWithTab>;

--- a/src/cloud/models/pageSecurityLevel.ts
+++ b/src/cloud/models/pageSecurityLevel.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { SecurityLevelSchema } from './securityLevel';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { SecurityLevelSchema, type SecurityLevel } from './securityLevel';
 
-export const PageSecurityLevelSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(SecurityLevelSchema).optional(),
-});
+export const PageSecurityLevelSchema = pageSchema(SecurityLevelSchema);
 
-export type PageSecurityLevel = z.infer<typeof PageSecurityLevelSchema>;
+/**
+ * @deprecated Use `Page<SecurityLevel>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageSecurityLevel = Page<SecurityLevel>;

--- a/src/cloud/models/pageSecurityLevelMember.ts
+++ b/src/cloud/models/pageSecurityLevelMember.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { SecurityLevelMemberSchema } from './securityLevelMember';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { SecurityLevelMemberSchema, type SecurityLevelMember } from './securityLevelMember';
 
-export const PageSecurityLevelMemberSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(SecurityLevelMemberSchema).optional(),
-});
+export const PageSecurityLevelMemberSchema = pageSchema(SecurityLevelMemberSchema);
 
-export type PageSecurityLevelMember = z.infer<typeof PageSecurityLevelMemberSchema>;
+/**
+ * @deprecated Use `Page<SecurityLevelMember>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageSecurityLevelMember = Page<SecurityLevelMember>;

--- a/src/cloud/models/pageSecuritySchemeWithProjects.ts
+++ b/src/cloud/models/pageSecuritySchemeWithProjects.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { SecuritySchemeWithProjectsSchema } from './securitySchemeWithProjects';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { SecuritySchemeWithProjectsSchema, type SecuritySchemeWithProjects } from './securitySchemeWithProjects';
 
-export const PageSecuritySchemeWithProjectsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(SecuritySchemeWithProjectsSchema).optional(),
-});
+export const PageSecuritySchemeWithProjectsSchema = pageSchema(SecuritySchemeWithProjectsSchema);
 
-export type PageSecuritySchemeWithProjects = z.infer<typeof PageSecuritySchemeWithProjectsSchema>;
+/**
+ * @deprecated Use `Page<SecuritySchemeWithProjects>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageSecuritySchemeWithProjects = Page<SecuritySchemeWithProjects>;

--- a/src/cloud/models/pageUiModificationDetails.ts
+++ b/src/cloud/models/pageUiModificationDetails.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { UiModificationDetailsSchema } from './uiModificationDetails';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { UiModificationDetailsSchema, type UiModificationDetails } from './uiModificationDetails';
 
-export const PageUiModificationDetailsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(UiModificationDetailsSchema).optional(),
-});
+export const PageUiModificationDetailsSchema = pageSchema(UiModificationDetailsSchema);
 
-export type PageUiModificationDetails = z.infer<typeof PageUiModificationDetailsSchema>;
+/**
+ * @deprecated Use `Page<UiModificationDetails>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageUiModificationDetails = Page<UiModificationDetails>;

--- a/src/cloud/models/pageUser.ts
+++ b/src/cloud/models/pageUser.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { DashboardUserSchema } from './dashboardUser';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { DashboardUserSchema, type DashboardUser } from './dashboardUser';
 
-export const PageUserSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(DashboardUserSchema).optional(),
-});
+export const PageUserSchema = pageSchema(DashboardUserSchema);
 
-export type PageUser = z.infer<typeof PageUserSchema>;
+/**
+ * @deprecated Use `Page<DashboardUser>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageUser = Page<DashboardUser>;

--- a/src/cloud/models/pageUserDetails.ts
+++ b/src/cloud/models/pageUserDetails.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { UserDetailsSchema } from './userDetails';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { UserDetailsSchema, type UserDetails } from './userDetails';
 
-export const PageUserDetailsSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(UserDetailsSchema).optional(),
-});
+export const PageUserDetailsSchema = pageSchema(UserDetailsSchema);
 
-export type PageUserDetails = z.infer<typeof PageUserDetailsSchema>;
+/** @deprecated Use `Page<UserDetails>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageUserDetails = Page<UserDetails>;

--- a/src/cloud/models/pageUserKey.ts
+++ b/src/cloud/models/pageUserKey.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { UserKeySchema } from './userKey';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { UserKeySchema, type UserKey } from './userKey';
 
-export const PageUserKeySchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(UserKeySchema).optional(),
-});
+export const PageUserKeySchema = pageSchema(UserKeySchema);
 
-export type PageUserKey = z.infer<typeof PageUserKeySchema>;
+/** @deprecated Use `Page<UserKey>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageUserKey = Page<UserKey>;

--- a/src/cloud/models/pageVersion.ts
+++ b/src/cloud/models/pageVersion.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { VersionSchema } from './version';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { VersionSchema, type Version } from './version';
 
-export const PageVersionSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(VersionSchema).optional(),
-});
+export const PageVersionSchema = pageSchema(VersionSchema);
 
-export type PageVersion = z.infer<typeof PageVersionSchema>;
+/** @deprecated Use `Page<Version>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageVersion = Page<Version>;

--- a/src/cloud/models/pageWebhook.ts
+++ b/src/cloud/models/pageWebhook.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { WebhookSchema } from './webhook';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { WebhookSchema, type Webhook } from './webhook';
 
-export const PageWebhookSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(WebhookSchema).optional(),
-});
+export const PageWebhookSchema = pageSchema(WebhookSchema);
 
-export type PageWebhook = z.infer<typeof PageWebhookSchema>;
+/** @deprecated Use `Page<Webhook>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageWebhook = Page<Webhook>;

--- a/src/cloud/models/pageWorkflow.ts
+++ b/src/cloud/models/pageWorkflow.ts
@@ -1,23 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { WorkflowSchema } from './workflow';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { WorkflowSchema, type Workflow } from './workflow';
 
-export const PageWorkflowSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(WorkflowSchema).optional(),
-});
+export const PageWorkflowSchema = pageSchema(WorkflowSchema);
 
-export type PageWorkflow = z.infer<typeof PageWorkflowSchema>;
+/** @deprecated Use `Page<Workflow>`, which describes the same shape. This alias is removed in the next major version. */
+export type PageWorkflow = Page<Workflow>;

--- a/src/cloud/models/pageWorkflowScheme.ts
+++ b/src/cloud/models/pageWorkflowScheme.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { WorkflowSchemeSchema } from './workflowScheme';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { WorkflowSchemeSchema, type WorkflowScheme } from './workflowScheme';
 
-export const PageWorkflowSchemeSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(WorkflowSchemeSchema).optional(),
-});
+export const PageWorkflowSchemeSchema = pageSchema(WorkflowSchemeSchema);
 
-export type PageWorkflowScheme = z.infer<typeof PageWorkflowSchemeSchema>;
+/**
+ * @deprecated Use `Page<WorkflowScheme>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PageWorkflowScheme = Page<WorkflowScheme>;

--- a/src/cloud/models/pageWorkflowTransitionRules.ts
+++ b/src/cloud/models/pageWorkflowTransitionRules.ts
@@ -1,23 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { WorkflowTransitionRulesSchema } from './workflowTransitionRules';
-/** A page of items. */
+import { pageSchema, type Page } from './page';
+import { WorkflowTransitionRulesSchema, type WorkflowTransitionRules } from './workflowTransitionRules';
 
-export const PageWorkflowTransitionRulesSchema = apiObject({
-  /** Whether this is the last page. */
-  isLast: z.boolean().optional(),
-  /** The maximum number of items that could be returned. */
-  maxResults: z.number().optional(),
-  /** If there is another page of results, the URL of the next page. */
-  nextPage: z.url().optional(),
-  /** The URL of the page. */
-  self: z.url().optional(),
-  /** The index of the first item returned. */
-  startAt: z.number().optional(),
-  /** The number of items returned. */
-  total: z.number().optional(),
-  /** The list of items. */
-  values: z.array(WorkflowTransitionRulesSchema).optional(),
-});
+export const PageWorkflowTransitionRulesSchema = pageSchema(WorkflowTransitionRulesSchema);
 
-export type PageWorkflowTransitionRules = z.infer<typeof PageWorkflowTransitionRulesSchema>;
+/**
+ * @deprecated Use `Page<WorkflowTransitionRules>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PageWorkflowTransitionRules = Page<WorkflowTransitionRules>;

--- a/src/serviceDesk/api/assets.ts
+++ b/src/serviceDesk/api/assets.ts
@@ -1,5 +1,8 @@
-import { PagedAssetsWorkspaceSchema, type PagedAssetsWorkspace } from '../models/pagedAssetsWorkspace';
-import { PagedInsightWorkspaceSchema, type PagedInsightWorkspace } from '../models/pagedInsightWorkspace';
+import { PagedAssetsWorkspaceSchema } from '../models/pagedAssetsWorkspace';
+import type { Page } from '../models/page';
+import type { AssetsWorkspace } from '../models/assetsWorkspace';
+import { PagedInsightWorkspaceSchema } from '../models/pagedInsightWorkspace';
+import type { InsightWorkspace } from '../models/insightWorkspace';
 import type { GetAssetsWorkspaces } from '../parameters/getAssetsWorkspaces';
 import type { GetInsightWorkspaces } from '../parameters/getInsightWorkspaces';
 import type { Client, SendRequestOptions } from '#/core';
@@ -13,8 +16,8 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getAssetsWorkspaces(
   client: Client,
   parameters?: GetAssetsWorkspaces,
-): Promise<PagedAssetsWorkspace> {
-  const config: SendRequestOptions<PagedAssetsWorkspace> = {
+): Promise<Page<AssetsWorkspace>> {
+  const config: SendRequestOptions<Page<AssetsWorkspace>> = {
     url: '/rest/servicedeskapi/assets/workspace',
     method: 'GET',
     searchParams: {
@@ -31,8 +34,8 @@ export async function getAssetsWorkspaces(
 export async function getInsightWorkspaces(
   client: Client,
   parameters?: GetInsightWorkspaces,
-): Promise<PagedInsightWorkspace> {
-  const config: SendRequestOptions<PagedInsightWorkspace> = {
+): Promise<Page<InsightWorkspace>> {
+  const config: SendRequestOptions<Page<InsightWorkspace>> = {
     url: '/rest/servicedeskapi/insight/workspace',
     method: 'GET',
     searchParams: {

--- a/src/serviceDesk/api/knowledgebase.ts
+++ b/src/serviceDesk/api/knowledgebase.ts
@@ -1,4 +1,6 @@
-import { PagedArticleSchema, type PagedArticle } from '../models/pagedArticle';
+import { PagedArticleSchema } from '../models/pagedArticle';
+import type { Page } from '../models/page';
+import type { Article } from '../models/article';
 import type { GetArticles } from '../parameters/getArticles';
 import type { ViewArticle } from '../parameters/viewArticle';
 import type { Client, SendRequestOptions } from '#/core';
@@ -11,8 +13,8 @@ import { z } from 'zod';
  * Permission to access the [customer
  * portal](https://confluence.atlassian.com/servicedeskcloud/configuring-the-customer-portal-732528918.html).
  */
-export async function getArticles(client: Client, parameters: GetArticles): Promise<PagedArticle> {
-  const config: SendRequestOptions<PagedArticle> = {
+export async function getArticles(client: Client, parameters: GetArticles): Promise<Page<Article>> {
+  const config: SendRequestOptions<Page<Article>> = {
     url: '/rest/servicedeskapi/knowledgebase/article',
     method: 'GET',
     searchParams: {

--- a/src/serviceDesk/api/organization.ts
+++ b/src/serviceDesk/api/organization.ts
@@ -1,8 +1,10 @@
-import { PagedOrganizationSchema, type PagedOrganization } from '../models/pagedOrganization';
+import { PagedOrganizationSchema } from '../models/pagedOrganization';
+import type { Page } from '../models/page';
 import { OrganizationSchema, type Organization } from '../models/organization';
 import { PropertyKeysSchema, type PropertyKeys } from '../models/propertyKeys';
 import { EntityPropertySchema, type EntityProperty } from '../models/entityProperty';
-import { PagedUserSchema, type PagedUser } from '../models/pagedUser';
+import { PagedUserSchema } from '../models/pagedUser';
+import type { User } from '../models/user';
 import type { GetOrganizations } from '../parameters/getOrganizations';
 import type { CreateOrganization } from '../parameters/createOrganization';
 import type { GetOrganization } from '../parameters/getOrganization';
@@ -29,8 +31,8 @@ import type { Client, SendRequestOptions } from '#/core';
  * **Response limitations**: If the user is a customer, only those organizations of which the customer is a member are
  * listed.
  */
-export async function getOrganizations(client: Client, parameters?: GetOrganizations): Promise<PagedOrganization> {
-  const config: SendRequestOptions<PagedOrganization> = {
+export async function getOrganizations(client: Client, parameters?: GetOrganizations): Promise<Page<Organization>> {
+  const config: SendRequestOptions<Page<Organization>> = {
     url: '/rest/servicedeskapi/organization',
     method: 'GET',
     searchParams: {
@@ -210,8 +212,8 @@ export async function deleteProperty(client: Client, parameters: DeleteProperty)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk administrator or agent.
  */
-export async function getUsersInOrganization(client: Client, parameters: GetUsersInOrganization): Promise<PagedUser> {
-  const config: SendRequestOptions<PagedUser> = {
+export async function getUsersInOrganization(client: Client, parameters: GetUsersInOrganization): Promise<Page<User>> {
+  const config: SendRequestOptions<Page<User>> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}/user`,
     method: 'GET',
     searchParams: {
@@ -274,8 +276,8 @@ export async function removeUsersFromOrganization(
 export async function getServiceDeskOrganizations(
   client: Client,
   parameters: GetServiceDeskOrganizations,
-): Promise<PagedOrganization> {
-  const config: SendRequestOptions<PagedOrganization> = {
+): Promise<Page<Organization>> {
+  const config: SendRequestOptions<Page<Organization>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/organization`,
     method: 'GET',
     searchParams: {

--- a/src/serviceDesk/api/request.ts
+++ b/src/serviceDesk/api/request.ts
@@ -1,23 +1,25 @@
-import { PagedCustomerRequestSchema, type PagedCustomerRequest } from '../models/pagedCustomerRequest';
+import { PagedCustomerRequestSchema } from '../models/pagedCustomerRequest';
+import type { Page } from '../models/page';
 import { CustomerRequestSchema, type CustomerRequest } from '../models/customerRequest';
-import { PagedApprovalSchema, type PagedApproval } from '../models/pagedApproval';
+import { PagedApprovalSchema } from '../models/pagedApproval';
 import { ApprovalSchema, type Approval } from '../models/approval';
-import { PagedAttachmentSchema, type PagedAttachment } from '../models/pagedAttachment';
+import { PagedAttachmentSchema } from '../models/pagedAttachment';
+import type { Attachment } from '../models/attachment';
 import { AttachmentCreateResultSchema, type AttachmentCreateResult } from '../models/attachmentCreateResult';
-import { PagedCommentSchema, type PagedComment } from '../models/pagedComment';
+import { PagedCommentSchema } from '../models/pagedComment';
 import { CommentSchema, type Comment } from '../models/comment';
 import {
   RequestNotificationSubscriptionSchema,
   type RequestNotificationSubscription,
 } from '../models/requestNotificationSubscription';
-import { PagedUserSchema, type PagedUser } from '../models/pagedUser';
-import { PagedSlaInformationSchema, type PagedSlaInformation } from '../models/pagedSlaInformation';
+import { PagedUserSchema } from '../models/pagedUser';
+import type { User } from '../models/user';
+import { PagedSlaInformationSchema } from '../models/pagedSlaInformation';
 import { SlaInformationSchema, type SlaInformation } from '../models/slaInformation';
-import {
-  PagedCustomerRequestStatusSchema,
-  type PagedCustomerRequestStatus,
-} from '../models/pagedCustomerRequestStatus';
-import { PagedCustomerTransitionSchema, type PagedCustomerTransition } from '../models/pagedCustomerTransition';
+import { PagedCustomerRequestStatusSchema } from '../models/pagedCustomerRequestStatus';
+import type { CustomerRequestStatus } from '../models/customerRequestStatus';
+import { PagedCustomerTransitionSchema } from '../models/pagedCustomerTransition';
+import type { CustomerTransition } from '../models/customerTransition';
 import type { GetCustomerRequests } from '../parameters/getCustomerRequests';
 import type { CreateCustomerRequest } from '../parameters/createCustomerRequest';
 import type { GetCustomerRequestByIdOrKey } from '../parameters/getCustomerRequestByIdOrKey';
@@ -59,8 +61,8 @@ import { type Client, type SendRequestOptions, BufferSchema, type Buffer } from 
 export async function getCustomerRequests(
   client: Client,
   parameters?: GetCustomerRequests,
-): Promise<PagedCustomerRequest> {
-  const config: SendRequestOptions<PagedCustomerRequest> = {
+): Promise<Page<CustomerRequest>> {
+  const config: SendRequestOptions<Page<CustomerRequest>> = {
     url: '/rest/servicedeskapi/request',
     method: 'GET',
     searchParams: {
@@ -159,8 +161,8 @@ export async function getCustomerRequestByIdOrKey(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the customer request.
  */
-export async function getApprovals(client: Client, parameters: GetApprovals): Promise<PagedApproval> {
-  const config: SendRequestOptions<PagedApproval> = {
+export async function getApprovals(client: Client, parameters: GetApprovals): Promise<Page<Approval>> {
+  const config: SendRequestOptions<Page<Approval>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/approval`,
     method: 'GET',
     searchParams: {
@@ -220,8 +222,8 @@ export async function answerApproval(client: Client, parameters: AnswerApproval)
 export async function getAttachmentsForRequest(
   client: Client,
   parameters: GetAttachmentsForRequest,
-): Promise<PagedAttachment> {
-  const config: SendRequestOptions<PagedAttachment> = {
+): Promise<Page<Attachment>> {
+  const config: SendRequestOptions<Page<Attachment>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/attachment`,
     method: 'GET',
     searchParams: {
@@ -324,8 +326,8 @@ export async function getAttachmentThumbnail(client: Client, parameters: GetAtta
  *
  * **Response limitations**: Customers are returned public comments only.
  */
-export async function getRequestComments(client: Client, parameters: GetRequestComments): Promise<PagedComment> {
-  const config: SendRequestOptions<PagedComment> = {
+export async function getRequestComments(client: Client, parameters: GetRequestComments): Promise<Page<Comment>> {
+  const config: SendRequestOptions<Page<Comment>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/comment`,
     method: 'GET',
     searchParams: {
@@ -442,8 +444,8 @@ export async function unsubscribe(client: Client, parameters: Unsubscribe): Prom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the customer request.
  */
-export async function getRequestParticipants(client: Client, parameters: GetRequestParticipants): Promise<PagedUser> {
-  const config: SendRequestOptions<PagedUser> = {
+export async function getRequestParticipants(client: Client, parameters: GetRequestParticipants): Promise<Page<User>> {
+  const config: SendRequestOptions<Page<User>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/participant`,
     method: 'GET',
     searchParams: {
@@ -466,8 +468,8 @@ export async function getRequestParticipants(client: Client, parameters: GetRequ
  * [request](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#api-request-post) resource, by defining
  * the participants in the `requestParticipants` field.
  */
-export async function addRequestParticipants(client: Client, parameters: AddRequestParticipants): Promise<PagedUser> {
-  const config: SendRequestOptions<PagedUser> = {
+export async function addRequestParticipants(client: Client, parameters: AddRequestParticipants): Promise<Page<User>> {
+  const config: SendRequestOptions<Page<User>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/participant`,
     method: 'POST',
     body: {
@@ -489,8 +491,8 @@ export async function addRequestParticipants(client: Client, parameters: AddRequ
 export async function removeRequestParticipants(
   client: Client,
   parameters: RemoveRequestParticipants,
-): Promise<PagedUser> {
-  const config: SendRequestOptions<PagedUser> = {
+): Promise<Page<User>> {
+  const config: SendRequestOptions<Page<User>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/participant`,
     method: 'DELETE',
     body: {
@@ -514,8 +516,8 @@ export async function removeRequestParticipants(
  * - Browse Projects permission on the project containing the customer request, including any restrictions imposed by
  *   issue security schemes or custom permission schemes on the specific issue.
  */
-export async function getSlaInformation(client: Client, parameters: GetSlaInformation): Promise<PagedSlaInformation> {
-  const config: SendRequestOptions<PagedSlaInformation> = {
+export async function getSlaInformation(client: Client, parameters: GetSlaInformation): Promise<Page<SlaInformation>> {
+  const config: SendRequestOptions<Page<SlaInformation>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/sla`,
     method: 'GET',
     searchParams: {
@@ -561,8 +563,8 @@ export async function getSlaInformationById(
 export async function getCustomerRequestStatus(
   client: Client,
   parameters: GetCustomerRequestStatus,
-): Promise<PagedCustomerRequestStatus> {
-  const config: SendRequestOptions<PagedCustomerRequestStatus> = {
+): Promise<Page<CustomerRequestStatus>> {
+  const config: SendRequestOptions<Page<CustomerRequestStatus>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/status`,
     method: 'GET',
     searchParams: {
@@ -586,8 +588,8 @@ export async function getCustomerRequestStatus(
 export async function getCustomerTransitions(
   client: Client,
   parameters: GetCustomerTransitions,
-): Promise<PagedCustomerTransition> {
-  const config: SendRequestOptions<PagedCustomerTransition> = {
+): Promise<Page<CustomerTransition>> {
+  const config: SendRequestOptions<Page<CustomerTransition>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/transition`,
     method: 'GET',
     searchParams: {

--- a/src/serviceDesk/api/servicedesk.ts
+++ b/src/serviceDesk/api/servicedesk.ts
@@ -1,14 +1,18 @@
-import { PagedServiceDeskSchema, type PagedServiceDesk } from '../models/pagedServiceDesk';
+import { PagedServiceDeskSchema } from '../models/pagedServiceDesk';
+import type { Page } from '../models/page';
 import { ServiceDeskSchema, type ServiceDesk } from '../models/serviceDesk';
 import { AttachTemporaryFileSchema, type AttachTemporaryFile } from '../models/attachTemporaryFile';
-import { PagedArticleSchema, type PagedArticle } from '../models/pagedArticle';
-import { PagedQueueSchema, type PagedQueue } from '../models/pagedQueue';
+import { PagedArticleSchema } from '../models/pagedArticle';
+import type { Article } from '../models/article';
+import { PagedQueueSchema } from '../models/pagedQueue';
 import { QueueSchema, type Queue } from '../models/queue';
-import { PagedIssueSchema, type PagedIssue } from '../models/pagedIssue';
-import { PagedRequestTypeSchema, type PagedRequestType } from '../models/pagedRequestType';
+import { PagedIssueSchema } from '../models/pagedIssue';
+import type { Issue } from '../models/issue';
+import { PagedRequestTypeSchema } from '../models/pagedRequestType';
 import { RequestTypeSchema, type RequestType } from '../models/requestType';
 import { CustomerRequestCreateMetaSchema, type CustomerRequestCreateMeta } from '../models/customerRequestCreateMeta';
-import { PagedRequestTypeGroupSchema, type PagedRequestTypeGroup } from '../models/pagedRequestTypeGroup';
+import { PagedRequestTypeGroupSchema } from '../models/pagedRequestTypeGroup';
+import type { RequestTypeGroup } from '../models/requestTypeGroup';
 import type { GetServiceDesks } from '../parameters/getServiceDesks';
 import type { GetServiceDeskById } from '../parameters/getServiceDeskById';
 import type { AttachTemporaryFile as AttachTemporaryFileParameters } from '../parameters/attachTemporaryFile';
@@ -35,8 +39,8 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Any
  */
-export async function getServiceDesks(client: Client, parameters?: GetServiceDesks): Promise<PagedServiceDesk> {
-  const config: SendRequestOptions<PagedServiceDesk> = {
+export async function getServiceDesks(client: Client, parameters?: GetServiceDesks): Promise<Page<ServiceDesk>> {
+  const config: SendRequestOptions<Page<ServiceDesk>> = {
     url: '/rest/servicedeskapi/servicedesk',
     method: 'GET',
     searchParams: {
@@ -164,8 +168,8 @@ export async function addCustomersSkippingPermissionCheck(
 export async function getServiceDeskArticles(
   client: Client,
   parameters: GetServiceDeskArticles,
-): Promise<PagedArticle> {
-  const config: SendRequestOptions<PagedArticle> = {
+): Promise<Page<Article>> {
+  const config: SendRequestOptions<Page<Article>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/knowledgebase/article`,
     method: 'GET',
     searchParams: {
@@ -189,8 +193,8 @@ export async function getServiceDeskArticles(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: service
  * desk's Agent.
  */
-export async function getQueues(client: Client, parameters: GetQueues): Promise<PagedQueue> {
-  const config: SendRequestOptions<PagedQueue> = {
+export async function getQueues(client: Client, parameters: GetQueues): Promise<Page<Queue>> {
+  const config: SendRequestOptions<Page<Queue>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/queue`,
     method: 'GET',
     searchParams: {
@@ -232,8 +236,8 @@ export async function getQueue(client: Client, parameters: GetQueue): Promise<Qu
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk's agent.
  */
-export async function getIssuesInQueue(client: Client, parameters: GetIssuesInQueue): Promise<PagedIssue> {
-  const config: SendRequestOptions<PagedIssue> = {
+export async function getIssuesInQueue(client: Client, parameters: GetIssuesInQueue): Promise<Page<Issue>> {
+  const config: SendRequestOptions<Page<Issue>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/queue/${parameters.queueId}/issue`,
     method: 'GET',
     searchParams: {
@@ -262,8 +266,8 @@ export async function getIssuesInQueue(client: Client, parameters: GetIssuesInQu
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to access the service desk.
  */
-export async function getRequestTypes(client: Client, parameters: GetRequestTypes): Promise<PagedRequestType> {
-  const config: SendRequestOptions<PagedRequestType> = {
+export async function getRequestTypes(client: Client, parameters: GetRequestTypes): Promise<Page<RequestType>> {
+  const config: SendRequestOptions<Page<RequestType>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/requesttype`,
     method: 'GET',
     searchParams: {
@@ -342,8 +346,8 @@ export async function getRequestTypeFields(
 export async function getRequestTypeGroups(
   client: Client,
   parameters: GetRequestTypeGroups,
-): Promise<PagedRequestTypeGroup> {
-  const config: SendRequestOptions<PagedRequestTypeGroup> = {
+): Promise<Page<RequestTypeGroup>> {
+  const config: SendRequestOptions<Page<RequestTypeGroup>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/requesttypegroup`,
     method: 'GET',
     searchParams: {

--- a/src/serviceDesk/createServiceDeskClient.ts
+++ b/src/serviceDesk/createServiceDeskClient.ts
@@ -67,39 +67,31 @@ import type {
   GetRequestTypeGroups,
 } from './parameters';
 import type {
-  PagedAssetsWorkspace,
-  PagedInsightWorkspace,
+  Page,
+  AssetsWorkspace,
+  InsightWorkspace,
   User,
   SoftwareInfo,
-  PagedArticle,
-  PagedOrganization,
+  Article,
   Organization,
   PropertyKeys,
   EntityProperty,
-  PagedUser,
-  PagedCustomerRequest,
   CustomerRequest,
-  PagedApproval,
   Approval,
-  PagedAttachment,
+  Attachment,
   AttachmentCreateResult,
-  PagedComment,
   Comment,
   RequestNotificationSubscription,
-  PagedSlaInformation,
   SlaInformation,
-  PagedCustomerRequestStatus,
-  PagedCustomerTransition,
-  PagedServiceDesk,
+  CustomerRequestStatus,
+  CustomerTransition,
   ServiceDesk,
   AttachTemporaryFile as AttachTemporaryFileModel,
-  PagedQueue,
   Queue,
-  PagedIssue,
-  PagedRequestType,
+  Issue,
   RequestType,
   CustomerRequestCreateMeta,
-  PagedRequestTypeGroup,
+  RequestTypeGroup,
 } from './models';
 
 export function createServiceDeskClient(clientConfig: ClientConfig | Client) {
@@ -107,9 +99,9 @@ export function createServiceDeskClient(clientConfig: ClientConfig | Client) {
 
   return {
     assets: {
-      getAssetsWorkspaces: (parameters?: GetAssetsWorkspaces): Promise<PagedAssetsWorkspace> =>
+      getAssetsWorkspaces: (parameters?: GetAssetsWorkspaces): Promise<Page<AssetsWorkspace>> =>
         assets.getAssetsWorkspaces(client, parameters),
-      getInsightWorkspaces: (parameters?: GetInsightWorkspaces): Promise<PagedInsightWorkspace> =>
+      getInsightWorkspaces: (parameters?: GetInsightWorkspaces): Promise<Page<InsightWorkspace>> =>
         assets.getInsightWorkspaces(client, parameters),
     },
     customer: {
@@ -123,11 +115,11 @@ export function createServiceDeskClient(clientConfig: ClientConfig | Client) {
       getInfo: (): Promise<SoftwareInfo> => info.getInfo(client),
     },
     knowledgebase: {
-      getArticles: (parameters: GetArticles): Promise<PagedArticle> => knowledgebase.getArticles(client, parameters),
+      getArticles: (parameters: GetArticles): Promise<Page<Article>> => knowledgebase.getArticles(client, parameters),
       viewArticle: (parameters: ViewArticle): Promise<string> => knowledgebase.viewArticle(client, parameters),
     },
     organization: {
-      getOrganizations: (parameters?: GetOrganizations): Promise<PagedOrganization> =>
+      getOrganizations: (parameters?: GetOrganizations): Promise<Page<Organization>> =>
         organization.getOrganizations(client, parameters),
       createOrganization: (parameters: CreateOrganization): Promise<Organization> =>
         organization.createOrganization(client, parameters),
@@ -140,29 +132,29 @@ export function createServiceDeskClient(clientConfig: ClientConfig | Client) {
       getProperty: (parameters: GetProperty): Promise<EntityProperty> => organization.getProperty(client, parameters),
       setProperty: (parameters: SetProperty): Promise<void> => organization.setProperty(client, parameters),
       deleteProperty: (parameters: DeleteProperty): Promise<void> => organization.deleteProperty(client, parameters),
-      getUsersInOrganization: (parameters: GetUsersInOrganization): Promise<PagedUser> =>
+      getUsersInOrganization: (parameters: GetUsersInOrganization): Promise<Page<User>> =>
         organization.getUsersInOrganization(client, parameters),
       addUsersToOrganization: (parameters: AddUsersToOrganization): Promise<void> =>
         organization.addUsersToOrganization(client, parameters),
       removeUsersFromOrganization: (parameters: RemoveUsersFromOrganization): Promise<void> =>
         organization.removeUsersFromOrganization(client, parameters),
-      getServiceDeskOrganizations: (parameters: GetServiceDeskOrganizations): Promise<PagedOrganization> =>
+      getServiceDeskOrganizations: (parameters: GetServiceDeskOrganizations): Promise<Page<Organization>> =>
         organization.getServiceDeskOrganizations(client, parameters),
       addOrganization: (parameters: AddOrganization): Promise<void> => organization.addOrganization(client, parameters),
       removeOrganization: (parameters: RemoveOrganization): Promise<void> =>
         organization.removeOrganization(client, parameters),
     },
     request: {
-      getCustomerRequests: (parameters?: GetCustomerRequests): Promise<PagedCustomerRequest> =>
+      getCustomerRequests: (parameters?: GetCustomerRequests): Promise<Page<CustomerRequest>> =>
         request.getCustomerRequests(client, parameters),
       createCustomerRequest: (parameters: CreateCustomerRequest): Promise<CustomerRequest> =>
         request.createCustomerRequest(client, parameters),
       getCustomerRequestByIdOrKey: (parameters: GetCustomerRequestByIdOrKey): Promise<CustomerRequest> =>
         request.getCustomerRequestByIdOrKey(client, parameters),
-      getApprovals: (parameters: GetApprovals): Promise<PagedApproval> => request.getApprovals(client, parameters),
+      getApprovals: (parameters: GetApprovals): Promise<Page<Approval>> => request.getApprovals(client, parameters),
       getApprovalById: (parameters: GetApprovalById): Promise<Approval> => request.getApprovalById(client, parameters),
       answerApproval: (parameters: AnswerApproval): Promise<Approval> => request.answerApproval(client, parameters),
-      getAttachmentsForRequest: (parameters: GetAttachmentsForRequest): Promise<PagedAttachment> =>
+      getAttachmentsForRequest: (parameters: GetAttachmentsForRequest): Promise<Page<Attachment>> =>
         request.getAttachmentsForRequest(client, parameters),
       createCommentWithAttachment: (parameters: CreateCommentWithAttachment): Promise<AttachmentCreateResult> =>
         request.createCommentWithAttachment(client, parameters),
@@ -170,7 +162,7 @@ export function createServiceDeskClient(clientConfig: ClientConfig | Client) {
         request.getAttachmentContent(client, parameters),
       getAttachmentThumbnail: (parameters: GetAttachmentThumbnail): Promise<Buffer> =>
         request.getAttachmentThumbnail(client, parameters),
-      getRequestComments: (parameters: GetRequestComments): Promise<PagedComment> =>
+      getRequestComments: (parameters: GetRequestComments): Promise<Page<Comment>> =>
         request.getRequestComments(client, parameters),
       createRequestComment: (parameters: CreateRequestComment): Promise<Comment> =>
         request.createRequestComment(client, parameters),
@@ -180,25 +172,25 @@ export function createServiceDeskClient(clientConfig: ClientConfig | Client) {
         request.getSubscriptionStatus(client, parameters),
       subscribe: (parameters: Subscribe): Promise<void> => request.subscribe(client, parameters),
       unsubscribe: (parameters: Unsubscribe): Promise<void> => request.unsubscribe(client, parameters),
-      getRequestParticipants: (parameters: GetRequestParticipants): Promise<PagedUser> =>
+      getRequestParticipants: (parameters: GetRequestParticipants): Promise<Page<User>> =>
         request.getRequestParticipants(client, parameters),
-      addRequestParticipants: (parameters: AddRequestParticipants): Promise<PagedUser> =>
+      addRequestParticipants: (parameters: AddRequestParticipants): Promise<Page<User>> =>
         request.addRequestParticipants(client, parameters),
-      removeRequestParticipants: (parameters: RemoveRequestParticipants): Promise<PagedUser> =>
+      removeRequestParticipants: (parameters: RemoveRequestParticipants): Promise<Page<User>> =>
         request.removeRequestParticipants(client, parameters),
-      getSlaInformation: (parameters: GetSlaInformation): Promise<PagedSlaInformation> =>
+      getSlaInformation: (parameters: GetSlaInformation): Promise<Page<SlaInformation>> =>
         request.getSlaInformation(client, parameters),
       getSlaInformationById: (parameters: GetSlaInformationById): Promise<SlaInformation> =>
         request.getSlaInformationById(client, parameters),
-      getCustomerRequestStatus: (parameters: GetCustomerRequestStatus): Promise<PagedCustomerRequestStatus> =>
+      getCustomerRequestStatus: (parameters: GetCustomerRequestStatus): Promise<Page<CustomerRequestStatus>> =>
         request.getCustomerRequestStatus(client, parameters),
-      getCustomerTransitions: (parameters: GetCustomerTransitions): Promise<PagedCustomerTransition> =>
+      getCustomerTransitions: (parameters: GetCustomerTransitions): Promise<Page<CustomerTransition>> =>
         request.getCustomerTransitions(client, parameters),
       performCustomerTransition: (parameters: PerformCustomerTransition): Promise<void> =>
         request.performCustomerTransition(client, parameters),
     },
     servicedesk: {
-      getServiceDesks: (parameters?: GetServiceDesks): Promise<PagedServiceDesk> =>
+      getServiceDesks: (parameters?: GetServiceDesks): Promise<Page<ServiceDesk>> =>
         servicedesk.getServiceDesks(client, parameters),
       getServiceDeskById: (parameters: GetServiceDeskById): Promise<ServiceDesk> =>
         servicedesk.getServiceDeskById(client, parameters),
@@ -207,19 +199,19 @@ export function createServiceDeskClient(clientConfig: ClientConfig | Client) {
       addCustomers: (parameters: AddCustomers): Promise<void> => servicedesk.addCustomers(client, parameters),
       addCustomersSkippingPermissionCheck: (parameters: AddCustomersSkippingPermissionCheck): Promise<void> =>
         servicedesk.addCustomersSkippingPermissionCheck(client, parameters),
-      getServiceDeskArticles: (parameters: GetServiceDeskArticles): Promise<PagedArticle> =>
+      getServiceDeskArticles: (parameters: GetServiceDeskArticles): Promise<Page<Article>> =>
         servicedesk.getServiceDeskArticles(client, parameters),
-      getQueues: (parameters: GetQueues): Promise<PagedQueue> => servicedesk.getQueues(client, parameters),
+      getQueues: (parameters: GetQueues): Promise<Page<Queue>> => servicedesk.getQueues(client, parameters),
       getQueue: (parameters: GetQueue): Promise<Queue> => servicedesk.getQueue(client, parameters),
-      getIssuesInQueue: (parameters: GetIssuesInQueue): Promise<PagedIssue> =>
+      getIssuesInQueue: (parameters: GetIssuesInQueue): Promise<Page<Issue>> =>
         servicedesk.getIssuesInQueue(client, parameters),
-      getRequestTypes: (parameters: GetRequestTypes): Promise<PagedRequestType> =>
+      getRequestTypes: (parameters: GetRequestTypes): Promise<Page<RequestType>> =>
         servicedesk.getRequestTypes(client, parameters),
       getRequestTypeById: (parameters: GetRequestTypeById): Promise<RequestType> =>
         servicedesk.getRequestTypeById(client, parameters),
       getRequestTypeFields: (parameters: GetRequestTypeFields): Promise<CustomerRequestCreateMeta> =>
         servicedesk.getRequestTypeFields(client, parameters),
-      getRequestTypeGroups: (parameters: GetRequestTypeGroups): Promise<PagedRequestTypeGroup> =>
+      getRequestTypeGroups: (parameters: GetRequestTypeGroups): Promise<Page<RequestTypeGroup>> =>
         servicedesk.getRequestTypeGroups(client, parameters),
     },
   };

--- a/src/serviceDesk/models/index.ts
+++ b/src/serviceDesk/models/index.ts
@@ -120,6 +120,8 @@ export * from './organizationCreate';
 
 export * from './organizationServiceDeskUpdate';
 
+export * from './page';
+
 export * from './pageOfChangelogs';
 
 export * from './pagedApproval';

--- a/src/serviceDesk/models/page.ts
+++ b/src/serviceDesk/models/page.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { apiObject } from '#/core';
+import { PagedLinkSchema } from './pagedLink';
+
+export function pageSchema<T extends z.ZodType>(item: T) {
+  return apiObject({
+    _expands: z.array(z.string()).optional(),
+    _links: PagedLinkSchema.optional(),
+    /** Indicates if this is the last page of records (true) or not (false). */
+    isLastPage: z.boolean().optional(),
+    /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
+    limit: z.number().optional(),
+    /** Number of items returned in the page. */
+    size: z.number().optional(),
+    /** Index of the first item returned in the page. */
+    start: z.number().optional(),
+    /** Details of the items included in the page. */
+    values: z.array(item).optional(),
+  });
+}
+
+export type Page<T> = z.infer<ReturnType<typeof pageSchema<z.ZodType<T>>>>;

--- a/src/serviceDesk/models/pagedApproval.ts
+++ b/src/serviceDesk/models/pagedApproval.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { ApprovalSchema } from './approval';
+import { pageSchema, type Page } from './page';
+import { ApprovalSchema, type Approval } from './approval';
 
-export const PagedApprovalSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(ApprovalSchema).optional(),
-});
+export const PagedApprovalSchema = pageSchema(ApprovalSchema);
 
-export type PagedApproval = z.infer<typeof PagedApprovalSchema>;
+/** @deprecated Use `Page<Approval>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedApproval = Page<Approval>;

--- a/src/serviceDesk/models/pagedArticle.ts
+++ b/src/serviceDesk/models/pagedArticle.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { ArticleSchema } from './article';
+import { pageSchema, type Page } from './page';
+import { ArticleSchema, type Article } from './article';
 
-export const PagedArticleSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(ArticleSchema).optional(),
-});
+export const PagedArticleSchema = pageSchema(ArticleSchema);
 
-export type PagedArticle = z.infer<typeof PagedArticleSchema>;
+/** @deprecated Use `Page<Article>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedArticle = Page<Article>;

--- a/src/serviceDesk/models/pagedAssetsWorkspace.ts
+++ b/src/serviceDesk/models/pagedAssetsWorkspace.ts
@@ -1,21 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { AssetsWorkspaceSchema } from './assetsWorkspace';
+import { pageSchema, type Page } from './page';
+import { AssetsWorkspaceSchema, type AssetsWorkspace } from './assetsWorkspace';
 
-export const PagedAssetsWorkspaceSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(AssetsWorkspaceSchema).optional(),
-});
+export const PagedAssetsWorkspaceSchema = pageSchema(AssetsWorkspaceSchema);
 
-export type PagedAssetsWorkspace = z.infer<typeof PagedAssetsWorkspaceSchema>;
+/**
+ * @deprecated Use `Page<AssetsWorkspace>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PagedAssetsWorkspace = Page<AssetsWorkspace>;

--- a/src/serviceDesk/models/pagedAttachment.ts
+++ b/src/serviceDesk/models/pagedAttachment.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { AttachmentSchema } from './attachment';
+import { pageSchema, type Page } from './page';
+import { AttachmentSchema, type Attachment } from './attachment';
 
-export const PagedAttachmentSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(AttachmentSchema).optional(),
-});
+export const PagedAttachmentSchema = pageSchema(AttachmentSchema);
 
-export type PagedAttachment = z.infer<typeof PagedAttachmentSchema>;
+/** @deprecated Use `Page<Attachment>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedAttachment = Page<Attachment>;

--- a/src/serviceDesk/models/pagedComment.ts
+++ b/src/serviceDesk/models/pagedComment.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { CommentSchema } from './comment';
+import { pageSchema, type Page } from './page';
+import { CommentSchema, type Comment } from './comment';
 
-export const PagedCommentSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(CommentSchema).optional(),
-});
+export const PagedCommentSchema = pageSchema(CommentSchema);
 
-export type PagedComment = z.infer<typeof PagedCommentSchema>;
+/** @deprecated Use `Page<Comment>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedComment = Page<Comment>;

--- a/src/serviceDesk/models/pagedCustomerRequest.ts
+++ b/src/serviceDesk/models/pagedCustomerRequest.ts
@@ -1,21 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { CustomerRequestSchema } from './customerRequest';
+import { pageSchema, type Page } from './page';
+import { CustomerRequestSchema, type CustomerRequest } from './customerRequest';
 
-export const PagedCustomerRequestSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(CustomerRequestSchema).optional(),
-});
+export const PagedCustomerRequestSchema = pageSchema(CustomerRequestSchema);
 
-export type PagedCustomerRequest = z.infer<typeof PagedCustomerRequestSchema>;
+/**
+ * @deprecated Use `Page<CustomerRequest>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PagedCustomerRequest = Page<CustomerRequest>;

--- a/src/serviceDesk/models/pagedCustomerRequestStatus.ts
+++ b/src/serviceDesk/models/pagedCustomerRequestStatus.ts
@@ -1,21 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { CustomerRequestStatusSchema } from './customerRequestStatus';
+import { pageSchema, type Page } from './page';
+import { CustomerRequestStatusSchema, type CustomerRequestStatus } from './customerRequestStatus';
 
-export const PagedCustomerRequestStatusSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(CustomerRequestStatusSchema).optional(),
-});
+export const PagedCustomerRequestStatusSchema = pageSchema(CustomerRequestStatusSchema);
 
-export type PagedCustomerRequestStatus = z.infer<typeof PagedCustomerRequestStatusSchema>;
+/**
+ * @deprecated Use `Page<CustomerRequestStatus>`, which describes the same shape. This alias is removed in the next
+ *   major version.
+ */
+export type PagedCustomerRequestStatus = Page<CustomerRequestStatus>;

--- a/src/serviceDesk/models/pagedCustomerTransition.ts
+++ b/src/serviceDesk/models/pagedCustomerTransition.ts
@@ -1,21 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { CustomerTransitionSchema } from './customerTransition';
+import { pageSchema, type Page } from './page';
+import { CustomerTransitionSchema, type CustomerTransition } from './customerTransition';
 
-export const PagedCustomerTransitionSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(CustomerTransitionSchema).optional(),
-});
+export const PagedCustomerTransitionSchema = pageSchema(CustomerTransitionSchema);
 
-export type PagedCustomerTransition = z.infer<typeof PagedCustomerTransitionSchema>;
+/**
+ * @deprecated Use `Page<CustomerTransition>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PagedCustomerTransition = Page<CustomerTransition>;

--- a/src/serviceDesk/models/pagedInsightWorkspace.ts
+++ b/src/serviceDesk/models/pagedInsightWorkspace.ts
@@ -1,21 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { InsightWorkspaceSchema } from './insightWorkspace';
+import { pageSchema, type Page } from './page';
+import { InsightWorkspaceSchema, type InsightWorkspace } from './insightWorkspace';
 
-export const PagedInsightWorkspaceSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(InsightWorkspaceSchema).optional(),
-});
+export const PagedInsightWorkspaceSchema = pageSchema(InsightWorkspaceSchema);
 
-export type PagedInsightWorkspace = z.infer<typeof PagedInsightWorkspaceSchema>;
+/**
+ * @deprecated Use `Page<InsightWorkspace>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PagedInsightWorkspace = Page<InsightWorkspace>;

--- a/src/serviceDesk/models/pagedIssue.ts
+++ b/src/serviceDesk/models/pagedIssue.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { IssueSchema } from './issue';
+import { pageSchema, type Page } from './page';
+import { IssueSchema, type Issue } from './issue';
 
-export const PagedIssueSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(IssueSchema).optional(),
-});
+export const PagedIssueSchema = pageSchema(IssueSchema);
 
-export type PagedIssue = z.infer<typeof PagedIssueSchema>;
+/** @deprecated Use `Page<Issue>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedIssue = Page<Issue>;

--- a/src/serviceDesk/models/pagedOrganization.ts
+++ b/src/serviceDesk/models/pagedOrganization.ts
@@ -1,21 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { OrganizationSchema } from './organization';
+import { pageSchema, type Page } from './page';
+import { OrganizationSchema, type Organization } from './organization';
 
-export const PagedOrganizationSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(OrganizationSchema).optional(),
-});
+export const PagedOrganizationSchema = pageSchema(OrganizationSchema);
 
-export type PagedOrganization = z.infer<typeof PagedOrganizationSchema>;
+/**
+ * @deprecated Use `Page<Organization>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PagedOrganization = Page<Organization>;

--- a/src/serviceDesk/models/pagedQueue.ts
+++ b/src/serviceDesk/models/pagedQueue.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { QueueSchema } from './queue';
+import { pageSchema, type Page } from './page';
+import { QueueSchema, type Queue } from './queue';
 
-export const PagedQueueSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(QueueSchema).optional(),
-});
+export const PagedQueueSchema = pageSchema(QueueSchema);
 
-export type PagedQueue = z.infer<typeof PagedQueueSchema>;
+/** @deprecated Use `Page<Queue>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedQueue = Page<Queue>;

--- a/src/serviceDesk/models/pagedRequestType.ts
+++ b/src/serviceDesk/models/pagedRequestType.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { RequestTypeSchema } from './requestType';
+import { pageSchema, type Page } from './page';
+import { RequestTypeSchema, type RequestType } from './requestType';
 
-export const PagedRequestTypeSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(RequestTypeSchema).optional(),
-});
+export const PagedRequestTypeSchema = pageSchema(RequestTypeSchema);
 
-export type PagedRequestType = z.infer<typeof PagedRequestTypeSchema>;
+/** @deprecated Use `Page<RequestType>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedRequestType = Page<RequestType>;

--- a/src/serviceDesk/models/pagedRequestTypeGroup.ts
+++ b/src/serviceDesk/models/pagedRequestTypeGroup.ts
@@ -1,21 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { RequestTypeGroupSchema } from './requestTypeGroup';
+import { pageSchema, type Page } from './page';
+import { RequestTypeGroupSchema, type RequestTypeGroup } from './requestTypeGroup';
 
-export const PagedRequestTypeGroupSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(RequestTypeGroupSchema).optional(),
-});
+export const PagedRequestTypeGroupSchema = pageSchema(RequestTypeGroupSchema);
 
-export type PagedRequestTypeGroup = z.infer<typeof PagedRequestTypeGroupSchema>;
+/**
+ * @deprecated Use `Page<RequestTypeGroup>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PagedRequestTypeGroup = Page<RequestTypeGroup>;

--- a/src/serviceDesk/models/pagedServiceDesk.ts
+++ b/src/serviceDesk/models/pagedServiceDesk.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { ServiceDeskSchema } from './serviceDesk';
+import { pageSchema, type Page } from './page';
+import { ServiceDeskSchema, type ServiceDesk } from './serviceDesk';
 
-export const PagedServiceDeskSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(ServiceDeskSchema).optional(),
-});
+export const PagedServiceDeskSchema = pageSchema(ServiceDeskSchema);
 
-export type PagedServiceDesk = z.infer<typeof PagedServiceDeskSchema>;
+/** @deprecated Use `Page<ServiceDesk>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedServiceDesk = Page<ServiceDesk>;

--- a/src/serviceDesk/models/pagedSlaInformation.ts
+++ b/src/serviceDesk/models/pagedSlaInformation.ts
@@ -1,21 +1,10 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { SlaInformationSchema } from './slaInformation';
+import { pageSchema, type Page } from './page';
+import { SlaInformationSchema, type SlaInformation } from './slaInformation';
 
-export const PagedSlaInformationSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(SlaInformationSchema).optional(),
-});
+export const PagedSlaInformationSchema = pageSchema(SlaInformationSchema);
 
-export type PagedSlaInformation = z.infer<typeof PagedSlaInformationSchema>;
+/**
+ * @deprecated Use `Page<SlaInformation>`, which describes the same shape. This alias is removed in the next major
+ *   version.
+ */
+export type PagedSlaInformation = Page<SlaInformation>;

--- a/src/serviceDesk/models/pagedUser.ts
+++ b/src/serviceDesk/models/pagedUser.ts
@@ -1,21 +1,7 @@
-import { z } from 'zod';
-import { apiObject } from '#/core';
-import { PagedLinkSchema } from './pagedLink';
-import { UserSchema } from './user';
+import { pageSchema, type Page } from './page';
+import { UserSchema, type User } from './user';
 
-export const PagedUserSchema = apiObject({
-  _expands: z.array(z.string()).optional(),
-  _links: PagedLinkSchema.optional(),
-  /** Indicates if this is the last page of records (true) or not (false). */
-  isLastPage: z.boolean().optional(),
-  /** Number of items to be returned per page, up to the maximum set for these objects in the current implementation. */
-  limit: z.number().optional(),
-  /** Number of items returned in the page. */
-  size: z.number().optional(),
-  /** Index of the first item returned in the page. */
-  start: z.number().optional(),
-  /** Details of the items included in the page. */
-  values: z.array(UserSchema).optional(),
-});
+export const PagedUserSchema = pageSchema(UserSchema);
 
-export type PagedUser = z.infer<typeof PagedUserSchema>;
+/** @deprecated Use `Page<User>`, which describes the same shape. This alias is removed in the next major version. */
+export type PagedUser = Page<User>;


### PR DESCRIPTION
Stacked on #439, which is stacked on #438. GitHub retargets each as the one below it merges.

Atlassian restates the pagination envelope once per item type — 82 components across the three APIs, identical but for what sits in `values`. Each generated a model of its own, so a page of boards and a page of users were two unrelated shapes with the same seven fields.

Each API now has one envelope, built from one factory:

```ts
const boards: Page<Board> = await agile.board.getAllBoards();
const comments: Page<Comment> = await jira.issueComments.getCommentsByIds({ ids: [10000, 10001] });
const articles: Page<Article> = await serviceDesk.knowledgebase.getArticles({ query: 'vpn' });
```

| API | pages folded | envelope |
| --- | --- | --- |
| cloud | 62 | `isLast`, `maxResults`, `nextPage`, `self`, `startAt`, `total`, `values` |
| serviceDesk | 17 | `_expands`, `_links`, `isLastPage`, `limit`, `size`, `start`, `values` |
| agile | 3 | cloud's, without `nextPage` and `self` |

Three generics rather than one: the envelopes genuinely differ, and giving agile cloud's would document two fields Jira Software never sends. All three are named `Page` — the packages have separate entry points, and no document generates a model of that name.

**Nothing is removed and no shape changes.** The 82 retired names stay as `@deprecated` aliases (`type PageBoard = Page<Board>`), assignable in both directions, going at the next major version. The schemas keep their own names — `PageBoardSchema` is the only handle on the runtime schema — so only the type carries the deprecation.

Every page type was checked against the one it replaces, in both directions, with `Eq<A, B>` against the previously built `dist`: agile, cloud and Service Desk all identical, and `PageBoard` ≡ `Page<Board>`.

Only exact matches folded — the cursor-based pages, `PageOfChangelogs`, `PageOfComments`, `PageOfWorklogs`, `PagedLink` and the one page whose items are written out inline generate exactly as before.

`124 files changed, 1093 insertions(+), 2034 deletions(-)`. The browser bundle goes from 481 kB to 471 kB.

Generator: `7e04314` (the envelope mechanism, 7 new tests) and `0a1992b` (the three declarations) on `apis-code-gen` master; suite at 141 green, no new lint findings in any touched file.

Local: `typecheck`, `lint`, 203 unit tests, `build`, `check:browser` (1969 runtime files, 5 entry points), `check:consumers` — all green.