### PR TITLE
release: 6.2.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Jira.js changelog
 
-## 6.2.0
+## 6.2.0-rc.1
+
+Release candidate for 6.2.0, published under the `next` tag: `npm i jira.js@next`. `npm i jira.js` still installs 6.1.0.
 
 Avatars moved bytes in both directions and the specification described both as JSON, so neither direction worked. Reading an image threw before the response reached the caller; uploading one had no way to send an image at all. Both are fixed here, along with two column endpoints broken by the same reading of the same specification.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira.js",
-  "version": "6.2.0",
+  "version": "6.2.0-rc.1",
   "description": "Modern Jira REST API client for JavaScript and TypeScript. Full-featured library for the Jira Cloud platform API, Jira Agile API, and Jira Service Management API, with every response validated at runtime. Works in Node.js and browsers with TypeScript support, tree-shaking, and comprehensive type definitions.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts a release candidate for 6.2.0 so the avatar and column fixes, `Page<T>`, the eleven renamed cloud models and the typed `createCustomField` can be exercised before they reach `latest`.

`package.json` moves to `6.2.0-rc.1` and the changelog section is retitled to match, which is what the release workflow reads for the GitHub release body. The `-rc.1` numbering follows the only precedent this repository has, `6.0.0-rc.1`.

Tagging `v6.2.0-rc.1` after this merges publishes under the `next` dist-tag — the workflow picks it from the hyphen in the version — and opens a GitHub prerelease. `npm i jira.js` keeps installing 6.1.0.

The section is retitled back to `## 6.2.0` when the final release is cut, exactly as `6.0.0-rc.1` became `6.0.0`.