### PR TITLE
fix: the assets suite stops claiming the two workspace paths still agree

### DIFF
--- a/tests/live/serviceDesk/assets.test.ts
+++ b/tests/live/serviceDesk/assets.test.ts
@@ -6,12 +6,17 @@ import { getClient } from '../setup/client';
 /**
  * Live suite for the Service Management `assets` API (`getAssetsWorkspaces`, `getInsightWorkspaces`).
  *
- * Two endpoints that do the same thing under two names — Insight was renamed Assets, and the older path is kept for
- * compatibility. That is the only thing worth asserting about them, and it is the kind of fact that is invisible in
- * the types: a caller reading the client sees two unrelated-looking methods.
+ * Two endpoints for one thing under two names — Insight was renamed Assets, and the older path is kept for
+ * compatibility. The suite used to assert that the pair behaves identically, which stopped being true when
+ * `/assets/workspace` began answering on this tenant while `/insight/workspace` did not.
  *
- * Both are gated behind the same agent licence as the rest of the surface, so what is pinned is the typed refusal and
- * that the two paths behave identically.
+ * That divergence is a licensing fact, not a retirement: the older path refuses with the same 403 as
+ * `getServiceDesks`, `getCustomerRequests` and `getOrganizations`, all four carrying a byte-identical copy of Jira's
+ * generic HTML error page. Atlassian has announced no removal, and both operations remain in the specification. So
+ * each path is pinned on its own terms — answer or typed refusal — rather than against the other.
+ *
+ * What the refusal is worth asserting for is the body: an HTML page is the one response on any of the three surfaces
+ * that the JSON parser has no way to read, and it still has to arrive as a typed error with its status intact.
  */
 describe('Jira Service Management — assets (live)', () => {
   let serviceDesk: ServiceDeskClient;
@@ -20,11 +25,18 @@ describe('Jira Service Management — assets (live)', () => {
     serviceDesk = createServiceDeskClient(getClient());
   });
 
-  it('answers the assets workspace lookup, or refuses typed', async () => {
-    const result = await serviceDesk.assets.getAssetsWorkspaces({ limit: 5 }).catch((e: unknown) => e);
+  /** Both names answer with the same page of workspace ids, so both are read the same way. */
+  const lookups: [string, () => Promise<unknown>][] = [
+    ['assets.getAssetsWorkspaces', () => serviceDesk.assets.getAssetsWorkspaces({ limit: 5 })],
+    ['assets.getInsightWorkspaces', () => serviceDesk.assets.getInsightWorkspaces({ limit: 5 })],
+  ];
+
+  it.each(lookups)('answers the %s lookup, or refuses typed', async (_name, lookup) => {
+    const result = await lookup().catch((e: unknown) => e);
 
     if (result instanceof Error) {
-      expect(isForbiddenError(result) || (result as { status?: number }).status === 404).toBe(true);
+      expect(isForbiddenError(result)).toBe(true);
+      expect((result as { status?: number }).status).toBe(403);
 
       return;
     }
@@ -35,20 +47,6 @@ describe('Jira Service Management — assets (live)', () => {
 
     for (const workspace of page.values ?? []) {
       expect(typeof workspace.workspaceId).toBe('string');
-    }
-  });
-
-  it('behaves identically through the older Insight path', async () => {
-    const assets = await serviceDesk.assets.getAssetsWorkspaces({ limit: 1 }).catch((e: unknown) => e);
-    const insight = await serviceDesk.assets.getInsightWorkspaces({ limit: 1 }).catch((e: unknown) => e);
-
-    const assetsFailed = assets instanceof Error;
-    const insightFailed = insight instanceof Error;
-
-    expect(assetsFailed).toBe(insightFailed);
-
-    if (assetsFailed && insightFailed) {
-      expect((assets as { status?: number }).status).toBe((insight as { status?: number }).status);
     }
   });
 });

--- a/tests/live/serviceDesk/request.test.ts
+++ b/tests/live/serviceDesk/request.test.ts
@@ -9,8 +9,10 @@ import { getClient } from '../setup/client';
  * Every endpoint here is gated behind an agent licence the test account does not hold, so this file asserts the
  * shape of the refusal across the whole surface rather than skipping. Two things make that worth doing.
  *
- * First, the refusal is a 403 with an empty body — the least informative answer in any of the three surfaces — so
- * that it arrives *typed* is the only thing standing between a caller and a bare rejection they cannot classify.
+ * First, the refusal is a 403 carrying Jira's generic HTML error page rather than a service-desk error — the same
+ * body `getServiceDesks`, `getOrganizations` and `getInsightWorkspaces` refuse with, and the one answer on any of the
+ * three surfaces that a JSON parser cannot read at all. That it arrives *typed*, with its status intact, is the only
+ * thing standing between a caller and a bare rejection they cannot classify.
  *
  * Second, several of these endpoints would be unsafe even with a licence: `createCustomerRequest` opens a real ticket
  * a support team would see, `createRequestComment` writes into a customer conversation, and


### PR DESCRIPTION
The nightly schema audit has been red since 22 August on a single assertion — `tests/live/serviceDesk/assets.test.ts` > *behaves identically through the older Insight path*. Three consecutive scheduled runs, same failure ([32691630760](https://github.com/MrRefactoring/jira.js/actions/runs/32691630760), [32618621804](https://github.com/MrRefactoring/jira.js/actions/runs/32618621804), [32552308415](https://github.com/MrRefactoring/jira.js/actions/runs/32552308415)).

## What actually broke

Nothing in the library. Reproduced against the live tenant:

```
GET /rest/servicedeskapi/assets/workspace   → 200 application/json
GET /rest/servicedeskapi/insight/workspace  → 403 text/html
```

The failing direction is the opposite of what the test name suggests. `/assets/workspace` **started answering** where it used to refuse; `/insight/workspace` stayed behind the same gate it was always behind. The symmetry the test asserted collapsed from the Assets side.

The timing lines up with the [Services / Assets / JSM unification](https://community.atlassian.com/forums/Jira-Service-Management-articles/Unifying-Services-Assets-and-Jira-Service-Management/ba-p/3221239), whose phased rollout began 15 August and runs for 2–3 weeks.

## Why this is not a retirement

Every endpoint on this surface refuses with a byte-identical body:

```
servicedesk.getServiceDesks      ForbiddenError 403  bodyLen=66787  html=true
request.getCustomerRequests      ForbiddenError 403  bodyLen=66787  html=true
organization.getOrganizations    ForbiddenError 403  bodyLen=66787  html=true
assets.getInsightWorkspaces      ForbiddenError 403  bodyLen=66787  html=true
```

`getInsightWorkspaces` is indistinguishable from three endpoints that are certainly alive — it is Jira's generic HTML error page, served because the account holds no agent licence, exactly as `tests/live/serviceDesk/info.test.ts` already documents. Alongside that: no entry in the [JSM changelog](https://developer.atlassian.com/cloud/jira/service-desk/changelog/), no deprecation notice, no sunset date, and both operations still present in the specification and in [the published docs](https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-assets/), where the older one carries only "This endpoint is deprecated, please use /assets/workspace/".

So the public surface is untouched — no method removed, no `@deprecated` added.

## The change

Both lookups collapse into one parameterised case following the existing live-suite idiom (`tests/live/agile/devops.test.ts`): each path is pinned on its own terms — a well-formed page, or a typed 403 — instead of against the other.

The speculative `|| status === 404` goes with it. It was written in `7d1d49d83` and no 404 was ever observed there; a real retirement should turn the audit red rather than slip through as tolerated.

`request.test.ts` gets a docblock correction only, no code change: it described the refusal as carrying an empty body, which is no longer true.

Skipping was considered and rejected — this suite states the case against it explicitly ("*rather than skipping*", "*rather than skip into vacuity*"), and the typed refusal is the one live assertion that a non-JSON body still reaches the caller as a classifiable error with its status intact.

## Verification

`pnpm lint`, `pnpm typecheck`, and the full serviceDesk suite under `vitest.config.audit.ts` — the strict-schema configuration the nightly audit runs — **21 passed**, including both new cases.