### PR TITLE
feat: the transport takes a signal, a fetch of your own, and stops taking a refused credential for a result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## 6.3.0
 
+### The transport
+
+Three long-standing requests, all of them the same shape: the client had no seam. `fetch` was reached as a global, a request could not be cancelled, and a response's headers were read for one thing and thrown away. None of that was visible from outside, and all three issues predate 6.0.
+
+* **Every call takes an `AbortSignal`.** Each method gains an optional argument after its parameters — an operation that takes no parameters takes it in their place — and the signal reaches `fetch`. It also cuts short a retry back-off, which until now had no upper bound on total wall time. Fixes [#406](https://github.com/MrRefactoring/jira.js/issues/406).
+
+  ```ts
+  await jira.issues.getIssue({ issueIdOrKey: 'PROJ-1' }, { signal: AbortSignal.timeout(5_000) });
+  await jira.announcementBanner.getBanner({ signal });
+  ```
+
+  The abort reason is rethrown untouched rather than wrapped in a `NetworkError`: `error.name === 'AbortError'` is what the ecosystem branches on, a `TimeoutError` from `AbortSignal.timeout()` stays a `TimeoutError`, and a reason of your own comes back as the object you passed. Aborting one call never disturbs an OAuth 2.0 refresh in flight — that refresh is single-flighted and shared by every concurrent request on the client.
+
+  Nothing that compiled before stops compiling: the argument is optional and it is last.
+
+* **The `fetch` the client calls is yours to replace.** `fetch` in the client configuration receives the URL and the `RequestInit` the client built, headers included, and returns a `Response`. That covers logging, tracing, a corporate proxy and fixture recording — what `middlewares` was used for before 6.0 removed axios, and what has had no replacement since. Fixes [#404](https://github.com/MrRefactoring/jira.js/issues/404).
+
+  ```ts
+  import { fetch as undiciFetch, ProxyAgent } from 'undici';
+
+  const dispatcher = new ProxyAgent(process.env.HTTPS_PROXY!);
+
+  const jira = createCloudClient({ host, auth, fetch: (url, init) => undiciFetch(url, { ...init, dispatcher }) });
+  ```
+
+  The OAuth 2.0 token and cloud-id calls go through it too, so a proxy covers the whole flow rather than working until the first refresh an hour later. The flip side is worth stating plainly: a wrapper that logs request bodies will see `client_secret` and `refresh_token` on the token call.
+
+  Its type is `(url: string, init: RequestInit) => Promise<Response>` rather than `typeof globalThis.fetch`, so undici's `fetch` — whose `RequestInit` carries `dispatcher` and lacks `duplex` — fits without a cast.
+
+* **An expired API token is an error rather than an empty result. This changes behaviour.** Around a quarter of Jira's operations can be reached anonymously, and on those a dead or revoked token does not fail the request: Jira serves it as the anonymous user, returns a well-formed response containing whatever an anonymous visitor may see, and reports the refusal only in the `X-Seraph-LoginReason` header. Measured against a live site, `GET /rest/api/3/project/search` with a dead token answers `200` and `{"total":0,"isLast":true,"values":[]}`. Fixes [#418](https://github.com/MrRefactoring/jira.js/issues/418).
+
+  The client now reads that header and throws `AuthError` whenever it says the credentials were refused — whatever the status, because the header rides on `200`, `400` and `401` alike and the diagnosis is the same in each case. `error.status` records the status that actually arrived rather than a `401` that never happened; that is what the new `AuthErrorOptions.status` is for.
+
+  Two values count: `AUTHENTICATED_FAILED` and `AUTHENTICATION_DENIED`, both meaning the credentials were presented and refused. `AUTHORISATION_FAILED` does not — it means the user is who they claim and merely lacks a permission, which the status already carries and `ForbiddenError` already describes. A genuine permission denial was measured to send no such header at all. The check runs only when the client was given credentials, so a deliberately anonymous client is untouched, and `getAuthOn401` is offered the same single retry a plain `401` earns it.
+
+  If your code treated an empty result on a dead token as normal, it will now throw. It was reading anonymous data and calling it yours.
+
+* **A header set to `undefined` is left out rather than sent.** `SendRequestOptions.headers` accepts `string | undefined`, and the transport strips the absent entries before the request is built — the same treatment `searchParams` and a JSON body have always had. An omitted header does not shadow one set in the client configuration either, so a per-request `undefined` falls through to the client-wide value instead of erasing it.
+
+* **Two authentication strategies for a self-hosted instance.** `basic` accepts a local `username` and `password` beside the Cloud pair of `email` and `apiToken`, and `oauth2Server` is OAuth 2.0 against an instance's own authorization server — `generateServerAuthorizationUrl`, `exchangeServerAuthorizationCode`, `refreshServerOAuth2Token` and `createServerOAuth2Manager`, all of them addressed to the site's own domain with no cloud id and no gateway involved.
+
+  They arrive with the transport rather than with the surface they are for, because `src/core` is generated whole and `createClient` branches on the strategy — separating them would mean hand-writing a core the generator does not produce. No surface in this release answers to them yet.
+
 ### Features
 
 * **Request parameter types are importable again.** `CreateIssue`, `GetIssue` and the twelve hundred others appeared in no published declaration file: a surface entry point re-exports `api`, `models` and its factory, and never `parameters`. They now have a subpath of their own:
@@ -18,6 +61,28 @@
 * **The documentation site builds again, and the API reference covers the whole package.** The reference was generated by walking every file under each entry point rather than by following its exports. That published four internal `core` modules as though they were API, and produced a page per generated model saying only `type X = z.infer<typeof XSchema>` — absent from the sidebar, linked from no signature, and between them enough weight to threaten the build's heap. It is generated from the package's own `exports` map now, so it documents exactly what a caller can import: every surface, every model and parameter type, and every zod schema. A new surface reaches the documentation the day it reaches the exports map, and an internal module never does.
 
   `validation.notExported` makes the reference a check on the public surface besides: a type built out of something the package does not export fails the documentation build. Five symbols were in exactly that position and are exported now — `authBasicSchema`, `authBearerSchema`, `CommonClientConfig`, `ParsedClientConfig` and `ErrorKind`.
+
+### Types
+
+* **Four request bodies are typed as the shape the endpoint reads, where they were `Record<string, any>`.** Each was generated from a request body the specification declares as something other than an object, which the generator had no reading for and degraded to an object of arbitrary keys. None of the four could be called correctly through its own declaration.
+
+  | Operation | Body was | Body is |
+  | --- | --- | --- |
+  | `issueWatchers.addWatcher` | `Record<string, any>` | `string` |
+  | `myself.setPreference` | `Record<string, any>` | `string` |
+  | `appMigration.updateEntityPropertiesValue` | `Record<string, any>` | `EntityPropertyDetails[]` |
+  | `servicedesk.attachTemporaryFile` (Service Desk) | `Record<string, any>` | `MultipartFile[]` |
+
+  ```ts
+  await jira.issueWatchers.addWatcher({ issueIdOrKey: 'PROJ-1', body: '5b10ac8d82e05b22cc7d4ef5' });
+  await jira.myself.setPreference({ key: 'user.notifications.mimetype', body: 'text' });
+  ```
+
+  The two that take a lone string were the sharper break. `addWatcher` wants an account id and `setPreference` a preference value, each sent as a JSON string — and an object was never a value either would accept, so the only way to call them was to cast a string past the declaration. The live suite did exactly that, with a helper whose whole purpose was to launder a `string` into a `Record<string, unknown>`. Those casts are what stops compiling now, and deleting each one is the fix.
+
+  The two that take an array break more quietly: an array satisfies `Record<string, any>`, so a caller already passing the right thing is untouched and needs no change. A caller passing a single object, which the old declaration invited and the endpoint refused, is the one the compiler now stops.
+
+  `tests/unit/nonObjectBodies.test.ts` pins all four against the wire. It is unit rather than live because two of them cannot be reached: `updateEntityPropertiesValue` is addressed with a Connect app's JWT, and `attachTemporaryFile` needs an agent licence — so what a live run can show is the typed refusal, and what it cannot show is that the body left the client as a bare string or a top-level array rather than wrapped in a key.
 
 ### General
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -20,6 +20,7 @@ export default defineConfig([
     },
     rules: {
       'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-nested-ternary': 'error',
       '@stylistic/comma-dangle': ['error', 'always-multiline'],
       '@stylistic/indent': ['error', 2],
       '@stylistic/lines-between-class-members': [

--- a/src/agile/api/backlog.ts
+++ b/src/agile/api/backlog.ts
@@ -1,18 +1,23 @@
 import type { MoveIssuesToBacklog } from '../parameters/moveIssuesToBacklog';
 import type { MoveIssuesToBacklogForBoard } from '../parameters/moveIssuesToBacklogForBoard';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Move issues to the backlog. This operation is equivalent to remove future and active sprints from a given set of
  * issues. At most 50 issues may be moved at once.
  */
-export async function moveIssuesToBacklog(client: Client, parameters: MoveIssuesToBacklog): Promise<void> {
+export async function moveIssuesToBacklog(
+  client: Client,
+  parameters: MoveIssuesToBacklog,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/agile/1.0/backlog/issue',
     method: 'POST',
     body: {
       issues: parameters.issues,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -26,6 +31,7 @@ export async function moveIssuesToBacklog(client: Client, parameters: MoveIssues
 export async function moveIssuesToBacklogForBoard(
   client: Client,
   parameters: MoveIssuesToBacklogForBoard,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/backlog/${parameters.boardId}/issue`,
@@ -36,6 +42,7 @@ export async function moveIssuesToBacklogForBoard(
       rankBeforeIssue: parameters.rankBeforeIssue,
       rankCustomFieldId: parameters.rankCustomFieldId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/board.ts
+++ b/src/agile/api/board.ts
@@ -46,7 +46,7 @@ import type { GetReportsForBoard as GetReportsForBoardParameters } from '../para
 import type { GetAllSprints as GetAllSprintsParameters } from '../parameters/getAllSprints';
 import type { GetBoardIssuesForSprint } from '../parameters/getBoardIssuesForSprint';
 import type { GetAllVersions as GetAllVersionsParameters } from '../parameters/getAllVersions';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns all boards. This only includes boards that the user has permission to view.
@@ -55,7 +55,11 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * - `read:board-scope:jira-software`, `read:project:jira`
  */
-export async function getAllBoards(client: Client, parameters?: GetAllBoards): Promise<Page<Board>> {
+export async function getAllBoards(
+  client: Client,
+  parameters?: GetAllBoards,
+  options?: RequestOptions,
+): Promise<Page<Board>> {
   const config: SendRequestOptions<Page<Board>> = {
     url: '/rest/agile/1.0/board',
     method: 'GET',
@@ -75,6 +79,7 @@ export async function getAllBoards(client: Client, parameters?: GetAllBoards): P
       filterId: parameters?.filterId,
     },
     schema: PageBoardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -106,7 +111,7 @@ export async function getAllBoards(client: Client, parameters?: GetAllBoards): P
  * - If you do not ORDER BY the Rank field for the filter of your board, you will not be able to reorder issues on the
  *   board.
  */
-export async function createBoard(client: Client, parameters: CreateBoard): Promise<Board> {
+export async function createBoard(client: Client, parameters: CreateBoard, options?: RequestOptions): Promise<Board> {
   const config: SendRequestOptions<Board> = {
     url: '/rest/agile/1.0/board',
     method: 'POST',
@@ -117,6 +122,7 @@ export async function createBoard(client: Client, parameters: CreateBoard): Prom
       type: parameters.type,
     },
     schema: BoardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -126,7 +132,11 @@ export async function createBoard(client: Client, parameters: CreateBoard): Prom
  * Returns any boards which use the provided filter id. This method can be executed by users without a valid software
  * license in order to find which boards are using a particular filter.
  */
-export async function getBoardByFilterId(client: Client, parameters: GetBoardByFilterId): Promise<Page<BoardFilter>> {
+export async function getBoardByFilterId(
+  client: Client,
+  parameters: GetBoardByFilterId,
+  options?: RequestOptions,
+): Promise<Page<BoardFilter>> {
   const config: SendRequestOptions<Page<BoardFilter>> = {
     url: `/rest/agile/1.0/board/filter/${parameters.filterId}`,
     method: 'GET',
@@ -135,6 +145,7 @@ export async function getBoardByFilterId(client: Client, parameters: GetBoardByF
       maxResults: parameters.maxResults,
     },
     schema: PageBoardFilterSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -145,21 +156,23 @@ export async function getBoardByFilterId(client: Client, parameters: GetBoardByF
  * Admins without the view permission will see the board as a private one, so will see only a subset of the board's data
  * (board location for instance).
  */
-export async function getBoard(client: Client, parameters: GetBoard): Promise<Board> {
+export async function getBoard(client: Client, parameters: GetBoard, options?: RequestOptions): Promise<Board> {
   const config: SendRequestOptions<Board> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}`,
     method: 'GET',
     schema: BoardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /** Deletes the board. Admin without the view permission can still remove the board. */
-export async function deleteBoard(client: Client, parameters: DeleteBoard): Promise<void> {
+export async function deleteBoard(client: Client, parameters: DeleteBoard, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -175,6 +188,7 @@ export async function deleteBoard(client: Client, parameters: DeleteBoard): Prom
 export async function getIssuesForBacklog(
   client: Client,
   parameters: GetIssuesForBacklog,
+  options?: RequestOptions,
 ): Promise<SoftwareIssueResults> {
   const config: SendRequestOptions<SoftwareIssueResults> = {
     url: `/rest/software/1.0/board/${parameters.boardId}/backlog`,
@@ -189,6 +203,7 @@ export async function getIssuesForBacklog(
       expand: parameters.expand,
     },
     schema: SoftwareIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -204,6 +219,7 @@ export async function getIssuesForBacklog(
 export async function getApproximateIssueCountForBacklog(
   client: Client,
   parameters: GetApproximateIssueCountForBacklog,
+  options?: RequestOptions,
 ): Promise<IssueCount> {
   const config: SendRequestOptions<IssueCount> = {
     url: `/rest/software/1.0/board/${parameters.boardId}/backlog/approximate-count`,
@@ -212,6 +228,7 @@ export async function getApproximateIssueCountForBacklog(
       jql: parameters.jql,
     },
     schema: IssueCountSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -240,11 +257,13 @@ export async function getApproximateIssueCountForBacklog(
 export async function getConfiguration(
   client: Client,
   parameters: GetConfigurationParameters,
+  options?: RequestOptions,
 ): Promise<GetConfiguration> {
   const config: SendRequestOptions<GetConfiguration> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/configuration`,
     method: 'GET',
     schema: GetConfigurationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -254,7 +273,11 @@ export async function getConfiguration(
  * Returns all epics from the board, for the given board ID. This only includes epics that the user has permission to
  * view. Note, if the user does not have permission to view the board, no epics will be returned at all.
  */
-export async function getEpics(client: Client, parameters: GetEpicsParameters): Promise<GetEpics> {
+export async function getEpics(
+  client: Client,
+  parameters: GetEpicsParameters,
+  options?: RequestOptions,
+): Promise<GetEpics> {
   const config: SendRequestOptions<GetEpics> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/epic`,
     method: 'GET',
@@ -264,6 +287,7 @@ export async function getEpics(client: Client, parameters: GetEpicsParameters): 
       done: parameters.done,
     },
     schema: GetEpicsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -279,6 +303,7 @@ export async function getEpics(client: Client, parameters: GetEpicsParameters): 
 export async function getIssuesWithoutEpicForBoard(
   client: Client,
   parameters: GetIssuesWithoutEpicForBoard,
+  options?: RequestOptions,
 ): Promise<SoftwareIssueResults> {
   const config: SendRequestOptions<SoftwareIssueResults> = {
     url: `/rest/software/1.0/board/${parameters.boardId}/epic/none/issue`,
@@ -293,6 +318,7 @@ export async function getIssuesWithoutEpicForBoard(
       expand: parameters.expand,
     },
     schema: SoftwareIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -308,6 +334,7 @@ export async function getIssuesWithoutEpicForBoard(
 export async function getBoardIssuesForEpic(
   client: Client,
   parameters: GetBoardIssuesForEpic,
+  options?: RequestOptions,
 ): Promise<SoftwareIssueResults> {
   const config: SendRequestOptions<SoftwareIssueResults> = {
     url: `/rest/software/1.0/board/${parameters.boardId}/epic/${parameters.epicId}/issue`,
@@ -322,6 +349,7 @@ export async function getBoardIssuesForEpic(
       expand: parameters.expand,
     },
     schema: SoftwareIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -330,22 +358,29 @@ export async function getBoardIssuesForEpic(
 export async function getFeaturesForBoard(
   client: Client,
   parameters: GetFeaturesForBoardParameters,
+  options?: RequestOptions,
 ): Promise<GetFeaturesForBoard> {
   const config: SendRequestOptions<GetFeaturesForBoard> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/features`,
     method: 'GET',
     schema: GetFeaturesForBoardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
-export async function toggleFeatures(client: Client, parameters: ToggleFeaturesParameters): Promise<ToggleFeatures> {
+export async function toggleFeatures(
+  client: Client,
+  parameters: ToggleFeaturesParameters,
+  options?: RequestOptions,
+): Promise<ToggleFeatures> {
   const config: SendRequestOptions<ToggleFeatures> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/features`,
     method: 'PUT',
     body: parameters.body,
     schema: ToggleFeaturesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -356,7 +391,11 @@ export async function toggleFeatures(client: Client, parameters: ToggleFeaturesP
  * moves an issue(s) onto a board from the backlog (by adding it to the issueList for the board) Or transitions the
  * issue(s) to the first column for a kanban board with backlog. At most 50 issues may be moved at once.
  */
-export async function moveIssuesToBoard(client: Client, parameters: MoveIssuesToBoard): Promise<void> {
+export async function moveIssuesToBoard(
+  client: Client,
+  parameters: MoveIssuesToBoard,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/issue`,
     method: 'POST',
@@ -366,6 +405,7 @@ export async function moveIssuesToBoard(client: Client, parameters: MoveIssuesTo
       rankBeforeIssue: parameters.rankBeforeIssue,
       rankCustomFieldId: parameters.rankCustomFieldId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -379,7 +419,11 @@ export async function moveIssuesToBoard(client: Client, parameters: MoveIssuesTo
  * Software project fields, like sprint, closedSprints, flagged, and epic. By default, the returned issues are ordered
  * by rank.
  */
-export async function getIssuesForBoard(client: Client, parameters: GetIssuesForBoard): Promise<SoftwareIssueResults> {
+export async function getIssuesForBoard(
+  client: Client,
+  parameters: GetIssuesForBoard,
+  options?: RequestOptions,
+): Promise<SoftwareIssueResults> {
   const config: SendRequestOptions<SoftwareIssueResults> = {
     url: `/rest/software/1.0/board/${parameters.boardId}/issue`,
     method: 'GET',
@@ -393,6 +437,7 @@ export async function getIssuesForBoard(client: Client, parameters: GetIssuesFor
       expand: parameters.expand,
     },
     schema: SoftwareIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -408,6 +453,7 @@ export async function getIssuesForBoard(client: Client, parameters: GetIssuesFor
 export async function getApproximateIssueCountForBoard(
   client: Client,
   parameters: GetApproximateIssueCountForBoard,
+  options?: RequestOptions,
 ): Promise<IssueCount> {
   const config: SendRequestOptions<IssueCount> = {
     url: `/rest/software/1.0/board/${parameters.boardId}/issue/approximate-count`,
@@ -416,6 +462,7 @@ export async function getApproximateIssueCountForBoard(
       jql: parameters.jql,
     },
     schema: IssueCountSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -436,7 +483,11 @@ export async function getApproximateIssueCountForBoard(
  * An issue belongs to the board if its status is mapped to the board's column. Epic issues do not belongs to the scrum
  * boards.
  */
-export async function getProjects(client: Client, parameters: GetProjectsParameters): Promise<GetProjects> {
+export async function getProjects(
+  client: Client,
+  parameters: GetProjectsParameters,
+  options?: RequestOptions,
+): Promise<GetProjects> {
   const config: SendRequestOptions<GetProjects> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/project`,
     method: 'GET',
@@ -445,6 +496,7 @@ export async function getProjects(client: Client, parameters: GetProjectsParamet
       maxResults: parameters.maxResults,
     },
     schema: GetProjectsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -461,11 +513,16 @@ export async function getProjects(client: Client, parameters: GetProjectsParamet
  * reference to ABC and BCD projects but query `project in (ABC, BCD) OR reporter = admin` doesn't have reference to any
  * project.
  */
-export async function getProjectsFull(client: Client, parameters: GetProjectsFullParameters): Promise<GetProjectsFull> {
+export async function getProjectsFull(
+  client: Client,
+  parameters: GetProjectsFullParameters,
+  options?: RequestOptions,
+): Promise<GetProjectsFull> {
   const config: SendRequestOptions<GetProjectsFull> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/project/full`,
     method: 'GET',
     schema: GetProjectsFullSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -475,11 +532,16 @@ export async function getProjectsFull(client: Client, parameters: GetProjectsFul
  * Returns the keys of all properties for the board identified by the id. The user who retrieves the property keys is
  * required to have permissions to view the board.
  */
-export async function getBoardPropertyKeys(client: Client, parameters: GetBoardPropertyKeys): Promise<PropertyKeys> {
+export async function getBoardPropertyKeys(
+  client: Client,
+  parameters: GetBoardPropertyKeys,
+  options?: RequestOptions,
+): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -489,11 +551,16 @@ export async function getBoardPropertyKeys(client: Client, parameters: GetBoardP
  * Returns the value of the property with a given key from the board identified by the provided id. The user who
  * retrieves the property is required to have permissions to view the board.
  */
-export async function getBoardProperty(client: Client, parameters: GetBoardProperty): Promise<EntityProperty> {
+export async function getBoardProperty(
+  client: Client,
+  parameters: GetBoardProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -505,11 +572,16 @@ export async function getBoardProperty(client: Client, parameters: GetBoardPrope
  * You can use this resource to store a custom data against the board identified by the id. The user who stores the data
  * is required to have permissions to modify the board.
  */
-export async function setBoardProperty(client: Client, parameters: SetBoardProperty): Promise<void> {
+export async function setBoardProperty(
+  client: Client,
+  parameters: SetBoardProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.propertyValue,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -519,17 +591,26 @@ export async function setBoardProperty(client: Client, parameters: SetBoardPrope
  * Removes the property from the board identified by the id. Ths user removing the property is required to have
  * permissions to modify the board.
  */
-export async function deleteBoardProperty(client: Client, parameters: DeleteBoardProperty): Promise<void> {
+export async function deleteBoardProperty(
+  client: Client,
+  parameters: DeleteBoardProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /** Returns all quick filters from a board, for a given board ID. */
-export async function getAllQuickFilters(client: Client, parameters: GetAllQuickFilters): Promise<Page<QuickFilter>> {
+export async function getAllQuickFilters(
+  client: Client,
+  parameters: GetAllQuickFilters,
+  options?: RequestOptions,
+): Promise<Page<QuickFilter>> {
   const config: SendRequestOptions<Page<QuickFilter>> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/quickfilter`,
     method: 'GET',
@@ -538,6 +619,7 @@ export async function getAllQuickFilters(client: Client, parameters: GetAllQuick
       maxResults: parameters.maxResults,
     },
     schema: PageQuickFilterSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -547,11 +629,16 @@ export async function getAllQuickFilters(client: Client, parameters: GetAllQuick
  * Returns the quick filter for a given quick filter ID. The quick filter will only be returned if the user can view the
  * board that the quick filter belongs to.
  */
-export async function getQuickFilter(client: Client, parameters: GetQuickFilter): Promise<QuickFilter> {
+export async function getQuickFilter(
+  client: Client,
+  parameters: GetQuickFilter,
+  options?: RequestOptions,
+): Promise<QuickFilter> {
   const config: SendRequestOptions<QuickFilter> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/quickfilter/${parameters.quickFilterId}`,
     method: 'GET',
     schema: QuickFilterSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -560,11 +647,13 @@ export async function getQuickFilter(client: Client, parameters: GetQuickFilter)
 export async function getReportsForBoard(
   client: Client,
   parameters: GetReportsForBoardParameters,
+  options?: RequestOptions,
 ): Promise<GetReportsForBoard> {
   const config: SendRequestOptions<GetReportsForBoard> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/reports`,
     method: 'GET',
     schema: GetReportsForBoardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -574,7 +663,11 @@ export async function getReportsForBoard(
  * Returns all sprints from a board, for a given board ID. This only includes sprints that the user has permission to
  * view.
  */
-export async function getAllSprints(client: Client, parameters: GetAllSprintsParameters): Promise<GetAllSprints> {
+export async function getAllSprints(
+  client: Client,
+  parameters: GetAllSprintsParameters,
+  options?: RequestOptions,
+): Promise<GetAllSprints> {
   const config: SendRequestOptions<GetAllSprints> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/sprint`,
     method: 'GET',
@@ -584,6 +677,7 @@ export async function getAllSprints(client: Client, parameters: GetAllSprintsPar
       state: parameters.state,
     },
     schema: GetAllSprintsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -599,6 +693,7 @@ export async function getAllSprints(client: Client, parameters: GetAllSprintsPar
 export async function getBoardIssuesForSprint(
   client: Client,
   parameters: GetBoardIssuesForSprint,
+  options?: RequestOptions,
 ): Promise<SoftwareIssueResults> {
   const config: SendRequestOptions<SoftwareIssueResults> = {
     url: `/rest/software/1.0/board/${parameters.boardId}/sprint/${parameters.sprintId}/issue`,
@@ -613,6 +708,7 @@ export async function getBoardIssuesForSprint(
       expand: parameters.expand,
     },
     schema: SoftwareIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -623,7 +719,11 @@ export async function getBoardIssuesForSprint(
  * view. Note, if the user does not have permission to view the board, no versions will be returned at all. Returned
  * versions are ordered by the name of the project from which they belong and then by sequence defined by user.
  */
-export async function getAllVersions(client: Client, parameters: GetAllVersionsParameters): Promise<GetAllVersions> {
+export async function getAllVersions(
+  client: Client,
+  parameters: GetAllVersionsParameters,
+  options?: RequestOptions,
+): Promise<GetAllVersions> {
   const config: SendRequestOptions<GetAllVersions> = {
     url: `/rest/agile/1.0/board/${parameters.boardId}/version`,
     method: 'GET',
@@ -633,6 +733,7 @@ export async function getAllVersions(client: Client, parameters: GetAllVersionsP
       released: parameters.released,
     },
     schema: GetAllVersionsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/builds.ts
+++ b/src/agile/api/builds.ts
@@ -4,7 +4,7 @@ import type { SubmitBuilds as SubmitBuildsParameters } from '../parameters/submi
 import type { DeleteBuildsByProperty } from '../parameters/deleteBuildsByProperty';
 import type { GetBuildByKey as GetBuildByKeyParameters } from '../parameters/getBuildByKey';
 import type { DeleteBuildByKey } from '../parameters/deleteBuildByKey';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Update / insert builds data.
@@ -20,7 +20,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * In the case of multiple builds being submitted in one request, each is validated individually prior to submission.
  * Details of which build failed submission (if any) are available in the response object.
  */
-export async function submitBuilds(client: Client, parameters: SubmitBuildsParameters): Promise<SubmitBuilds> {
+export async function submitBuilds(
+  client: Client,
+  parameters: SubmitBuildsParameters,
+  options?: RequestOptions,
+): Promise<SubmitBuilds> {
   const config: SendRequestOptions<SubmitBuilds> = {
     url: '/rest/builds/0.1/bulk',
     method: 'POST',
@@ -30,6 +34,7 @@ export async function submitBuilds(client: Client, parameters: SubmitBuildsParam
       providerMetadata: parameters.providerMetadata,
     },
     schema: SubmitBuildsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -49,7 +54,11 @@ export async function submitBuilds(client: Client, parameters: SubmitBuildsParam
  * Deletion is performed asynchronously. The `getBuildByKey` operation can be used to confirm that data has been deleted
  * successfully (if needed).
  */
-export async function deleteBuildsByProperty(client: Client, parameters: DeleteBuildsByProperty): Promise<void> {
+export async function deleteBuildsByProperty(
+  client: Client,
+  parameters: DeleteBuildsByProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/builds/0.1/bulkByProperties',
     method: 'DELETE',
@@ -57,6 +66,7 @@ export async function deleteBuildsByProperty(client: Client, parameters: DeleteB
       accountId: parameters.accountId,
       repoId: parameters.repoId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -67,11 +77,16 @@ export async function deleteBuildsByProperty(client: Client, parameters: DeleteB
  *
  * The result will be what is currently stored, ignoring any pending updates or deletes.
  */
-export async function getBuildByKey(client: Client, parameters: GetBuildByKeyParameters): Promise<GetBuildByKey> {
+export async function getBuildByKey(
+  client: Client,
+  parameters: GetBuildByKeyParameters,
+  options?: RequestOptions,
+): Promise<GetBuildByKey> {
   const config: SendRequestOptions<GetBuildByKey> = {
     url: `/rest/builds/0.1/pipelines/${parameters.pipelineId}/builds/${parameters.buildNumber}`,
     method: 'GET',
     schema: GetBuildByKeySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -83,10 +98,15 @@ export async function getBuildByKey(client: Client, parameters: GetBuildByKeyPar
  * Deletion is performed asynchronously. The `getBuildByKey` operation can be used to confirm that data has been deleted
  * successfully (if needed).
  */
-export async function deleteBuildByKey(client: Client, parameters: DeleteBuildByKey): Promise<void> {
+export async function deleteBuildByKey(
+  client: Client,
+  parameters: DeleteBuildByKey,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/builds/0.1/pipelines/${parameters.pipelineId}/builds/${parameters.buildNumber}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/deployments.ts
+++ b/src/agile/api/deployments.ts
@@ -9,7 +9,7 @@ import type { DeleteDeploymentsByProperty } from '../parameters/deleteDeployment
 import type { GetDeploymentByKey as GetDeploymentByKeyParameters } from '../parameters/getDeploymentByKey';
 import type { DeleteDeploymentByKey } from '../parameters/deleteDeploymentByKey';
 import type { GetDeploymentGatingStatusByKey as GetDeploymentGatingStatusByKeyParameters } from '../parameters/getDeploymentGatingStatusByKey';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Update / insert deployment data.
@@ -28,6 +28,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function submitDeployments(
   client: Client,
   parameters: SubmitDeploymentsParameters,
+  options?: RequestOptions,
 ): Promise<SubmitDeployments> {
   const config: SendRequestOptions<SubmitDeployments> = {
     url: '/rest/deployments/0.1/bulk',
@@ -38,6 +39,7 @@ export async function submitDeployments(
       providerMetadata: parameters.providerMetadata,
     },
     schema: SubmitDeploymentsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -59,6 +61,7 @@ export async function submitDeployments(
 export async function deleteDeploymentsByProperty(
   client: Client,
   parameters: DeleteDeploymentsByProperty,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/deployments/0.1/bulkByProperties',
@@ -67,6 +70,7 @@ export async function deleteDeploymentsByProperty(
       accountId: parameters.accountId,
       createdBy: parameters.createdBy,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -81,11 +85,13 @@ export async function deleteDeploymentsByProperty(
 export async function getDeploymentByKey(
   client: Client,
   parameters: GetDeploymentByKeyParameters,
+  options?: RequestOptions,
 ): Promise<GetDeploymentByKey> {
   const config: SendRequestOptions<GetDeploymentByKey> = {
     url: `/rest/deployments/0.1/pipelines/${parameters.pipelineId}/environments/${parameters.environmentId}/deployments/${parameters.deploymentSequenceNumber}`,
     method: 'GET',
     schema: GetDeploymentByKeySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -98,10 +104,15 @@ export async function getDeploymentByKey(
  * Deletion is performed asynchronously. The `getDeploymentByKey` operation can be used to confirm that data has been
  * deleted successfully (if needed).
  */
-export async function deleteDeploymentByKey(client: Client, parameters: DeleteDeploymentByKey): Promise<void> {
+export async function deleteDeploymentByKey(
+  client: Client,
+  parameters: DeleteDeploymentByKey,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/deployments/0.1/pipelines/${parameters.pipelineId}/environments/${parameters.environmentId}/deployments/${parameters.deploymentSequenceNumber}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -115,11 +126,13 @@ export async function deleteDeploymentByKey(client: Client, parameters: DeleteDe
 export async function getDeploymentGatingStatusByKey(
   client: Client,
   parameters: GetDeploymentGatingStatusByKeyParameters,
+  options?: RequestOptions,
 ): Promise<GetDeploymentGatingStatusByKey> {
   const config: SendRequestOptions<GetDeploymentGatingStatusByKey> = {
     url: `/rest/deployments/0.1/pipelines/${parameters.pipelineId}/environments/${parameters.environmentId}/deployments/${parameters.deploymentSequenceNumber}/gating-status`,
     method: 'GET',
     schema: GetDeploymentGatingStatusByKeySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/developmentInformation.ts
+++ b/src/agile/api/developmentInformation.ts
@@ -10,7 +10,7 @@ import type { DeleteRepository } from '../parameters/deleteRepository';
 import type { DeleteByProperties } from '../parameters/deleteByProperties';
 import type { ExistsByProperties as ExistsByPropertiesParameters } from '../parameters/existsByProperties';
 import type { DeleteEntity } from '../parameters/deleteEntity';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Stores development information provided in the request to make it available when viewing issues in Jira. Existing
@@ -22,6 +22,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function storeDevelopmentInformation(
   client: Client,
   parameters: StoreDevelopmentInformationParameters,
+  options?: RequestOptions,
 ): Promise<StoreDevelopmentInformation> {
   const config: SendRequestOptions<StoreDevelopmentInformation> = {
     url: '/rest/devinfo/0.10/bulk',
@@ -34,6 +35,7 @@ export async function storeDevelopmentInformation(
       providerMetadata: parameters.providerMetadata,
     },
     schema: StoreDevelopmentInformationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -43,11 +45,16 @@ export async function storeDevelopmentInformation(
  * For the specified repository ID, retrieves the repository and the most recent 400 development information entities.
  * The result will be what is currently stored, ignoring any pending updates or deletes.
  */
-export async function getRepository(client: Client, parameters: GetRepositoryParameters): Promise<GetRepository> {
+export async function getRepository(
+  client: Client,
+  parameters: GetRepositoryParameters,
+  options?: RequestOptions,
+): Promise<GetRepository> {
   const config: SendRequestOptions<GetRepository> = {
     url: `/rest/devinfo/0.10/repository/${parameters.repositoryId}`,
     method: 'GET',
     schema: GetRepositorySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -57,13 +64,18 @@ export async function getRepository(client: Client, parameters: GetRepositoryPar
  * Deletes the repository data stored by the given ID and all related development information entities. Deletion is
  * performed asynchronously.
  */
-export async function deleteRepository(client: Client, parameters: DeleteRepository): Promise<void> {
+export async function deleteRepository(
+  client: Client,
+  parameters: DeleteRepository,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/devinfo/0.10/repository/${parameters.repositoryId}`,
     method: 'DELETE',
     searchParams: {
       _updateSequenceId: parameters.updateSequenceId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -77,13 +89,18 @@ export async function deleteRepository(client: Client, parameters: DeleteReposit
  * Optional param `_updateSequenceId` is no longer supported. Deletion is performed asynchronously: specified entities
  * will eventually be removed from Jira.
  */
-export async function deleteByProperties(client: Client, parameters: DeleteByProperties): Promise<void> {
+export async function deleteByProperties(
+  client: Client,
+  parameters: DeleteByProperties,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/devinfo/0.10/bulkByProperties',
     method: 'DELETE',
     searchParams: {
       _updateSequenceId: parameters.updateSequenceId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -99,6 +116,7 @@ export async function deleteByProperties(client: Client, parameters: DeleteByPro
 export async function existsByProperties(
   client: Client,
   parameters?: ExistsByPropertiesParameters,
+  options?: RequestOptions,
 ): Promise<ExistsByProperties> {
   const config: SendRequestOptions<ExistsByProperties> = {
     url: '/rest/devinfo/0.10/existsByProperties',
@@ -107,19 +125,21 @@ export async function existsByProperties(
       _updateSequenceId: parameters?.updateSequenceId,
     },
     schema: ExistsByPropertiesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /** Deletes particular development information entity. Deletion is performed asynchronously. */
-export async function deleteEntity(client: Client, parameters: DeleteEntity): Promise<void> {
+export async function deleteEntity(client: Client, parameters: DeleteEntity, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/devinfo/0.10/repository/${parameters.repositoryId}/${parameters.entityType}/${parameters.entityId}`,
     method: 'DELETE',
     searchParams: {
       _updateSequenceId: parameters.updateSequenceId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/devopsComponents.ts
+++ b/src/agile/api/devopsComponents.ts
@@ -4,7 +4,7 @@ import type { SubmitComponents as SubmitComponentsParameters } from '../paramete
 import type { DeleteComponentsByProperty } from '../parameters/deleteComponentsByProperty';
 import type { GetComponentById as GetComponentByIdParameters } from '../parameters/getComponentById';
 import type { DeleteComponentById } from '../parameters/deleteComponentById';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Update / insert DevOps Component data.
@@ -27,6 +27,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function submitComponents(
   client: Client,
   parameters: SubmitComponentsParameters,
+  options?: RequestOptions,
 ): Promise<SubmitComponents> {
   const config: SendRequestOptions<SubmitComponents> = {
     url: '/rest/devopscomponents/1.0/bulk',
@@ -37,6 +38,7 @@ export async function submitComponents(
       providerMetadata: parameters.providerMetadata,
     },
     schema: SubmitComponentsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -60,6 +62,7 @@ export async function submitComponents(
 export async function deleteComponentsByProperty(
   client: Client,
   parameters: DeleteComponentsByProperty,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/devopscomponents/1.0/bulkByProperties',
@@ -68,6 +71,7 @@ export async function deleteComponentsByProperty(
       accountId: parameters.accountId,
       createdBy: parameters.createdBy,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -84,11 +88,13 @@ export async function deleteComponentsByProperty(
 export async function getComponentById(
   client: Client,
   parameters: GetComponentByIdParameters,
+  options?: RequestOptions,
 ): Promise<GetComponentById> {
   const config: SendRequestOptions<GetComponentById> = {
     url: `/rest/devopscomponents/1.0/devopscomponents/${parameters.componentId}`,
     method: 'GET',
     schema: GetComponentByIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -103,10 +109,15 @@ export async function getComponentById(
  * Only Connect apps that define the `jiraDevOpsComponentProvider` module can access this resource. This resource
  * requires the 'DELETE' scope for Connect apps.
  */
-export async function deleteComponentById(client: Client, parameters: DeleteComponentById): Promise<void> {
+export async function deleteComponentById(
+  client: Client,
+  parameters: DeleteComponentById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/devopscomponents/1.0/devopscomponents/${parameters.componentId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/epic.ts
+++ b/src/agile/api/epic.ts
@@ -7,20 +7,25 @@ import type { PartiallyUpdateEpic } from '../parameters/partiallyUpdateEpic';
 import type { MoveIssuesToEpic } from '../parameters/moveIssuesToEpic';
 import type { GetIssuesForEpic } from '../parameters/getIssuesForEpic';
 import type { RankEpics } from '../parameters/rankEpics';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Removes issues from epics. The user needs to have the edit issue permission for all issue they want to remove from
  * epics. The maximum number of issues that can be moved in one operation is 50. **Note:** This operation does not work
  * for epics in next-gen projects. Instead, update the issue using `{ fields: { parent: {} } }`
  */
-export async function removeIssuesFromEpic(client: Client, parameters: RemoveIssuesFromEpic): Promise<void> {
+export async function removeIssuesFromEpic(
+  client: Client,
+  parameters: RemoveIssuesFromEpic,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/agile/1.0/epic/none/issue',
     method: 'POST',
     body: {
       issues: parameters.issues,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -40,6 +45,7 @@ export async function removeIssuesFromEpic(client: Client, parameters: RemoveIss
 export async function getIssuesWithoutEpic(
   client: Client,
   parameters?: GetIssuesWithoutEpic,
+  options?: RequestOptions,
 ): Promise<SoftwareIssueResults> {
   const config: SendRequestOptions<SoftwareIssueResults> = {
     url: '/rest/software/1.0/epic/none/issue',
@@ -54,6 +60,7 @@ export async function getIssuesWithoutEpic(
       expand: parameters?.expand,
     },
     schema: SoftwareIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -63,11 +70,12 @@ export async function getIssuesWithoutEpic(
  * Returns the epic for a given epic ID. This epic will only be returned if the user has permission to view it.
  * **Note:** This operation does not work for epics in next-gen projects.
  */
-export async function getEpic(client: Client, parameters: GetEpic): Promise<Epic> {
+export async function getEpic(client: Client, parameters: GetEpic, options?: RequestOptions): Promise<Epic> {
   const config: SendRequestOptions<Epic> = {
     url: `/rest/agile/1.0/epic/${parameters.epicIdOrKey}`,
     method: 'GET',
     schema: EpicSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -78,7 +86,11 @@ export async function getEpic(client: Client, parameters: GetEpic): Promise<Epic
  * updated. Valid values for color are `color_1` to `color_9`. **Note:** This operation does not work for epics in
  * next-gen projects.
  */
-export async function partiallyUpdateEpic(client: Client, parameters: PartiallyUpdateEpic): Promise<Epic> {
+export async function partiallyUpdateEpic(
+  client: Client,
+  parameters: PartiallyUpdateEpic,
+  options?: RequestOptions,
+): Promise<Epic> {
   const config: SendRequestOptions<Epic> = {
     url: `/rest/agile/1.0/epic/${parameters.epicIdOrKey}`,
     method: 'POST',
@@ -89,6 +101,7 @@ export async function partiallyUpdateEpic(client: Client, parameters: PartiallyU
       summary: parameters.summary,
     },
     schema: EpicSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -100,13 +113,18 @@ export async function partiallyUpdateEpic(client: Client, parameters: PartiallyU
  * edit issue permission for all issue they want to move and to the epic. The maximum number of issues that can be moved
  * in one operation is 50. **Note:** This operation does not work for epics in next-gen projects.
  */
-export async function moveIssuesToEpic(client: Client, parameters: MoveIssuesToEpic): Promise<void> {
+export async function moveIssuesToEpic(
+  client: Client,
+  parameters: MoveIssuesToEpic,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/epic/${parameters.epicIdOrKey}/issue`,
     method: 'POST',
     body: {
       issues: parameters.issues,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -123,7 +141,11 @@ export async function moveIssuesToEpic(client: Client, parameters: MoveIssuesToE
  * `parent` JQL field, see [Advanced
  * searching](https://confluence.atlassian.com/x/dAiiLQ#Advancedsearching-fieldsreference-Parent).
  */
-export async function getIssuesForEpic(client: Client, parameters: GetIssuesForEpic): Promise<SoftwareIssueResults> {
+export async function getIssuesForEpic(
+  client: Client,
+  parameters: GetIssuesForEpic,
+  options?: RequestOptions,
+): Promise<SoftwareIssueResults> {
   const config: SendRequestOptions<SoftwareIssueResults> = {
     url: `/rest/software/1.0/epic/${parameters.epicIdOrKey}/issue`,
     method: 'GET',
@@ -137,6 +159,7 @@ export async function getIssuesForEpic(client: Client, parameters: GetIssuesForE
       expand: parameters.expand,
     },
     schema: SoftwareIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -149,7 +172,7 @@ export async function getIssuesForEpic(client: Client, parameters: GetIssuesForE
  *
  * **Note:** This operation does not work for epics in next-gen projects.
  */
-export async function rankEpics(client: Client, parameters: RankEpics): Promise<void> {
+export async function rankEpics(client: Client, parameters: RankEpics, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/epic/${parameters.epicIdOrKey}/rank`,
     method: 'PUT',
@@ -158,6 +181,7 @@ export async function rankEpics(client: Client, parameters: RankEpics): Promise<
       rankBeforeEpic: parameters.rankBeforeEpic,
       rankCustomFieldId: parameters.rankCustomFieldId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/featureFlags.ts
+++ b/src/agile/api/featureFlags.ts
@@ -4,7 +4,7 @@ import type { SubmitFeatureFlags as SubmitFeatureFlagsParameters } from '../para
 import type { DeleteFeatureFlagsByProperty } from '../parameters/deleteFeatureFlagsByProperty';
 import type { GetFeatureFlagById as GetFeatureFlagByIdParameters } from '../parameters/getFeatureFlagById';
 import type { DeleteFeatureFlagById } from '../parameters/deleteFeatureFlagById';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Update / insert Feature Flag data.
@@ -22,6 +22,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function submitFeatureFlags(
   client: Client,
   parameters: SubmitFeatureFlagsParameters,
+  options?: RequestOptions,
 ): Promise<SubmitFeatureFlags> {
   const config: SendRequestOptions<SubmitFeatureFlags> = {
     url: '/rest/featureflags/0.1/bulk',
@@ -32,6 +33,7 @@ export async function submitFeatureFlags(
       providerMetadata: parameters.providerMetadata,
     },
     schema: SubmitFeatureFlagsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -52,6 +54,7 @@ export async function submitFeatureFlags(
 export async function deleteFeatureFlagsByProperty(
   client: Client,
   parameters: DeleteFeatureFlagsByProperty,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/featureflags/0.1/bulkByProperties',
@@ -60,6 +63,7 @@ export async function deleteFeatureFlagsByProperty(
       accountId: parameters.accountId,
       createdBy: parameters.createdBy,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -73,11 +77,13 @@ export async function deleteFeatureFlagsByProperty(
 export async function getFeatureFlagById(
   client: Client,
   parameters: GetFeatureFlagByIdParameters,
+  options?: RequestOptions,
 ): Promise<GetFeatureFlagById> {
   const config: SendRequestOptions<GetFeatureFlagById> = {
     url: `/rest/featureflags/0.1/flag/${parameters.featureFlagId}`,
     method: 'GET',
     schema: GetFeatureFlagByIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -89,10 +95,15 @@ export async function getFeatureFlagById(
  * Deletion is performed asynchronously. The getFeatureFlagById operation can be used to confirm that data has been
  * deleted successfully (if needed).
  */
-export async function deleteFeatureFlagById(client: Client, parameters: DeleteFeatureFlagById): Promise<void> {
+export async function deleteFeatureFlagById(
+  client: Client,
+  parameters: DeleteFeatureFlagById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/featureflags/0.1/flag/${parameters.featureFlagId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/issue.ts
+++ b/src/agile/api/issue.ts
@@ -8,7 +8,7 @@ import type { RankIssues } from '../parameters/rankIssues';
 import type { GetIssue } from '../parameters/getIssue';
 import type { GetIssueEstimationForBoard as GetIssueEstimationForBoardParameters } from '../parameters/getIssueEstimationForBoard';
 import type { EstimateIssueForBoard as EstimateIssueForBoardParameters } from '../parameters/estimateIssueForBoard';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Moves (ranks) issues before or after a given issue. At most 50 issues may be ranked at once.
@@ -18,7 +18,7 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * If rankCustomFieldId is not defined, the default rank field will be used.
  */
-export async function rankIssues(client: Client, parameters: RankIssues): Promise<void> {
+export async function rankIssues(client: Client, parameters: RankIssues, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/agile/1.0/issue/rank',
     method: 'PUT',
@@ -28,6 +28,7 @@ export async function rankIssues(client: Client, parameters: RankIssues): Promis
       rankBeforeIssue: parameters.rankBeforeIssue,
       rankCustomFieldId: parameters.rankCustomFieldId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -37,7 +38,7 @@ export async function rankIssues(client: Client, parameters: RankIssues): Promis
  * Returns a single issue, for a given issue ID or issue key. Issues returned from this resource include Agile fields,
  * like sprint, closedSprints, flagged, and epic.
  */
-export async function getIssue(client: Client, parameters: GetIssue): Promise<Issue> {
+export async function getIssue(client: Client, parameters: GetIssue, options?: RequestOptions): Promise<Issue> {
   const config: SendRequestOptions<Issue> = {
     url: `/rest/agile/1.0/issue/${parameters.issueIdOrKey}`,
     method: 'GET',
@@ -47,6 +48,7 @@ export async function getIssue(client: Client, parameters: GetIssue): Promise<Is
       updateHistory: parameters.updateHistory,
     },
     schema: IssueSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -67,6 +69,7 @@ export async function getIssue(client: Client, parameters: GetIssue): Promise<Is
 export async function getIssueEstimationForBoard(
   client: Client,
   parameters: GetIssueEstimationForBoardParameters,
+  options?: RequestOptions,
 ): Promise<GetIssueEstimationForBoard> {
   const config: SendRequestOptions<GetIssueEstimationForBoard> = {
     url: `/rest/agile/1.0/issue/${parameters.issueIdOrKey}/estimation`,
@@ -75,6 +78,7 @@ export async function getIssueEstimationForBoard(
       boardId: parameters.boardId,
     },
     schema: GetIssueEstimationForBoardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -98,6 +102,7 @@ export async function getIssueEstimationForBoard(
 export async function estimateIssueForBoard(
   client: Client,
   parameters: EstimateIssueForBoardParameters,
+  options?: RequestOptions,
 ): Promise<EstimateIssueForBoard> {
   const config: SendRequestOptions<EstimateIssueForBoard> = {
     url: `/rest/agile/1.0/issue/${parameters.issueIdOrKey}/estimation`,
@@ -109,6 +114,7 @@ export async function estimateIssueForBoard(
       value: parameters.value,
     },
     schema: EstimateIssueForBoardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/operations.ts
+++ b/src/agile/api/operations.ts
@@ -15,7 +15,7 @@ import type { GetIncidentById as GetIncidentByIdParameters } from '../parameters
 import type { DeleteIncidentById } from '../parameters/deleteIncidentById';
 import type { GetReviewById as GetReviewByIdParameters } from '../parameters/getReviewById';
 import type { DeleteReviewById } from '../parameters/deleteReviewById';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Insert Operations Workspace IDs to establish a relationship between them and the Jira site the app is installed in.
@@ -28,6 +28,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function submitOperationsWorkspaces(
   client: Client,
   parameters: SubmitOperationsWorkspacesParameters,
+  options?: RequestOptions,
 ): Promise<SubmitOperationsWorkspaces> {
   const config: SendRequestOptions<SubmitOperationsWorkspaces> = {
     url: '/rest/operations/1.0/linkedWorkspaces/bulk',
@@ -36,6 +37,7 @@ export async function submitOperationsWorkspaces(
       workspaceIds: parameters.workspaceIds,
     },
     schema: SubmitOperationsWorkspacesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -49,13 +51,18 @@ export async function submitOperationsWorkspaces(
  *
  * E.g. DELETE /bulk?workspaceIds=111-222-333,444-555-666
  */
-export async function deleteWorkspaces(client: Client, parameters: DeleteWorkspaces): Promise<void> {
+export async function deleteWorkspaces(
+  client: Client,
+  parameters: DeleteWorkspaces,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/operations/1.0/linkedWorkspaces/bulk',
     method: 'DELETE',
     searchParams: {
       workspaceIds: parameters.workspaceIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -72,7 +79,11 @@ export async function deleteWorkspaces(client: Client, parameters: DeleteWorkspa
  * Only Connect apps that define the `jiraOperationsInfoProvider` module can access this resource. This resource
  * requires the 'READ' scope for Connect apps.
  */
-export async function getWorkspaces(client: Client, parameters?: GetWorkspacesParameters): Promise<GetWorkspaces> {
+export async function getWorkspaces(
+  client: Client,
+  parameters?: GetWorkspacesParameters,
+  options?: RequestOptions,
+): Promise<GetWorkspaces> {
   const config: SendRequestOptions<GetWorkspaces> = {
     url: '/rest/operations/1.0/linkedWorkspaces',
     method: 'GET',
@@ -80,6 +91,7 @@ export async function getWorkspaces(client: Client, parameters?: GetWorkspacesPa
       workspaceId: parameters?.workspaceId,
     },
     schema: GetWorkspacesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -104,12 +116,17 @@ export async function getWorkspaces(client: Client, parameters?: GetWorkspacesPa
  * Only Connect apps that define the `jiraOperationsInfoProvider` module can access this resource. This resource
  * requires the 'WRITE' scope for Connect apps.
  */
-export async function submitEntity(client: Client, parameters: SubmitEntityParameters): Promise<SubmitEntity> {
+export async function submitEntity(
+  client: Client,
+  parameters: SubmitEntityParameters,
+  options?: RequestOptions,
+): Promise<SubmitEntity> {
   const config: SendRequestOptions<SubmitEntity> = {
     url: '/rest/operations/1.0/bulk',
     method: 'POST',
     body: parameters.body,
     schema: SubmitEntitySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -130,7 +147,11 @@ export async function submitEntity(client: Client, parameters: SubmitEntityParam
  * Only Connect apps that define the `jiraOperationsInfoProvider` module can access this resource. This resource
  * requires the 'DELETE' scope for Connect apps.
  */
-export async function deleteEntityByProperty(client: Client, parameters: DeleteEntityByProperty): Promise<void> {
+export async function deleteEntityByProperty(
+  client: Client,
+  parameters: DeleteEntityByProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/operations/1.0/bulkByProperties',
     method: 'DELETE',
@@ -138,6 +159,7 @@ export async function deleteEntityByProperty(client: Client, parameters: DeleteE
       accountId: parameters.accountId,
       createdBy: parameters.createdBy,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -151,11 +173,16 @@ export async function deleteEntityByProperty(client: Client, parameters: DeleteE
  * Only Connect apps that define the `jiraOperationsInfoProvider` module can access this resource. This resource
  * requires the 'READ' scope for Connect apps.
  */
-export async function getIncidentById(client: Client, parameters: GetIncidentByIdParameters): Promise<GetIncidentById> {
+export async function getIncidentById(
+  client: Client,
+  parameters: GetIncidentByIdParameters,
+  options?: RequestOptions,
+): Promise<GetIncidentById> {
   const config: SendRequestOptions<GetIncidentById> = {
     url: `/rest/operations/1.0/incidents/${parameters.incidentId}`,
     method: 'GET',
     schema: GetIncidentByIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -170,10 +197,15 @@ export async function getIncidentById(client: Client, parameters: GetIncidentByI
  * Only Connect apps that define the `jiraOperationsInfoProvider` module can access this resource. This resource
  * requires the 'DELETE' scope for Connect apps.
  */
-export async function deleteIncidentById(client: Client, parameters: DeleteIncidentById): Promise<void> {
+export async function deleteIncidentById(
+  client: Client,
+  parameters: DeleteIncidentById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/operations/1.0/incidents/${parameters.incidentId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -187,11 +219,16 @@ export async function deleteIncidentById(client: Client, parameters: DeleteIncid
  * Only Connect apps that define the `jiraOperationsInfoProvider` module can access this resource. This resource
  * requires the 'READ' scope for Connect apps.
  */
-export async function getReviewById(client: Client, parameters: GetReviewByIdParameters): Promise<GetReviewById> {
+export async function getReviewById(
+  client: Client,
+  parameters: GetReviewByIdParameters,
+  options?: RequestOptions,
+): Promise<GetReviewById> {
   const config: SendRequestOptions<GetReviewById> = {
     url: `/rest/operations/1.0/post-incident-reviews/${parameters.reviewId}`,
     method: 'GET',
     schema: GetReviewByIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -206,10 +243,15 @@ export async function getReviewById(client: Client, parameters: GetReviewByIdPar
  * Only Connect apps that define the `jiraOperationsInfoProvider` module can access this resource. This resource
  * requires the 'DELETE' scope for Connect apps.
  */
-export async function deleteReviewById(client: Client, parameters: DeleteReviewById): Promise<void> {
+export async function deleteReviewById(
+  client: Client,
+  parameters: DeleteReviewById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/operations/1.0/post-incident-reviews/${parameters.reviewId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/remoteLinks.ts
+++ b/src/agile/api/remoteLinks.ts
@@ -4,7 +4,7 @@ import type { SubmitRemoteLinks as SubmitRemoteLinksParameters } from '../parame
 import type { DeleteRemoteLinksByProperty } from '../parameters/deleteRemoteLinksByProperty';
 import type { GetRemoteLinkById as GetRemoteLinkByIdParameters } from '../parameters/getRemoteLinkById';
 import type { DeleteRemoteLinkById } from '../parameters/deleteRemoteLinkById';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Update / insert Remote Link data.
@@ -22,6 +22,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function submitRemoteLinks(
   client: Client,
   parameters: SubmitRemoteLinksParameters,
+  options?: RequestOptions,
 ): Promise<SubmitRemoteLinks> {
   const config: SendRequestOptions<SubmitRemoteLinks> = {
     url: '/rest/remotelinks/1.0/bulk',
@@ -32,6 +33,7 @@ export async function submitRemoteLinks(
       providerMetadata: parameters.providerMetadata,
     },
     schema: SubmitRemoteLinksSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -54,6 +56,7 @@ export async function submitRemoteLinks(
 export async function deleteRemoteLinksByProperty(
   client: Client,
   parameters: DeleteRemoteLinksByProperty,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/remotelinks/1.0/bulkByProperties',
@@ -61,6 +64,7 @@ export async function deleteRemoteLinksByProperty(
     searchParams: {
       params: parameters.params,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -74,11 +78,13 @@ export async function deleteRemoteLinksByProperty(
 export async function getRemoteLinkById(
   client: Client,
   parameters: GetRemoteLinkByIdParameters,
+  options?: RequestOptions,
 ): Promise<GetRemoteLinkById> {
   const config: SendRequestOptions<GetRemoteLinkById> = {
     url: `/rest/remotelinks/1.0/remotelink/${parameters.remoteLinkId}`,
     method: 'GET',
     schema: GetRemoteLinkByIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -90,10 +96,15 @@ export async function getRemoteLinkById(
  * Deletion is performed asynchronously. The `getRemoteLinkById` operation can be used to confirm that data has been
  * deleted successfully (if needed).
  */
-export async function deleteRemoteLinkById(client: Client, parameters: DeleteRemoteLinkById): Promise<void> {
+export async function deleteRemoteLinkById(
+  client: Client,
+  parameters: DeleteRemoteLinkById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/remotelinks/1.0/remotelink/${parameters.remoteLinkId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/securityInformation.ts
+++ b/src/agile/api/securityInformation.ts
@@ -9,20 +9,25 @@ import type { SubmitVulnerabilities as SubmitVulnerabilitiesParameters } from '.
 import type { DeleteVulnerabilitiesByProperty } from '../parameters/deleteVulnerabilitiesByProperty';
 import type { GetVulnerabilityById as GetVulnerabilityByIdParameters } from '../parameters/getVulnerabilityById';
 import type { DeleteVulnerabilityById } from '../parameters/deleteVulnerabilityById';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Insert Security Workspace IDs to establish a relationship between them and the Jira site the app is installed on. If
  * a relationship between the workspace ID and Jira already exists then the workspace ID will be ignored and Jira will
  * process the rest of the entries.
  */
-export async function submitWorkspaces(client: Client, parameters: SubmitWorkspaces): Promise<void> {
+export async function submitWorkspaces(
+  client: Client,
+  parameters: SubmitWorkspaces,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/security/1.0/linkedWorkspaces/bulk',
     method: 'POST',
     body: {
       workspaceIds: parameters.workspaceIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -33,13 +38,18 @@ export async function submitWorkspaces(client: Client, parameters: SubmitWorkspa
  *
  * E.g. DELETE /bulk?workspaceIds=111-222-333,444-555-666
  */
-export async function deleteLinkedWorkspaces(client: Client, parameters: DeleteLinkedWorkspaces): Promise<void> {
+export async function deleteLinkedWorkspaces(
+  client: Client,
+  parameters: DeleteLinkedWorkspaces,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/security/1.0/linkedWorkspaces/bulk',
     method: 'DELETE',
     searchParams: {
       workspaceIds: parameters.workspaceIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -50,11 +60,12 @@ export async function deleteLinkedWorkspaces(client: Client, parameters: DeleteL
  *
  * The result will be what is currently stored, ignoring any pending updates or deletes.
  */
-export async function getLinkedWorkspaces(client: Client): Promise<GetLinkedWorkspaces> {
+export async function getLinkedWorkspaces(client: Client, options?: RequestOptions): Promise<GetLinkedWorkspaces> {
   const config: SendRequestOptions<GetLinkedWorkspaces> = {
     url: '/rest/security/1.0/linkedWorkspaces',
     method: 'GET',
     schema: GetLinkedWorkspacesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -68,11 +79,13 @@ export async function getLinkedWorkspaces(client: Client): Promise<GetLinkedWork
 export async function getLinkedWorkspaceById(
   client: Client,
   parameters: GetLinkedWorkspaceByIdParameters,
+  options?: RequestOptions,
 ): Promise<GetLinkedWorkspaceById> {
   const config: SendRequestOptions<GetLinkedWorkspaceById> = {
     url: `/rest/security/1.0/linkedWorkspaces/${parameters.workspaceId}`,
     method: 'GET',
     schema: GetLinkedWorkspaceByIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -96,6 +109,7 @@ export async function getLinkedWorkspaceById(
 export async function submitVulnerabilities(
   client: Client,
   parameters: SubmitVulnerabilitiesParameters,
+  options?: RequestOptions,
 ): Promise<SubmitVulnerabilities> {
   const config: SendRequestOptions<SubmitVulnerabilities> = {
     url: '/rest/security/1.0/bulk',
@@ -107,6 +121,7 @@ export async function submitVulnerabilities(
       providerMetadata: parameters.providerMetadata,
     },
     schema: SubmitVulnerabilitiesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -127,6 +142,7 @@ export async function submitVulnerabilities(
 export async function deleteVulnerabilitiesByProperty(
   client: Client,
   parameters: DeleteVulnerabilitiesByProperty,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/security/1.0/bulkByProperties',
@@ -135,6 +151,7 @@ export async function deleteVulnerabilitiesByProperty(
       accountId: parameters.accountId,
       createdBy: parameters.createdBy,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -148,11 +165,13 @@ export async function deleteVulnerabilitiesByProperty(
 export async function getVulnerabilityById(
   client: Client,
   parameters: GetVulnerabilityByIdParameters,
+  options?: RequestOptions,
 ): Promise<GetVulnerabilityById> {
   const config: SendRequestOptions<GetVulnerabilityById> = {
     url: `/rest/security/1.0/vulnerability/${parameters.vulnerabilityId}`,
     method: 'GET',
     schema: GetVulnerabilityByIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -164,10 +183,15 @@ export async function getVulnerabilityById(
  * Deletion is performed asynchronously. The GET vulnerability endpoint can be used to confirm that data has been
  * deleted successfully (if needed).
  */
-export async function deleteVulnerabilityById(client: Client, parameters: DeleteVulnerabilityById): Promise<void> {
+export async function deleteVulnerabilityById(
+  client: Client,
+  parameters: DeleteVulnerabilityById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/security/1.0/vulnerability/${parameters.vulnerabilityId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/api/sprint.ts
+++ b/src/agile/api/sprint.ts
@@ -14,7 +14,7 @@ import type { GetProperty } from '../parameters/getProperty';
 import type { SetProperty } from '../parameters/setProperty';
 import type { DeleteProperty } from '../parameters/deleteProperty';
 import type { SwapSprint } from '../parameters/swapSprint';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Creates a future sprint. Sprint name and origin board id are required. Start date, end date, and goal are optional.
@@ -22,7 +22,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * Note that the sprint name is trimmed. Also, when starting sprints from the UI, the "endDate" set through this call is
  * ignored and instead the last sprint's duration is used to fill the form.
  */
-export async function createSprint(client: Client, parameters: CreateSprint): Promise<Sprint> {
+export async function createSprint(
+  client: Client,
+  parameters: CreateSprint,
+  options?: RequestOptions,
+): Promise<Sprint> {
   const config: SendRequestOptions<Sprint> = {
     url: '/rest/agile/1.0/sprint',
     method: 'POST',
@@ -34,6 +38,7 @@ export async function createSprint(client: Client, parameters: CreateSprint): Pr
       startDate: parameters.startDate,
     },
     schema: SprintSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -43,11 +48,12 @@ export async function createSprint(client: Client, parameters: CreateSprint): Pr
  * Returns the sprint for a given sprint ID. The sprint will only be returned if the user can view the board that the
  * sprint was created on, or view at least one of the issues in the sprint.
  */
-export async function getSprint(client: Client, parameters: GetSprint): Promise<Sprint> {
+export async function getSprint(client: Client, parameters: GetSprint, options?: RequestOptions): Promise<Sprint> {
   const config: SendRequestOptions<Sprint> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}`,
     method: 'GET',
     schema: SprintSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -67,7 +73,11 @@ export async function getSprint(client: Client, parameters: GetSprint): Promise<
  * - Other changes to state are not allowed.
  * - The completeDate field cannot be updated manually.
  */
-export async function partiallyUpdateSprint(client: Client, parameters: PartiallyUpdateSprint): Promise<Sprint> {
+export async function partiallyUpdateSprint(
+  client: Client,
+  parameters: PartiallyUpdateSprint,
+  options?: RequestOptions,
+): Promise<Sprint> {
   const config: SendRequestOptions<Sprint> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}`,
     method: 'POST',
@@ -83,6 +93,7 @@ export async function partiallyUpdateSprint(client: Client, parameters: Partiall
       state: parameters.state,
     },
     schema: SprintSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -102,7 +113,11 @@ export async function partiallyUpdateSprint(client: Client, parameters: Partiall
  * - Other changes to state are not allowed.
  * - The completeDate field cannot be updated manually.
  */
-export async function updateSprint(client: Client, parameters: UpdateSprint): Promise<Sprint> {
+export async function updateSprint(
+  client: Client,
+  parameters: UpdateSprint,
+  options?: RequestOptions,
+): Promise<Sprint> {
   const config: SendRequestOptions<Sprint> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}`,
     method: 'PUT',
@@ -118,16 +133,18 @@ export async function updateSprint(client: Client, parameters: UpdateSprint): Pr
       state: parameters.state,
     },
     schema: SprintSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /** Deletes a sprint. Once a sprint is deleted, all open issues in the sprint will be moved to the backlog. */
-export async function deleteSprint(client: Client, parameters: DeleteSprint): Promise<void> {
+export async function deleteSprint(client: Client, parameters: DeleteSprint, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -137,7 +154,11 @@ export async function deleteSprint(client: Client, parameters: DeleteSprint): Pr
  * Moves issues to a sprint, for a given sprint ID. Issues can only be moved to open or active sprints. The maximum
  * number of issues that can be moved in one operation is 50.
  */
-export async function moveIssuesToSprintAndRank(client: Client, parameters: MoveIssuesToSprintAndRank): Promise<void> {
+export async function moveIssuesToSprintAndRank(
+  client: Client,
+  parameters: MoveIssuesToSprintAndRank,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}/issue`,
     method: 'POST',
@@ -147,6 +168,7 @@ export async function moveIssuesToSprintAndRank(client: Client, parameters: Move
       rankBeforeIssue: parameters.rankBeforeIssue,
       rankCustomFieldId: parameters.rankCustomFieldId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -161,6 +183,7 @@ export async function moveIssuesToSprintAndRank(client: Client, parameters: Move
 export async function getIssuesForSprint(
   client: Client,
   parameters: GetIssuesForSprint,
+  options?: RequestOptions,
 ): Promise<SoftwareIssueResults> {
   const config: SendRequestOptions<SoftwareIssueResults> = {
     url: `/rest/software/1.0/sprint/${parameters.sprintId}/issue`,
@@ -175,6 +198,7 @@ export async function getIssuesForSprint(
       expand: parameters.expand,
     },
     schema: SoftwareIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -184,11 +208,16 @@ export async function getIssuesForSprint(
  * Returns the keys of all properties for the sprint identified by the id. The user who retrieves the property keys is
  * required to have permissions to view the sprint.
  */
-export async function getPropertiesKeys(client: Client, parameters: GetPropertiesKeys): Promise<PropertyKeys> {
+export async function getPropertiesKeys(
+  client: Client,
+  parameters: GetPropertiesKeys,
+  options?: RequestOptions,
+): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -198,11 +227,16 @@ export async function getPropertiesKeys(client: Client, parameters: GetPropertie
  * Returns the value of the property with a given key from the sprint identified by the provided id. The user who
  * retrieves the property is required to have permissions to view the sprint.
  */
-export async function getProperty(client: Client, parameters: GetProperty): Promise<EntityProperty> {
+export async function getProperty(
+  client: Client,
+  parameters: GetProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -214,11 +248,12 @@ export async function getProperty(client: Client, parameters: GetProperty): Prom
  * You can use this resource to store a custom data against the sprint identified by the id. The user who stores the
  * data is required to have permissions to modify the sprint.
  */
-export async function setProperty(client: Client, parameters: SetProperty): Promise<void> {
+export async function setProperty(client: Client, parameters: SetProperty, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.propertyValue,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -228,23 +263,29 @@ export async function setProperty(client: Client, parameters: SetProperty): Prom
  * Removes the property from the sprint identified by the id. Ths user removing the property is required to have
  * permissions to modify the sprint.
  */
-export async function deleteProperty(client: Client, parameters: DeleteProperty): Promise<void> {
+export async function deleteProperty(
+  client: Client,
+  parameters: DeleteProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /** Swap the position of the sprint with the second sprint. */
-export async function swapSprint(client: Client, parameters: SwapSprint): Promise<void> {
+export async function swapSprint(client: Client, parameters: SwapSprint, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/agile/1.0/sprint/${parameters.sprintId}/swap`,
     method: 'POST',
     body: {
       sprintToSwapWith: parameters.sprintToSwapWith,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/agile/createAgileClient.ts
+++ b/src/agile/createAgileClient.ts
@@ -1,4 +1,4 @@
-import { type ClientConfig, type Client, createClient } from '#/core';
+import { type ClientConfig, type Client, type RequestOptions, createClient } from '#/core';
 import * as backlog from './api/backlog';
 import * as board from './api/board';
 import * as epic from './api/epic';
@@ -163,202 +163,271 @@ export function createAgileClient(clientConfig: ClientConfig | Client) {
 
   return {
     backlog: {
-      moveIssuesToBacklog: (parameters: MoveIssuesToBacklog): Promise<void> =>
-        backlog.moveIssuesToBacklog(client, parameters),
-      moveIssuesToBacklogForBoard: (parameters: MoveIssuesToBacklogForBoard): Promise<void> =>
-        backlog.moveIssuesToBacklogForBoard(client, parameters),
+      moveIssuesToBacklog: (parameters: MoveIssuesToBacklog, options?: RequestOptions): Promise<void> =>
+        backlog.moveIssuesToBacklog(client, parameters, options),
+      moveIssuesToBacklogForBoard: (parameters: MoveIssuesToBacklogForBoard, options?: RequestOptions): Promise<void> =>
+        backlog.moveIssuesToBacklogForBoard(client, parameters, options),
     },
     board: {
-      getAllBoards: (parameters?: GetAllBoards): Promise<Page<Board>> => board.getAllBoards(client, parameters),
-      createBoard: (parameters: CreateBoard): Promise<Board> => board.createBoard(client, parameters),
-      getBoardByFilterId: (parameters: GetBoardByFilterId): Promise<Page<BoardFilter>> =>
-        board.getBoardByFilterId(client, parameters),
-      getBoard: (parameters: GetBoard): Promise<Board> => board.getBoard(client, parameters),
-      deleteBoard: (parameters: DeleteBoard): Promise<void> => board.deleteBoard(client, parameters),
-      getIssuesForBacklog: (parameters: GetIssuesForBacklog): Promise<SoftwareIssueResults> =>
-        board.getIssuesForBacklog(client, parameters),
-      getApproximateIssueCountForBacklog: (parameters: GetApproximateIssueCountForBacklog): Promise<IssueCount> =>
-        board.getApproximateIssueCountForBacklog(client, parameters),
-      getConfiguration: (parameters: GetConfiguration): Promise<GetConfigurationModel> =>
-        board.getConfiguration(client, parameters),
-      getEpics: (parameters: GetEpics): Promise<GetEpicsModel> => board.getEpics(client, parameters),
-      getIssuesWithoutEpicForBoard: (parameters: GetIssuesWithoutEpicForBoard): Promise<SoftwareIssueResults> =>
-        board.getIssuesWithoutEpicForBoard(client, parameters),
-      getBoardIssuesForEpic: (parameters: GetBoardIssuesForEpic): Promise<SoftwareIssueResults> =>
-        board.getBoardIssuesForEpic(client, parameters),
-      getFeaturesForBoard: (parameters: GetFeaturesForBoard): Promise<GetFeaturesForBoardModel> =>
-        board.getFeaturesForBoard(client, parameters),
-      toggleFeatures: (parameters: ToggleFeatures): Promise<ToggleFeaturesModel> =>
-        board.toggleFeatures(client, parameters),
-      moveIssuesToBoard: (parameters: MoveIssuesToBoard): Promise<void> => board.moveIssuesToBoard(client, parameters),
-      getIssuesForBoard: (parameters: GetIssuesForBoard): Promise<SoftwareIssueResults> =>
-        board.getIssuesForBoard(client, parameters),
-      getApproximateIssueCountForBoard: (parameters: GetApproximateIssueCountForBoard): Promise<IssueCount> =>
-        board.getApproximateIssueCountForBoard(client, parameters),
-      getProjects: (parameters: GetProjects): Promise<GetProjectsModel> => board.getProjects(client, parameters),
-      getProjectsFull: (parameters: GetProjectsFull): Promise<GetProjectsFullModel> =>
-        board.getProjectsFull(client, parameters),
-      getBoardPropertyKeys: (parameters: GetBoardPropertyKeys): Promise<PropertyKeys> =>
-        board.getBoardPropertyKeys(client, parameters),
-      getBoardProperty: (parameters: GetBoardProperty): Promise<EntityProperty> =>
-        board.getBoardProperty(client, parameters),
-      setBoardProperty: (parameters: SetBoardProperty): Promise<void> => board.setBoardProperty(client, parameters),
-      deleteBoardProperty: (parameters: DeleteBoardProperty): Promise<void> =>
-        board.deleteBoardProperty(client, parameters),
-      getAllQuickFilters: (parameters: GetAllQuickFilters): Promise<Page<QuickFilter>> =>
-        board.getAllQuickFilters(client, parameters),
-      getQuickFilter: (parameters: GetQuickFilter): Promise<QuickFilter> => board.getQuickFilter(client, parameters),
-      getReportsForBoard: (parameters: GetReportsForBoard): Promise<GetReportsForBoardModel> =>
-        board.getReportsForBoard(client, parameters),
-      getAllSprints: (parameters: GetAllSprints): Promise<GetAllSprintsModel> =>
-        board.getAllSprints(client, parameters),
-      getBoardIssuesForSprint: (parameters: GetBoardIssuesForSprint): Promise<SoftwareIssueResults> =>
-        board.getBoardIssuesForSprint(client, parameters),
-      getAllVersions: (parameters: GetAllVersions): Promise<GetAllVersionsModel> =>
-        board.getAllVersions(client, parameters),
+      getAllBoards: (parameters?: GetAllBoards, options?: RequestOptions): Promise<Page<Board>> =>
+        board.getAllBoards(client, parameters, options),
+      createBoard: (parameters: CreateBoard, options?: RequestOptions): Promise<Board> =>
+        board.createBoard(client, parameters, options),
+      getBoardByFilterId: (parameters: GetBoardByFilterId, options?: RequestOptions): Promise<Page<BoardFilter>> =>
+        board.getBoardByFilterId(client, parameters, options),
+      getBoard: (parameters: GetBoard, options?: RequestOptions): Promise<Board> =>
+        board.getBoard(client, parameters, options),
+      deleteBoard: (parameters: DeleteBoard, options?: RequestOptions): Promise<void> =>
+        board.deleteBoard(client, parameters, options),
+      getIssuesForBacklog: (parameters: GetIssuesForBacklog, options?: RequestOptions): Promise<SoftwareIssueResults> =>
+        board.getIssuesForBacklog(client, parameters, options),
+      getApproximateIssueCountForBacklog: (
+        parameters: GetApproximateIssueCountForBacklog,
+        options?: RequestOptions,
+      ): Promise<IssueCount> => board.getApproximateIssueCountForBacklog(client, parameters, options),
+      getConfiguration: (parameters: GetConfiguration, options?: RequestOptions): Promise<GetConfigurationModel> =>
+        board.getConfiguration(client, parameters, options),
+      getEpics: (parameters: GetEpics, options?: RequestOptions): Promise<GetEpicsModel> =>
+        board.getEpics(client, parameters, options),
+      getIssuesWithoutEpicForBoard: (
+        parameters: GetIssuesWithoutEpicForBoard,
+        options?: RequestOptions,
+      ): Promise<SoftwareIssueResults> => board.getIssuesWithoutEpicForBoard(client, parameters, options),
+      getBoardIssuesForEpic: (
+        parameters: GetBoardIssuesForEpic,
+        options?: RequestOptions,
+      ): Promise<SoftwareIssueResults> => board.getBoardIssuesForEpic(client, parameters, options),
+      getFeaturesForBoard: (
+        parameters: GetFeaturesForBoard,
+        options?: RequestOptions,
+      ): Promise<GetFeaturesForBoardModel> => board.getFeaturesForBoard(client, parameters, options),
+      toggleFeatures: (parameters: ToggleFeatures, options?: RequestOptions): Promise<ToggleFeaturesModel> =>
+        board.toggleFeatures(client, parameters, options),
+      moveIssuesToBoard: (parameters: MoveIssuesToBoard, options?: RequestOptions): Promise<void> =>
+        board.moveIssuesToBoard(client, parameters, options),
+      getIssuesForBoard: (parameters: GetIssuesForBoard, options?: RequestOptions): Promise<SoftwareIssueResults> =>
+        board.getIssuesForBoard(client, parameters, options),
+      getApproximateIssueCountForBoard: (
+        parameters: GetApproximateIssueCountForBoard,
+        options?: RequestOptions,
+      ): Promise<IssueCount> => board.getApproximateIssueCountForBoard(client, parameters, options),
+      getProjects: (parameters: GetProjects, options?: RequestOptions): Promise<GetProjectsModel> =>
+        board.getProjects(client, parameters, options),
+      getProjectsFull: (parameters: GetProjectsFull, options?: RequestOptions): Promise<GetProjectsFullModel> =>
+        board.getProjectsFull(client, parameters, options),
+      getBoardPropertyKeys: (parameters: GetBoardPropertyKeys, options?: RequestOptions): Promise<PropertyKeys> =>
+        board.getBoardPropertyKeys(client, parameters, options),
+      getBoardProperty: (parameters: GetBoardProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        board.getBoardProperty(client, parameters, options),
+      setBoardProperty: (parameters: SetBoardProperty, options?: RequestOptions): Promise<void> =>
+        board.setBoardProperty(client, parameters, options),
+      deleteBoardProperty: (parameters: DeleteBoardProperty, options?: RequestOptions): Promise<void> =>
+        board.deleteBoardProperty(client, parameters, options),
+      getAllQuickFilters: (parameters: GetAllQuickFilters, options?: RequestOptions): Promise<Page<QuickFilter>> =>
+        board.getAllQuickFilters(client, parameters, options),
+      getQuickFilter: (parameters: GetQuickFilter, options?: RequestOptions): Promise<QuickFilter> =>
+        board.getQuickFilter(client, parameters, options),
+      getReportsForBoard: (
+        parameters: GetReportsForBoard,
+        options?: RequestOptions,
+      ): Promise<GetReportsForBoardModel> => board.getReportsForBoard(client, parameters, options),
+      getAllSprints: (parameters: GetAllSprints, options?: RequestOptions): Promise<GetAllSprintsModel> =>
+        board.getAllSprints(client, parameters, options),
+      getBoardIssuesForSprint: (
+        parameters: GetBoardIssuesForSprint,
+        options?: RequestOptions,
+      ): Promise<SoftwareIssueResults> => board.getBoardIssuesForSprint(client, parameters, options),
+      getAllVersions: (parameters: GetAllVersions, options?: RequestOptions): Promise<GetAllVersionsModel> =>
+        board.getAllVersions(client, parameters, options),
     },
     epic: {
-      removeIssuesFromEpic: (parameters: RemoveIssuesFromEpic): Promise<void> =>
-        epic.removeIssuesFromEpic(client, parameters),
-      getIssuesWithoutEpic: (parameters?: GetIssuesWithoutEpic): Promise<SoftwareIssueResults> =>
-        epic.getIssuesWithoutEpic(client, parameters),
-      getEpic: (parameters: GetEpic): Promise<Epic> => epic.getEpic(client, parameters),
-      partiallyUpdateEpic: (parameters: PartiallyUpdateEpic): Promise<Epic> =>
-        epic.partiallyUpdateEpic(client, parameters),
-      moveIssuesToEpic: (parameters: MoveIssuesToEpic): Promise<void> => epic.moveIssuesToEpic(client, parameters),
-      getIssuesForEpic: (parameters: GetIssuesForEpic): Promise<SoftwareIssueResults> =>
-        epic.getIssuesForEpic(client, parameters),
-      rankEpics: (parameters: RankEpics): Promise<void> => epic.rankEpics(client, parameters),
+      removeIssuesFromEpic: (parameters: RemoveIssuesFromEpic, options?: RequestOptions): Promise<void> =>
+        epic.removeIssuesFromEpic(client, parameters, options),
+      getIssuesWithoutEpic: (
+        parameters?: GetIssuesWithoutEpic,
+        options?: RequestOptions,
+      ): Promise<SoftwareIssueResults> => epic.getIssuesWithoutEpic(client, parameters, options),
+      getEpic: (parameters: GetEpic, options?: RequestOptions): Promise<Epic> =>
+        epic.getEpic(client, parameters, options),
+      partiallyUpdateEpic: (parameters: PartiallyUpdateEpic, options?: RequestOptions): Promise<Epic> =>
+        epic.partiallyUpdateEpic(client, parameters, options),
+      moveIssuesToEpic: (parameters: MoveIssuesToEpic, options?: RequestOptions): Promise<void> =>
+        epic.moveIssuesToEpic(client, parameters, options),
+      getIssuesForEpic: (parameters: GetIssuesForEpic, options?: RequestOptions): Promise<SoftwareIssueResults> =>
+        epic.getIssuesForEpic(client, parameters, options),
+      rankEpics: (parameters: RankEpics, options?: RequestOptions): Promise<void> =>
+        epic.rankEpics(client, parameters, options),
     },
     issue: {
-      rankIssues: (parameters: RankIssues): Promise<void> => issue.rankIssues(client, parameters),
-      getIssue: (parameters: GetIssue): Promise<Issue> => issue.getIssue(client, parameters),
-      getIssueEstimationForBoard: (parameters: GetIssueEstimationForBoard): Promise<GetIssueEstimationForBoardModel> =>
-        issue.getIssueEstimationForBoard(client, parameters),
-      estimateIssueForBoard: (parameters: EstimateIssueForBoard): Promise<EstimateIssueForBoardModel> =>
-        issue.estimateIssueForBoard(client, parameters),
+      rankIssues: (parameters: RankIssues, options?: RequestOptions): Promise<void> =>
+        issue.rankIssues(client, parameters, options),
+      getIssue: (parameters: GetIssue, options?: RequestOptions): Promise<Issue> =>
+        issue.getIssue(client, parameters, options),
+      getIssueEstimationForBoard: (
+        parameters: GetIssueEstimationForBoard,
+        options?: RequestOptions,
+      ): Promise<GetIssueEstimationForBoardModel> => issue.getIssueEstimationForBoard(client, parameters, options),
+      estimateIssueForBoard: (
+        parameters: EstimateIssueForBoard,
+        options?: RequestOptions,
+      ): Promise<EstimateIssueForBoardModel> => issue.estimateIssueForBoard(client, parameters, options),
     },
     sprint: {
-      createSprint: (parameters: CreateSprint): Promise<Sprint> => sprint.createSprint(client, parameters),
-      getSprint: (parameters: GetSprint): Promise<Sprint> => sprint.getSprint(client, parameters),
-      partiallyUpdateSprint: (parameters: PartiallyUpdateSprint): Promise<Sprint> =>
-        sprint.partiallyUpdateSprint(client, parameters),
-      updateSprint: (parameters: UpdateSprint): Promise<Sprint> => sprint.updateSprint(client, parameters),
-      deleteSprint: (parameters: DeleteSprint): Promise<void> => sprint.deleteSprint(client, parameters),
-      moveIssuesToSprintAndRank: (parameters: MoveIssuesToSprintAndRank): Promise<void> =>
-        sprint.moveIssuesToSprintAndRank(client, parameters),
-      getIssuesForSprint: (parameters: GetIssuesForSprint): Promise<SoftwareIssueResults> =>
-        sprint.getIssuesForSprint(client, parameters),
-      getPropertiesKeys: (parameters: GetPropertiesKeys): Promise<PropertyKeys> =>
-        sprint.getPropertiesKeys(client, parameters),
-      getProperty: (parameters: GetProperty): Promise<EntityProperty> => sprint.getProperty(client, parameters),
-      setProperty: (parameters: SetProperty): Promise<void> => sprint.setProperty(client, parameters),
-      deleteProperty: (parameters: DeleteProperty): Promise<void> => sprint.deleteProperty(client, parameters),
-      swapSprint: (parameters: SwapSprint): Promise<void> => sprint.swapSprint(client, parameters),
+      createSprint: (parameters: CreateSprint, options?: RequestOptions): Promise<Sprint> =>
+        sprint.createSprint(client, parameters, options),
+      getSprint: (parameters: GetSprint, options?: RequestOptions): Promise<Sprint> =>
+        sprint.getSprint(client, parameters, options),
+      partiallyUpdateSprint: (parameters: PartiallyUpdateSprint, options?: RequestOptions): Promise<Sprint> =>
+        sprint.partiallyUpdateSprint(client, parameters, options),
+      updateSprint: (parameters: UpdateSprint, options?: RequestOptions): Promise<Sprint> =>
+        sprint.updateSprint(client, parameters, options),
+      deleteSprint: (parameters: DeleteSprint, options?: RequestOptions): Promise<void> =>
+        sprint.deleteSprint(client, parameters, options),
+      moveIssuesToSprintAndRank: (parameters: MoveIssuesToSprintAndRank, options?: RequestOptions): Promise<void> =>
+        sprint.moveIssuesToSprintAndRank(client, parameters, options),
+      getIssuesForSprint: (parameters: GetIssuesForSprint, options?: RequestOptions): Promise<SoftwareIssueResults> =>
+        sprint.getIssuesForSprint(client, parameters, options),
+      getPropertiesKeys: (parameters: GetPropertiesKeys, options?: RequestOptions): Promise<PropertyKeys> =>
+        sprint.getPropertiesKeys(client, parameters, options),
+      getProperty: (parameters: GetProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        sprint.getProperty(client, parameters, options),
+      setProperty: (parameters: SetProperty, options?: RequestOptions): Promise<void> =>
+        sprint.setProperty(client, parameters, options),
+      deleteProperty: (parameters: DeleteProperty, options?: RequestOptions): Promise<void> =>
+        sprint.deleteProperty(client, parameters, options),
+      swapSprint: (parameters: SwapSprint, options?: RequestOptions): Promise<void> =>
+        sprint.swapSprint(client, parameters, options),
     },
     developmentInformation: {
       storeDevelopmentInformation: (
         parameters: StoreDevelopmentInformation,
+        options?: RequestOptions,
       ): Promise<StoreDevelopmentInformationModel> =>
-        developmentInformation.storeDevelopmentInformation(client, parameters),
-      getRepository: (parameters: GetRepository): Promise<GetRepositoryModel> =>
-        developmentInformation.getRepository(client, parameters),
-      deleteRepository: (parameters: DeleteRepository): Promise<void> =>
-        developmentInformation.deleteRepository(client, parameters),
-      deleteByProperties: (parameters: DeleteByProperties): Promise<void> =>
-        developmentInformation.deleteByProperties(client, parameters),
-      existsByProperties: (parameters?: ExistsByProperties): Promise<ExistsByPropertiesModel> =>
-        developmentInformation.existsByProperties(client, parameters),
-      deleteEntity: (parameters: DeleteEntity): Promise<void> =>
-        developmentInformation.deleteEntity(client, parameters),
+        developmentInformation.storeDevelopmentInformation(client, parameters, options),
+      getRepository: (parameters: GetRepository, options?: RequestOptions): Promise<GetRepositoryModel> =>
+        developmentInformation.getRepository(client, parameters, options),
+      deleteRepository: (parameters: DeleteRepository, options?: RequestOptions): Promise<void> =>
+        developmentInformation.deleteRepository(client, parameters, options),
+      deleteByProperties: (parameters: DeleteByProperties, options?: RequestOptions): Promise<void> =>
+        developmentInformation.deleteByProperties(client, parameters, options),
+      existsByProperties: (
+        parameters?: ExistsByProperties,
+        options?: RequestOptions,
+      ): Promise<ExistsByPropertiesModel> => developmentInformation.existsByProperties(client, parameters, options),
+      deleteEntity: (parameters: DeleteEntity, options?: RequestOptions): Promise<void> =>
+        developmentInformation.deleteEntity(client, parameters, options),
     },
     featureFlags: {
-      submitFeatureFlags: (parameters: SubmitFeatureFlags): Promise<SubmitFeatureFlagsModel> =>
-        featureFlags.submitFeatureFlags(client, parameters),
-      deleteFeatureFlagsByProperty: (parameters: DeleteFeatureFlagsByProperty): Promise<void> =>
-        featureFlags.deleteFeatureFlagsByProperty(client, parameters),
-      getFeatureFlagById: (parameters: GetFeatureFlagById): Promise<GetFeatureFlagByIdModel> =>
-        featureFlags.getFeatureFlagById(client, parameters),
-      deleteFeatureFlagById: (parameters: DeleteFeatureFlagById): Promise<void> =>
-        featureFlags.deleteFeatureFlagById(client, parameters),
+      submitFeatureFlags: (
+        parameters: SubmitFeatureFlags,
+        options?: RequestOptions,
+      ): Promise<SubmitFeatureFlagsModel> => featureFlags.submitFeatureFlags(client, parameters, options),
+      deleteFeatureFlagsByProperty: (
+        parameters: DeleteFeatureFlagsByProperty,
+        options?: RequestOptions,
+      ): Promise<void> => featureFlags.deleteFeatureFlagsByProperty(client, parameters, options),
+      getFeatureFlagById: (
+        parameters: GetFeatureFlagById,
+        options?: RequestOptions,
+      ): Promise<GetFeatureFlagByIdModel> => featureFlags.getFeatureFlagById(client, parameters, options),
+      deleteFeatureFlagById: (parameters: DeleteFeatureFlagById, options?: RequestOptions): Promise<void> =>
+        featureFlags.deleteFeatureFlagById(client, parameters, options),
     },
     deployments: {
-      submitDeployments: (parameters: SubmitDeployments): Promise<SubmitDeploymentsModel> =>
-        deployments.submitDeployments(client, parameters),
-      deleteDeploymentsByProperty: (parameters: DeleteDeploymentsByProperty): Promise<void> =>
-        deployments.deleteDeploymentsByProperty(client, parameters),
-      getDeploymentByKey: (parameters: GetDeploymentByKey): Promise<GetDeploymentByKeyModel> =>
-        deployments.getDeploymentByKey(client, parameters),
-      deleteDeploymentByKey: (parameters: DeleteDeploymentByKey): Promise<void> =>
-        deployments.deleteDeploymentByKey(client, parameters),
+      submitDeployments: (parameters: SubmitDeployments, options?: RequestOptions): Promise<SubmitDeploymentsModel> =>
+        deployments.submitDeployments(client, parameters, options),
+      deleteDeploymentsByProperty: (parameters: DeleteDeploymentsByProperty, options?: RequestOptions): Promise<void> =>
+        deployments.deleteDeploymentsByProperty(client, parameters, options),
+      getDeploymentByKey: (
+        parameters: GetDeploymentByKey,
+        options?: RequestOptions,
+      ): Promise<GetDeploymentByKeyModel> => deployments.getDeploymentByKey(client, parameters, options),
+      deleteDeploymentByKey: (parameters: DeleteDeploymentByKey, options?: RequestOptions): Promise<void> =>
+        deployments.deleteDeploymentByKey(client, parameters, options),
       getDeploymentGatingStatusByKey: (
         parameters: GetDeploymentGatingStatusByKey,
-      ): Promise<GetDeploymentGatingStatusByKeyModel> => deployments.getDeploymentGatingStatusByKey(client, parameters),
+        options?: RequestOptions,
+      ): Promise<GetDeploymentGatingStatusByKeyModel> =>
+        deployments.getDeploymentGatingStatusByKey(client, parameters, options),
     },
     builds: {
-      submitBuilds: (parameters: SubmitBuilds): Promise<SubmitBuildsModel> => builds.submitBuilds(client, parameters),
-      deleteBuildsByProperty: (parameters: DeleteBuildsByProperty): Promise<void> =>
-        builds.deleteBuildsByProperty(client, parameters),
-      getBuildByKey: (parameters: GetBuildByKey): Promise<GetBuildByKeyModel> =>
-        builds.getBuildByKey(client, parameters),
-      deleteBuildByKey: (parameters: DeleteBuildByKey): Promise<void> => builds.deleteBuildByKey(client, parameters),
+      submitBuilds: (parameters: SubmitBuilds, options?: RequestOptions): Promise<SubmitBuildsModel> =>
+        builds.submitBuilds(client, parameters, options),
+      deleteBuildsByProperty: (parameters: DeleteBuildsByProperty, options?: RequestOptions): Promise<void> =>
+        builds.deleteBuildsByProperty(client, parameters, options),
+      getBuildByKey: (parameters: GetBuildByKey, options?: RequestOptions): Promise<GetBuildByKeyModel> =>
+        builds.getBuildByKey(client, parameters, options),
+      deleteBuildByKey: (parameters: DeleteBuildByKey, options?: RequestOptions): Promise<void> =>
+        builds.deleteBuildByKey(client, parameters, options),
     },
     remoteLinks: {
-      submitRemoteLinks: (parameters: SubmitRemoteLinks): Promise<SubmitRemoteLinksModel> =>
-        remoteLinks.submitRemoteLinks(client, parameters),
-      deleteRemoteLinksByProperty: (parameters: DeleteRemoteLinksByProperty): Promise<void> =>
-        remoteLinks.deleteRemoteLinksByProperty(client, parameters),
-      getRemoteLinkById: (parameters: GetRemoteLinkById): Promise<GetRemoteLinkByIdModel> =>
-        remoteLinks.getRemoteLinkById(client, parameters),
-      deleteRemoteLinkById: (parameters: DeleteRemoteLinkById): Promise<void> =>
-        remoteLinks.deleteRemoteLinkById(client, parameters),
+      submitRemoteLinks: (parameters: SubmitRemoteLinks, options?: RequestOptions): Promise<SubmitRemoteLinksModel> =>
+        remoteLinks.submitRemoteLinks(client, parameters, options),
+      deleteRemoteLinksByProperty: (parameters: DeleteRemoteLinksByProperty, options?: RequestOptions): Promise<void> =>
+        remoteLinks.deleteRemoteLinksByProperty(client, parameters, options),
+      getRemoteLinkById: (parameters: GetRemoteLinkById, options?: RequestOptions): Promise<GetRemoteLinkByIdModel> =>
+        remoteLinks.getRemoteLinkById(client, parameters, options),
+      deleteRemoteLinkById: (parameters: DeleteRemoteLinkById, options?: RequestOptions): Promise<void> =>
+        remoteLinks.deleteRemoteLinkById(client, parameters, options),
     },
     securityInformation: {
-      submitWorkspaces: (parameters: SubmitWorkspaces): Promise<void> =>
-        securityInformation.submitWorkspaces(client, parameters),
-      deleteLinkedWorkspaces: (parameters: DeleteLinkedWorkspaces): Promise<void> =>
-        securityInformation.deleteLinkedWorkspaces(client, parameters),
-      getLinkedWorkspaces: (): Promise<GetLinkedWorkspaces> => securityInformation.getLinkedWorkspaces(client),
-      getLinkedWorkspaceById: (parameters: GetLinkedWorkspaceById): Promise<GetLinkedWorkspaceByIdModel> =>
-        securityInformation.getLinkedWorkspaceById(client, parameters),
-      submitVulnerabilities: (parameters: SubmitVulnerabilities): Promise<SubmitVulnerabilitiesModel> =>
-        securityInformation.submitVulnerabilities(client, parameters),
-      deleteVulnerabilitiesByProperty: (parameters: DeleteVulnerabilitiesByProperty): Promise<void> =>
-        securityInformation.deleteVulnerabilitiesByProperty(client, parameters),
-      getVulnerabilityById: (parameters: GetVulnerabilityById): Promise<GetVulnerabilityByIdModel> =>
-        securityInformation.getVulnerabilityById(client, parameters),
-      deleteVulnerabilityById: (parameters: DeleteVulnerabilityById): Promise<void> =>
-        securityInformation.deleteVulnerabilityById(client, parameters),
+      submitWorkspaces: (parameters: SubmitWorkspaces, options?: RequestOptions): Promise<void> =>
+        securityInformation.submitWorkspaces(client, parameters, options),
+      deleteLinkedWorkspaces: (parameters: DeleteLinkedWorkspaces, options?: RequestOptions): Promise<void> =>
+        securityInformation.deleteLinkedWorkspaces(client, parameters, options),
+      getLinkedWorkspaces: (options?: RequestOptions): Promise<GetLinkedWorkspaces> =>
+        securityInformation.getLinkedWorkspaces(client, options),
+      getLinkedWorkspaceById: (
+        parameters: GetLinkedWorkspaceById,
+        options?: RequestOptions,
+      ): Promise<GetLinkedWorkspaceByIdModel> =>
+        securityInformation.getLinkedWorkspaceById(client, parameters, options),
+      submitVulnerabilities: (
+        parameters: SubmitVulnerabilities,
+        options?: RequestOptions,
+      ): Promise<SubmitVulnerabilitiesModel> => securityInformation.submitVulnerabilities(client, parameters, options),
+      deleteVulnerabilitiesByProperty: (
+        parameters: DeleteVulnerabilitiesByProperty,
+        options?: RequestOptions,
+      ): Promise<void> => securityInformation.deleteVulnerabilitiesByProperty(client, parameters, options),
+      getVulnerabilityById: (
+        parameters: GetVulnerabilityById,
+        options?: RequestOptions,
+      ): Promise<GetVulnerabilityByIdModel> => securityInformation.getVulnerabilityById(client, parameters, options),
+      deleteVulnerabilityById: (parameters: DeleteVulnerabilityById, options?: RequestOptions): Promise<void> =>
+        securityInformation.deleteVulnerabilityById(client, parameters, options),
     },
     operations: {
-      submitOperationsWorkspaces: (parameters: SubmitOperationsWorkspaces): Promise<SubmitOperationsWorkspacesModel> =>
-        operations.submitOperationsWorkspaces(client, parameters),
-      deleteWorkspaces: (parameters: DeleteWorkspaces): Promise<void> =>
-        operations.deleteWorkspaces(client, parameters),
-      getWorkspaces: (parameters?: GetWorkspaces): Promise<GetWorkspacesModel> =>
-        operations.getWorkspaces(client, parameters),
-      submitEntity: (parameters: SubmitEntity): Promise<SubmitEntityModel> =>
-        operations.submitEntity(client, parameters),
-      deleteEntityByProperty: (parameters: DeleteEntityByProperty): Promise<void> =>
-        operations.deleteEntityByProperty(client, parameters),
-      getIncidentById: (parameters: GetIncidentById): Promise<GetIncidentByIdModel> =>
-        operations.getIncidentById(client, parameters),
-      deleteIncidentById: (parameters: DeleteIncidentById): Promise<void> =>
-        operations.deleteIncidentById(client, parameters),
-      getReviewById: (parameters: GetReviewById): Promise<GetReviewByIdModel> =>
-        operations.getReviewById(client, parameters),
-      deleteReviewById: (parameters: DeleteReviewById): Promise<void> =>
-        operations.deleteReviewById(client, parameters),
+      submitOperationsWorkspaces: (
+        parameters: SubmitOperationsWorkspaces,
+        options?: RequestOptions,
+      ): Promise<SubmitOperationsWorkspacesModel> => operations.submitOperationsWorkspaces(client, parameters, options),
+      deleteWorkspaces: (parameters: DeleteWorkspaces, options?: RequestOptions): Promise<void> =>
+        operations.deleteWorkspaces(client, parameters, options),
+      getWorkspaces: (parameters?: GetWorkspaces, options?: RequestOptions): Promise<GetWorkspacesModel> =>
+        operations.getWorkspaces(client, parameters, options),
+      submitEntity: (parameters: SubmitEntity, options?: RequestOptions): Promise<SubmitEntityModel> =>
+        operations.submitEntity(client, parameters, options),
+      deleteEntityByProperty: (parameters: DeleteEntityByProperty, options?: RequestOptions): Promise<void> =>
+        operations.deleteEntityByProperty(client, parameters, options),
+      getIncidentById: (parameters: GetIncidentById, options?: RequestOptions): Promise<GetIncidentByIdModel> =>
+        operations.getIncidentById(client, parameters, options),
+      deleteIncidentById: (parameters: DeleteIncidentById, options?: RequestOptions): Promise<void> =>
+        operations.deleteIncidentById(client, parameters, options),
+      getReviewById: (parameters: GetReviewById, options?: RequestOptions): Promise<GetReviewByIdModel> =>
+        operations.getReviewById(client, parameters, options),
+      deleteReviewById: (parameters: DeleteReviewById, options?: RequestOptions): Promise<void> =>
+        operations.deleteReviewById(client, parameters, options),
     },
     devopsComponents: {
-      submitComponents: (parameters: SubmitComponents): Promise<SubmitComponentsModel> =>
-        devopsComponents.submitComponents(client, parameters),
-      deleteComponentsByProperty: (parameters: DeleteComponentsByProperty): Promise<void> =>
-        devopsComponents.deleteComponentsByProperty(client, parameters),
-      getComponentById: (parameters: GetComponentById): Promise<GetComponentByIdModel> =>
-        devopsComponents.getComponentById(client, parameters),
-      deleteComponentById: (parameters: DeleteComponentById): Promise<void> =>
-        devopsComponents.deleteComponentById(client, parameters),
+      submitComponents: (parameters: SubmitComponents, options?: RequestOptions): Promise<SubmitComponentsModel> =>
+        devopsComponents.submitComponents(client, parameters, options),
+      deleteComponentsByProperty: (parameters: DeleteComponentsByProperty, options?: RequestOptions): Promise<void> =>
+        devopsComponents.deleteComponentsByProperty(client, parameters, options),
+      getComponentById: (parameters: GetComponentById, options?: RequestOptions): Promise<GetComponentByIdModel> =>
+        devopsComponents.getComponentById(client, parameters, options),
+      deleteComponentById: (parameters: DeleteComponentById, options?: RequestOptions): Promise<void> =>
+        devopsComponents.deleteComponentById(client, parameters, options),
     },
   };
 }

--- a/src/cloud/api/announcementBanner.ts
+++ b/src/cloud/api/announcementBanner.ts
@@ -3,7 +3,7 @@ import {
   type AnnouncementBannerConfiguration,
 } from '../models/announcementBannerConfiguration';
 import type { SetBanner } from '../parameters/setBanner';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the current announcement banner configuration.
@@ -11,11 +11,12 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getBanner(client: Client): Promise<AnnouncementBannerConfiguration> {
+export async function getBanner(client: Client, options?: RequestOptions): Promise<AnnouncementBannerConfiguration> {
   const config: SendRequestOptions<AnnouncementBannerConfiguration> = {
     url: '/rest/api/3/announcementBanner',
     method: 'GET',
     schema: AnnouncementBannerConfigurationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -27,7 +28,7 @@ export async function getBanner(client: Client): Promise<AnnouncementBannerConfi
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function setBanner(client: Client, parameters: SetBanner): Promise<void> {
+export async function setBanner(client: Client, parameters: SetBanner, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/announcementBanner',
     method: 'PUT',
@@ -37,6 +38,7 @@ export async function setBanner(client: Client, parameters: SetBanner): Promise<
       message: parameters.message,
       visibility: parameters.visibility,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/api.ts
+++ b/src/cloud/api/api.ts
@@ -1,6 +1,6 @@
 import { BulkWorklogKeyResponseSchema, type BulkWorklogKeyResponse } from '../models/bulkWorklogKeyResponse';
 import type { GetWorklogsByIssueIdAndWorklogId } from '../parameters/getWorklogsByIssueIdAndWorklogId';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns worklog details for a list of issue ID and worklog ID pairs.
@@ -17,6 +17,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getWorklogsByIssueIdAndWorklogId(
   client: Client,
   parameters: GetWorklogsByIssueIdAndWorklogId,
+  options?: RequestOptions,
 ): Promise<BulkWorklogKeyResponse> {
   const config: SendRequestOptions<BulkWorklogKeyResponse> = {
     url: '/rest/internal/api/latest/worklog/bulk',
@@ -25,6 +26,7 @@ export async function getWorklogsByIssueIdAndWorklogId(
       requests: parameters.requests,
     },
     schema: BulkWorklogKeyResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/appDataPolicies.ts
+++ b/src/cloud/api/appDataPolicies.ts
@@ -1,21 +1,26 @@
 import { WorkspaceDataPolicySchema, type WorkspaceDataPolicy } from '../models/workspaceDataPolicy';
 import { ProjectDataPoliciesSchema, type ProjectDataPolicies } from '../models/projectDataPolicies';
 import type { GetPolicies } from '../parameters/getPolicies';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /** Returns data policy for the workspace. */
-export async function getPolicy(client: Client): Promise<WorkspaceDataPolicy> {
+export async function getPolicy(client: Client, options?: RequestOptions): Promise<WorkspaceDataPolicy> {
   const config: SendRequestOptions<WorkspaceDataPolicy> = {
     url: '/rest/api/3/data-policy',
     method: 'GET',
     schema: WorkspaceDataPolicySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /** Returns data policies for the projects specified in the request. */
-export async function getPolicies(client: Client, parameters?: GetPolicies): Promise<ProjectDataPolicies> {
+export async function getPolicies(
+  client: Client,
+  parameters?: GetPolicies,
+  options?: RequestOptions,
+): Promise<ProjectDataPolicies> {
   const config: SendRequestOptions<ProjectDataPolicies> = {
     url: '/rest/api/3/data-policy/project',
     method: 'GET',
@@ -23,6 +28,7 @@ export async function getPolicies(client: Client, parameters?: GetPolicies): Pro
       ids: parameters?.ids,
     },
     schema: ProjectDataPoliciesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/appMigration.ts
+++ b/src/cloud/api/appMigration.ts
@@ -5,7 +5,7 @@ import {
 import type { UpdateIssueFields } from '../parameters/updateIssueFields';
 import type { UpdateEntityPropertiesValue } from '../parameters/updateEntityPropertiesValue';
 import type { WorkflowRuleSearch } from '../parameters/workflowRuleSearch';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Updates the value of a custom field added by Connect apps on one or more issues. The values of up to 200 custom
@@ -14,7 +14,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Only
  * Connect apps can make this request
  */
-export async function updateIssueFields(client: Client, parameters: UpdateIssueFields): Promise<void> {
+export async function updateIssueFields(
+  client: Client,
+  parameters: UpdateIssueFields,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/atlassian-connect/1/migration/field',
     method: 'PUT',
@@ -24,6 +28,7 @@ export async function updateIssueFields(client: Client, parameters: UpdateIssueF
     body: {
       updateValueList: parameters.updateValueList,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -36,6 +41,7 @@ export async function updateIssueFields(client: Client, parameters: UpdateIssueF
 export async function updateEntityPropertiesValue(
   client: Client,
   parameters: UpdateEntityPropertiesValue,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/atlassian-connect/1/migration/properties/${parameters.entityType}`,
@@ -44,6 +50,7 @@ export async function updateEntityPropertiesValue(
       'Atlassian-Transfer-Id': parameters['Atlassian-Transfer-Id'],
     },
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -56,6 +63,7 @@ export async function updateEntityPropertiesValue(
 export async function workflowRuleSearch(
   client: Client,
   parameters: WorkflowRuleSearch,
+  options?: RequestOptions,
 ): Promise<WorkflowRulesSearchDetails> {
   const config: SendRequestOptions<WorkflowRulesSearchDetails> = {
     url: '/rest/atlassian-connect/1/migration/workflow/rule/search',
@@ -69,6 +77,7 @@ export async function workflowRuleSearch(
       workflowEntityId: parameters.workflowEntityId,
     },
     schema: WorkflowRulesSearchDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/appProperties.ts
+++ b/src/cloud/api/appProperties.ts
@@ -10,7 +10,7 @@ import type { DeleteAddonProperty } from '../parameters/deleteAddonProperty';
 import type { GetForgeAppProperty as GetForgeAppPropertyParameters } from '../parameters/getForgeAppProperty';
 import type { PutForgeAppProperty } from '../parameters/putForgeAppProperty';
 import type { DeleteForgeAppProperty } from '../parameters/deleteForgeAppProperty';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Gets all the properties of an app. The reserved key `connect_client_key_019cdff3-8bfb-71fe-9628-875b700aebb8` is not
@@ -20,11 +20,16 @@ import type { Client, SendRequestOptions } from '#/core';
  * Connect app whose key matches `addonKey` can make this request. Additionally, Forge apps can access Connect app
  * properties (stored against the same `app.connect.key`).
  */
-export async function getAddonProperties(client: Client, parameters: GetAddonProperties): Promise<PropertyKeys> {
+export async function getAddonProperties(
+  client: Client,
+  parameters: GetAddonProperties,
+  options?: RequestOptions,
+): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/atlassian-connect/1/addons/${parameters.addonKey}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -40,11 +45,16 @@ export async function getAddonProperties(client: Client, parameters: GetAddonPro
  * Connect app whose key matches `addonKey` can make this request. Additionally, Forge apps can access Connect app
  * properties (stored against the same `app.connect.key`).
  */
-export async function getAddonProperty(client: Client, parameters: GetAddonProperty): Promise<EntityProperty> {
+export async function getAddonProperty(
+  client: Client,
+  parameters: GetAddonProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/atlassian-connect/1/addons/${parameters.addonKey}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -60,12 +70,17 @@ export async function getAddonProperty(client: Client, parameters: GetAddonPrope
  * Connect app whose key matches `addonKey` can make this request. Additionally, Forge apps can access Connect app
  * properties (stored against the same `app.connect.key`).
  */
-export async function putAddonProperty(client: Client, parameters: PutAddonProperty): Promise<OperationMessage> {
+export async function putAddonProperty(
+  client: Client,
+  parameters: PutAddonProperty,
+  options?: RequestOptions,
+): Promise<OperationMessage> {
   const config: SendRequestOptions<OperationMessage> = {
     url: `/rest/atlassian-connect/1/addons/${parameters.addonKey}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
     schema: OperationMessageSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -78,10 +93,15 @@ export async function putAddonProperty(client: Client, parameters: PutAddonPrope
  * Connect app whose key matches `addonKey` can make this request. Additionally, Forge apps can access Connect app
  * properties (stored against the same `app.connect.key`).
  */
-export async function deleteAddonProperty(client: Client, parameters: DeleteAddonProperty): Promise<void> {
+export async function deleteAddonProperty(
+  client: Client,
+  parameters: DeleteAddonProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/atlassian-connect/1/addons/${parameters.addonKey}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -95,11 +115,15 @@ export async function deleteAddonProperty(client: Client, parameters: DeleteAddo
  * **[asApp()](https://developer.atlassian.com/platform/forge/apis-reference/fetch-api-product.requestjira/#method-signature)**
  * requests from Forge.
  */
-export async function getForgeAppPropertyKeys(client: Client): Promise<GetForgeAppPropertyKeys> {
+export async function getForgeAppPropertyKeys(
+  client: Client,
+  options?: RequestOptions,
+): Promise<GetForgeAppPropertyKeys> {
   const config: SendRequestOptions<GetForgeAppPropertyKeys> = {
     url: '/rest/forge/1/app/properties',
     method: 'GET',
     schema: GetForgeAppPropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -116,11 +140,13 @@ export async function getForgeAppPropertyKeys(client: Client): Promise<GetForgeA
 export async function getForgeAppProperty(
   client: Client,
   parameters: GetForgeAppPropertyParameters,
+  options?: RequestOptions,
 ): Promise<GetForgeAppProperty> {
   const config: SendRequestOptions<GetForgeAppProperty> = {
     url: `/rest/forge/1/app/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: GetForgeAppPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -145,12 +171,17 @@ export async function getForgeAppProperty(
  * The new `write:app-data:jira` OAuth scope is 100% optional now, and not using it won't break your app. However, we
  * recommend adding it to your app's scope list because we will eventually make it mandatory.
  */
-export async function putForgeAppProperty(client: Client, parameters: PutForgeAppProperty): Promise<OperationMessage> {
+export async function putForgeAppProperty(
+  client: Client,
+  parameters: PutForgeAppProperty,
+  options?: RequestOptions,
+): Promise<OperationMessage> {
   const config: SendRequestOptions<OperationMessage> = {
     url: `/rest/forge/1/app/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
     schema: OperationMessageSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -167,10 +198,15 @@ export async function putForgeAppProperty(client: Client, parameters: PutForgeAp
  * The new `write:app-data:jira` OAuth scope is 100% optional now, and not using it won't break your app. However, we
  * recommend adding it to your app's scope list because we will eventually make it mandatory.
  */
-export async function deleteForgeAppProperty(client: Client, parameters: DeleteForgeAppProperty): Promise<void> {
+export async function deleteForgeAppProperty(
+  client: Client,
+  parameters: DeleteForgeAppProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/forge/1/app/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/applicationRoles.ts
+++ b/src/cloud/api/applicationRoles.ts
@@ -1,6 +1,6 @@
 import { ApplicationRoleSchema, type ApplicationRole } from '../models/applicationRole';
 import type { GetApplicationRole } from '../parameters/getApplicationRole';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -10,11 +10,12 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getAllApplicationRoles(client: Client): Promise<ApplicationRole[]> {
+export async function getAllApplicationRoles(client: Client, options?: RequestOptions): Promise<ApplicationRole[]> {
   const config: SendRequestOptions<ApplicationRole[]> = {
     url: '/rest/api/3/applicationrole',
     method: 'GET',
     schema: z.array(ApplicationRoleSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -26,11 +27,16 @@ export async function getAllApplicationRoles(client: Client): Promise<Applicatio
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getApplicationRole(client: Client, parameters: GetApplicationRole): Promise<ApplicationRole> {
+export async function getApplicationRole(
+  client: Client,
+  parameters: GetApplicationRole,
+  options?: RequestOptions,
+): Promise<ApplicationRole> {
   const config: SendRequestOptions<ApplicationRole> = {
     url: `/rest/api/3/applicationrole/${parameters.key}`,
     method: 'GET',
     schema: ApplicationRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/auditRecords.ts
+++ b/src/cloud/api/auditRecords.ts
@@ -1,6 +1,6 @@
 import { AuditRecordsSchema, type AuditRecords } from '../models/auditRecords';
 import type { GetAuditRecords } from '../parameters/getAuditRecords';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a list of audit records. The list can be filtered to include items:
@@ -25,7 +25,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getAuditRecords(client: Client, parameters?: GetAuditRecords): Promise<AuditRecords> {
+export async function getAuditRecords(
+  client: Client,
+  parameters?: GetAuditRecords,
+  options?: RequestOptions,
+): Promise<AuditRecords> {
   const config: SendRequestOptions<AuditRecords> = {
     url: '/rest/api/3/auditing/record',
     method: 'GET',
@@ -37,6 +41,7 @@ export async function getAuditRecords(client: Client, parameters?: GetAuditRecor
       to: parameters?.to,
     },
     schema: AuditRecordsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/avatars.ts
+++ b/src/cloud/api/avatars.ts
@@ -8,7 +8,7 @@ import type { DeleteAvatar } from '../parameters/deleteAvatar';
 import type { GetAvatarImageByType } from '../parameters/getAvatarImageByType';
 import type { GetAvatarImageByID } from '../parameters/getAvatarImageByID';
 import type { GetAvatarImageByOwner } from '../parameters/getAvatarImageByOwner';
-import { type Client, type SendRequestOptions, BlobSchema } from '#/core';
+import { type Client, type RequestOptions, type SendRequestOptions, BlobSchema } from '#/core';
 
 /**
  * Returns a list of system avatar details by owner type, where the owner types are issue type, project, user or
@@ -18,11 +18,16 @@ import { type Client, type SendRequestOptions, BlobSchema } from '#/core';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAllSystemAvatars(client: Client, parameters: GetAllSystemAvatars): Promise<SystemAvatars> {
+export async function getAllSystemAvatars(
+  client: Client,
+  parameters: GetAllSystemAvatars,
+  options?: RequestOptions,
+): Promise<SystemAvatars> {
   const config: SendRequestOptions<SystemAvatars> = {
     url: `/rest/api/3/avatar/${parameters.type}/system`,
     method: 'GET',
     schema: SystemAvatarsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -42,11 +47,12 @@ export async function getAllSystemAvatars(client: Client, parameters: GetAllSyst
  * - For system avatars, none.
  * - For priority avatars, none.
  */
-export async function getAvatars(client: Client, parameters: GetAvatars): Promise<Avatars> {
+export async function getAvatars(client: Client, parameters: GetAvatars, options?: RequestOptions): Promise<Avatars> {
   const config: SendRequestOptions<Avatars> = {
     url: `/rest/api/3/universal_avatar/type/${parameters.type}/owner/${parameters.entityId}`,
     method: 'GET',
     schema: AvatarsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -93,7 +99,7 @@ export async function getAvatars(client: Client, parameters: GetAvatars): Promis
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function storeAvatar(client: Client, parameters: StoreAvatar): Promise<Avatar> {
+export async function storeAvatar(client: Client, parameters: StoreAvatar, options?: RequestOptions): Promise<Avatar> {
   const config: SendRequestOptions<Avatar> = {
     url: `/rest/api/3/universal_avatar/type/${parameters.type}/owner/${parameters.entityId}`,
     method: 'POST',
@@ -107,6 +113,7 @@ export async function storeAvatar(client: Client, parameters: StoreAvatar): Prom
     },
     body: parameters.body,
     schema: AvatarSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -118,10 +125,11 @@ export async function storeAvatar(client: Client, parameters: StoreAvatar): Prom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteAvatar(client: Client, parameters: DeleteAvatar): Promise<void> {
+export async function deleteAvatar(client: Client, parameters: DeleteAvatar, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/universal_avatar/type/${parameters.type}/owner/${parameters.owningObjectId}/avatar/${parameters.id}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -134,7 +142,11 @@ export async function deleteAvatar(client: Client, parameters: DeleteAvatar): Pr
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAvatarImageByType(client: Client, parameters: GetAvatarImageByType): Promise<Blob> {
+export async function getAvatarImageByType(
+  client: Client,
+  parameters: GetAvatarImageByType,
+  options?: RequestOptions,
+): Promise<Blob> {
   const config: SendRequestOptions<Blob> = {
     url: `/rest/api/3/universal_avatar/view/type/${parameters.type}`,
     method: 'GET',
@@ -143,6 +155,7 @@ export async function getAvatarImageByType(client: Client, parameters: GetAvatar
       format: parameters.format,
     },
     schema: BlobSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -162,7 +175,11 @@ export async function getAvatarImageByType(client: Client, parameters: GetAvatar
  *   at least one project the issue type is used in.
  * - For priority avatars, none.
  */
-export async function getAvatarImageByID(client: Client, parameters: GetAvatarImageByID): Promise<Blob> {
+export async function getAvatarImageByID(
+  client: Client,
+  parameters: GetAvatarImageByID,
+  options?: RequestOptions,
+): Promise<Blob> {
   const config: SendRequestOptions<Blob> = {
     url: `/rest/api/3/universal_avatar/view/type/${parameters.type}/avatar/${parameters.id}`,
     method: 'GET',
@@ -171,6 +188,7 @@ export async function getAvatarImageByID(client: Client, parameters: GetAvatarIm
       format: parameters.format,
     },
     schema: BlobSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -190,7 +208,11 @@ export async function getAvatarImageByID(client: Client, parameters: GetAvatarIm
  *   at least one project the issue type is used in.
  * - For priority avatars, none.
  */
-export async function getAvatarImageByOwner(client: Client, parameters: GetAvatarImageByOwner): Promise<Blob> {
+export async function getAvatarImageByOwner(
+  client: Client,
+  parameters: GetAvatarImageByOwner,
+  options?: RequestOptions,
+): Promise<Blob> {
   const config: SendRequestOptions<Blob> = {
     url: `/rest/api/3/universal_avatar/view/type/${parameters.type}/owner/${parameters.entityId}`,
     method: 'GET',
@@ -199,6 +221,7 @@ export async function getAvatarImageByOwner(client: Client, parameters: GetAvata
       format: parameters.format,
     },
     schema: BlobSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/dashboards.ts
+++ b/src/cloud/api/dashboards.ts
@@ -11,7 +11,7 @@ import type { GetDashboardItemProperty } from '../parameters/getDashboardItemPro
 import type { SetDashboardItemProperty } from '../parameters/setDashboardItemProperty';
 import type { DeleteDashboardItemProperty } from '../parameters/deleteDashboardItemProperty';
 import type { GetDashboard } from '../parameters/getDashboard';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a list of dashboards owned by or shared with the user. The list may be filtered to include only favorite or
@@ -21,7 +21,11 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAllDashboards(client: Client, parameters?: GetAllDashboards): Promise<PageOfDashboards> {
+export async function getAllDashboards(
+  client: Client,
+  parameters?: GetAllDashboards,
+  options?: RequestOptions,
+): Promise<PageOfDashboards> {
   const config: SendRequestOptions<PageOfDashboards> = {
     url: '/rest/api/3/dashboard',
     method: 'GET',
@@ -31,6 +35,7 @@ export async function getAllDashboards(client: Client, parameters?: GetAllDashbo
       maxResults: parameters?.maxResults,
     },
     schema: PageOfDashboardsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -57,6 +62,7 @@ export async function getAllDashboards(client: Client, parameters?: GetAllDashbo
 export async function getDashboardsPaginated(
   client: Client,
   parameters?: GetDashboardsPaginated,
+  options?: RequestOptions,
 ): Promise<Page<Dashboard>> {
   const config: SendRequestOptions<Page<Dashboard>> = {
     url: '/rest/api/3/dashboard/search',
@@ -74,6 +80,7 @@ export async function getDashboardsPaginated(
       expand: parameters?.expand,
     },
     schema: PageDashboardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -90,11 +97,13 @@ export async function getDashboardsPaginated(
 export async function getDashboardItemPropertyKeys(
   client: Client,
   parameters: GetDashboardItemPropertyKeys,
+  options?: RequestOptions,
 ): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/api/3/dashboard/${parameters.dashboardId}/items/${parameters.itemId}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -124,11 +133,13 @@ export async function getDashboardItemPropertyKeys(
 export async function getDashboardItemProperty(
   client: Client,
   parameters: GetDashboardItemProperty,
+  options?: RequestOptions,
 ): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/api/3/dashboard/${parameters.dashboardId}/items/${parameters.itemId}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -158,11 +169,16 @@ export async function getDashboardItemProperty(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** The user
  * must have edit permisson of the dashboard.
  */
-export async function setDashboardItemProperty(client: Client, parameters: SetDashboardItemProperty): Promise<void> {
+export async function setDashboardItemProperty(
+  client: Client,
+  parameters: SetDashboardItemProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/dashboard/${parameters.dashboardId}/items/${parameters.itemId}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -179,10 +195,12 @@ export async function setDashboardItemProperty(client: Client, parameters: SetDa
 export async function deleteDashboardItemProperty(
   client: Client,
   parameters: DeleteDashboardItemProperty,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/dashboard/${parameters.dashboardId}/items/${parameters.itemId}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -199,11 +217,16 @@ export async function deleteDashboardItemProperty(
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) are considered owners of the System
  * dashboard. The System dashboard is considered to be shared with all other users.
  */
-export async function getDashboard(client: Client, parameters: GetDashboard): Promise<Dashboard> {
+export async function getDashboard(
+  client: Client,
+  parameters: GetDashboard,
+  options?: RequestOptions,
+): Promise<Dashboard> {
   const config: SendRequestOptions<Dashboard> = {
     url: `/rest/api/3/dashboard/${parameters.id}`,
     method: 'GET',
     schema: DashboardSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/dynamicModules.ts
+++ b/src/cloud/api/dynamicModules.ts
@@ -1,7 +1,7 @@
 import { ConnectModulesSchema, type ConnectModules } from '../models/connectModules';
 import type { RegisterModules } from '../parameters/registerModules';
 import type { RemoveModules } from '../parameters/removeModules';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns all modules registered dynamically by the calling app.
@@ -9,11 +9,12 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Only
  * Connect apps can make this request.
  */
-export async function getModules(client: Client): Promise<ConnectModules> {
+export async function getModules(client: Client, options?: RequestOptions): Promise<ConnectModules> {
   const config: SendRequestOptions<ConnectModules> = {
     url: '/rest/atlassian-connect/1/app/module/dynamic',
     method: 'GET',
     schema: ConnectModulesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -25,13 +26,18 @@ export async function getModules(client: Client): Promise<ConnectModules> {
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Only
  * Connect apps can make this request.
  */
-export async function registerModules(client: Client, parameters: RegisterModules): Promise<void> {
+export async function registerModules(
+  client: Client,
+  parameters: RegisterModules,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/atlassian-connect/1/app/module/dynamic',
     method: 'POST',
     body: {
       modules: parameters.modules,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -43,13 +49,18 @@ export async function registerModules(client: Client, parameters: RegisterModule
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Only
  * Connect apps can make this request.
  */
-export async function removeModules(client: Client, parameters: RemoveModules): Promise<void> {
+export async function removeModules(
+  client: Client,
+  parameters: RemoveModules,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/atlassian-connect/1/app/module/dynamic',
     method: 'DELETE',
     searchParams: {
       moduleKey: parameters.moduleKey,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/filterSharing.ts
+++ b/src/cloud/api/filterSharing.ts
@@ -5,7 +5,7 @@ import type { GetSharePermissions } from '../parameters/getSharePermissions';
 import type { AddSharePermission } from '../parameters/addSharePermission';
 import type { GetSharePermission } from '../parameters/getSharePermission';
 import type { DeleteSharePermission } from '../parameters/deleteSharePermission';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -14,11 +14,12 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getDefaultShareScope(client: Client): Promise<DefaultShareScope> {
+export async function getDefaultShareScope(client: Client, options?: RequestOptions): Promise<DefaultShareScope> {
   const config: SendRequestOptions<DefaultShareScope> = {
     url: '/rest/api/3/filter/defaultShareScope',
     method: 'GET',
     schema: DefaultShareScopeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -33,6 +34,7 @@ export async function getDefaultShareScope(client: Client): Promise<DefaultShare
 export async function setDefaultShareScope(
   client: Client,
   parameters: SetDefaultShareScope,
+  options?: RequestOptions,
 ): Promise<DefaultShareScope> {
   const config: SendRequestOptions<DefaultShareScope> = {
     url: '/rest/api/3/filter/defaultShareScope',
@@ -41,6 +43,7 @@ export async function setDefaultShareScope(
       scope: parameters.scope,
     },
     schema: DefaultShareScopeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -62,11 +65,16 @@ export async function setDefaultShareScope(
  * - Filters shared with a public project.
  * - Filters shared with the public.
  */
-export async function getSharePermissions(client: Client, parameters: GetSharePermissions): Promise<SharePermission[]> {
+export async function getSharePermissions(
+  client: Client,
+  parameters: GetSharePermissions,
+  options?: RequestOptions,
+): Promise<SharePermission[]> {
   const config: SendRequestOptions<SharePermission[]> = {
     url: `/rest/api/3/filter/${parameters.id}/permission`,
     method: 'GET',
     schema: z.array(SharePermissionSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -83,7 +91,11 @@ export async function getSharePermissions(client: Client, parameters: GetSharePe
  * dashboards and filters_ [global permission](https://confluence.atlassian.com/x/x4dKLg) and the user must own the
  * filter.
  */
-export async function addSharePermission(client: Client, parameters: AddSharePermission): Promise<SharePermission[]> {
+export async function addSharePermission(
+  client: Client,
+  parameters: AddSharePermission,
+  options?: RequestOptions,
+): Promise<SharePermission[]> {
   const config: SendRequestOptions<SharePermission[]> = {
     url: `/rest/api/3/filter/${parameters.id}/permission`,
     method: 'POST',
@@ -97,6 +109,7 @@ export async function addSharePermission(client: Client, parameters: AddSharePer
       type: parameters.type,
     },
     schema: z.array(SharePermissionSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -118,11 +131,16 @@ export async function addSharePermission(client: Client, parameters: AddSharePer
  * - Filters shared with a public project.
  * - Filters shared with the public.
  */
-export async function getSharePermission(client: Client, parameters: GetSharePermission): Promise<SharePermission> {
+export async function getSharePermission(
+  client: Client,
+  parameters: GetSharePermission,
+  options?: RequestOptions,
+): Promise<SharePermission> {
   const config: SendRequestOptions<SharePermission> = {
     url: `/rest/api/3/filter/${parameters.id}/permission/${parameters.permissionId}`,
     method: 'GET',
     schema: SharePermissionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -134,10 +152,15 @@ export async function getSharePermission(client: Client, parameters: GetSharePer
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira and the user must own the filter.
  */
-export async function deleteSharePermission(client: Client, parameters: DeleteSharePermission): Promise<void> {
+export async function deleteSharePermission(
+  client: Client,
+  parameters: DeleteSharePermission,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/filter/${parameters.id}/permission/${parameters.permissionId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/filters.ts
+++ b/src/cloud/api/filters.ts
@@ -15,7 +15,7 @@ import type { SetColumns } from '../parameters/setColumns';
 import type { ResetColumns } from '../parameters/resetColumns';
 import type { SetFavouriteForFilter } from '../parameters/setFavouriteForFilter';
 import type { DeleteFavouriteForFilter } from '../parameters/deleteFavouriteForFilter';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -26,7 +26,11 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function createFilter(client: Client, parameters: CreateFilter): Promise<Filter> {
+export async function createFilter(
+  client: Client,
+  parameters: CreateFilter,
+  options?: RequestOptions,
+): Promise<Filter> {
   const config: SendRequestOptions<Filter> = {
     url: '/rest/api/3/filter',
     method: 'POST',
@@ -53,6 +57,7 @@ export async function createFilter(client: Client, parameters: CreateFilter): Pr
       isWritable: parameters.isWritable,
     },
     schema: FilterSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -76,7 +81,11 @@ export async function createFilter(client: Client, parameters: CreateFilter): Pr
  * For example, if the user favorites a public filter that is subsequently made private that filter is not returned by
  * this operation.
  */
-export async function getFavouriteFilters(client: Client, parameters?: GetFavouriteFilters): Promise<Filter[]> {
+export async function getFavouriteFilters(
+  client: Client,
+  parameters?: GetFavouriteFilters,
+  options?: RequestOptions,
+): Promise<Filter[]> {
   const config: SendRequestOptions<Filter[]> = {
     url: '/rest/api/3/filter/favourite',
     method: 'GET',
@@ -84,6 +93,7 @@ export async function getFavouriteFilters(client: Client, parameters?: GetFavour
       expand: parameters?.expand,
     },
     schema: z.array(FilterSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -106,7 +116,11 @@ export async function getFavouriteFilters(client: Client, parameters?: GetFavour
  * For example, if the user favorites a public filter that is subsequently made private that filter is not returned by
  * this operation.
  */
-export async function getMyFilters(client: Client, parameters?: GetMyFilters): Promise<Filter[]> {
+export async function getMyFilters(
+  client: Client,
+  parameters?: GetMyFilters,
+  options?: RequestOptions,
+): Promise<Filter[]> {
   const config: SendRequestOptions<Filter[]> = {
     url: '/rest/api/3/filter/my',
     method: 'GET',
@@ -115,6 +129,7 @@ export async function getMyFilters(client: Client, parameters?: GetMyFilters): P
       includeFavourites: parameters?.includeFavourites,
     },
     schema: z.array(FilterSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -143,6 +158,7 @@ export async function getMyFilters(client: Client, parameters?: GetMyFilters): P
 export async function getFiltersPaginated(
   client: Client,
   parameters?: GetFiltersPaginated,
+  options?: RequestOptions,
 ): Promise<Page<FilterDetails>> {
   const config: SendRequestOptions<Page<FilterDetails>> = {
     url: '/rest/api/3/filter/search',
@@ -162,6 +178,7 @@ export async function getFiltersPaginated(
       isSubstringMatch: parameters?.isSubstringMatch,
     },
     schema: PageFilterDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -182,7 +199,7 @@ export async function getFiltersPaginated(
  * - Shared with a public project.
  * - Shared with the public.
  */
-export async function getFilter(client: Client, parameters: GetFilter): Promise<Filter> {
+export async function getFilter(client: Client, parameters: GetFilter, options?: RequestOptions): Promise<Filter> {
   const config: SendRequestOptions<Filter> = {
     url: `/rest/api/3/filter/${parameters.id}`,
     method: 'GET',
@@ -191,6 +208,7 @@ export async function getFilter(client: Client, parameters: GetFilter): Promise<
       overrideSharePermissions: parameters.overrideSharePermissions,
     },
     schema: FilterSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -202,7 +220,11 @@ export async function getFilter(client: Client, parameters: GetFilter): Promise<
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira, however the user must own the filter.
  */
-export async function updateFilter(client: Client, parameters: UpdateFilter): Promise<Filter> {
+export async function updateFilter(
+  client: Client,
+  parameters: UpdateFilter,
+  options?: RequestOptions,
+): Promise<Filter> {
   const config: SendRequestOptions<Filter> = {
     url: `/rest/api/3/filter/${parameters.id}`,
     method: 'PUT',
@@ -212,6 +234,7 @@ export async function updateFilter(client: Client, parameters: UpdateFilter): Pr
     },
     body: parameters.body,
     schema: FilterSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -224,10 +247,11 @@ export async function updateFilter(client: Client, parameters: UpdateFilter): Pr
  * to access Jira, however filters can only be deleted by the creator of the filter or a user with _Administer Jira_
  * [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteFilter(client: Client, parameters: DeleteFilter): Promise<void> {
+export async function deleteFilter(client: Client, parameters: DeleteFilter, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/filter/${parameters.id}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -249,11 +273,16 @@ export async function deleteFilter(client: Client, parameters: DeleteFilter): Pr
  * - Filters shared with a public project.
  * - Filters shared with the public.
  */
-export async function getColumns(client: Client, parameters: GetColumns): Promise<ColumnItem[]> {
+export async function getColumns(
+  client: Client,
+  parameters: GetColumns,
+  options?: RequestOptions,
+): Promise<ColumnItem[]> {
   const config: SendRequestOptions<ColumnItem[]> = {
     url: `/rest/api/3/filter/${parameters.id}/columns`,
     method: 'GET',
     schema: z.array(ColumnItemSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -279,13 +308,14 @@ export async function getColumns(client: Client, parameters: GetColumns): Promis
  * - Filters shared with a public project.
  * - Filters shared with the public.
  */
-export async function setColumns(client: Client, parameters: SetColumns): Promise<void> {
+export async function setColumns(client: Client, parameters: SetColumns, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/filter/${parameters.id}/columns`,
     method: 'PUT',
     body: {
       columns: parameters.columns,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -304,10 +334,11 @@ export async function setColumns(client: Client, parameters: SetColumns): Promis
  * - Filters shared with a public project.
  * - Filters shared with the public.
  */
-export async function resetColumns(client: Client, parameters: ResetColumns): Promise<void> {
+export async function resetColumns(client: Client, parameters: ResetColumns, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/filter/${parameters.id}/columns`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -326,7 +357,11 @@ export async function resetColumns(client: Client, parameters: ResetColumns): Pr
  * - Filters shared with a public project.
  * - Filters shared with the public.
  */
-export async function setFavouriteForFilter(client: Client, parameters: SetFavouriteForFilter): Promise<Filter> {
+export async function setFavouriteForFilter(
+  client: Client,
+  parameters: SetFavouriteForFilter,
+  options?: RequestOptions,
+): Promise<Filter> {
   const config: SendRequestOptions<Filter> = {
     url: `/rest/api/3/filter/${parameters.id}/favourite`,
     method: 'PUT',
@@ -334,6 +369,7 @@ export async function setFavouriteForFilter(client: Client, parameters: SetFavou
       expand: parameters.expand,
     },
     schema: FilterSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -347,7 +383,11 @@ export async function setFavouriteForFilter(client: Client, parameters: SetFavou
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function deleteFavouriteForFilter(client: Client, parameters: DeleteFavouriteForFilter): Promise<Filter> {
+export async function deleteFavouriteForFilter(
+  client: Client,
+  parameters: DeleteFavouriteForFilter,
+  options?: RequestOptions,
+): Promise<Filter> {
   const config: SendRequestOptions<Filter> = {
     url: `/rest/api/3/filter/${parameters.id}/favourite`,
     method: 'DELETE',
@@ -355,6 +395,7 @@ export async function deleteFavouriteForFilter(client: Client, parameters: Delet
       expand: parameters.expand,
     },
     schema: FilterSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/groupAndUserPicker.ts
+++ b/src/cloud/api/groupAndUserPicker.ts
@@ -1,6 +1,6 @@
 import { FoundUsersAndGroupsSchema, type FoundUsersAndGroups } from '../models/foundUsersAndGroups';
 import type { FindUsersAndGroups } from '../parameters/findUsersAndGroups';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a list of users and groups matching a string. The string is used:
@@ -37,7 +37,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * users and groups_ [global permission](https://confluence.atlassian.com/x/yodKLg).
  */
-export async function findUsersAndGroups(client: Client, parameters: FindUsersAndGroups): Promise<FoundUsersAndGroups> {
+export async function findUsersAndGroups(
+  client: Client,
+  parameters: FindUsersAndGroups,
+  options?: RequestOptions,
+): Promise<FoundUsersAndGroups> {
   const config: SendRequestOptions<FoundUsersAndGroups> = {
     url: '/rest/api/3/groupuserpicker',
     method: 'GET',
@@ -54,6 +58,7 @@ export async function findUsersAndGroups(client: Client, parameters: FindUsersAn
       includeAiAgents: parameters.includeAiAgents,
     },
     schema: FoundUsersAndGroupsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/groups.ts
+++ b/src/cloud/api/groups.ts
@@ -9,7 +9,7 @@ import type { GetUsersFromGroup } from '../parameters/getUsersFromGroup';
 import type { AddUserToGroup } from '../parameters/addUserToGroup';
 import type { RemoveUserFromGroup } from '../parameters/removeUserFromGroup';
 import type { FindGroups } from '../parameters/findGroups';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Creates a group.
@@ -17,7 +17,7 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Site
  * administration (that is, member of the _site-admin_ [group](https://confluence.atlassian.com/x/24xjL)).
  */
-export async function createGroup(client: Client, parameters: CreateGroup): Promise<Group> {
+export async function createGroup(client: Client, parameters: CreateGroup, options?: RequestOptions): Promise<Group> {
   const config: SendRequestOptions<Group> = {
     url: '/rest/api/3/group',
     method: 'POST',
@@ -25,6 +25,7 @@ export async function createGroup(client: Client, parameters: CreateGroup): Prom
       name: parameters.name,
     },
     schema: GroupSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -36,7 +37,7 @@ export async function createGroup(client: Client, parameters: CreateGroup): Prom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Site
  * administration (that is, member of the _site-admin_ strategic [group](https://confluence.atlassian.com/x/24xjL)).
  */
-export async function removeGroup(client: Client, parameters: RemoveGroup): Promise<void> {
+export async function removeGroup(client: Client, parameters: RemoveGroup, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/group',
     method: 'DELETE',
@@ -46,6 +47,7 @@ export async function removeGroup(client: Client, parameters: RemoveGroup): Prom
       swapGroup: parameters.swapGroup,
       swapGroupId: parameters.swapGroupId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -62,7 +64,11 @@ export async function removeGroup(client: Client, parameters: RemoveGroup): Prom
  * - _Browse users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getUsersFromGroup(client: Client, parameters?: GetUsersFromGroup): Promise<Page<UserDetails>> {
+export async function getUsersFromGroup(
+  client: Client,
+  parameters?: GetUsersFromGroup,
+  options?: RequestOptions,
+): Promise<Page<UserDetails>> {
   const config: SendRequestOptions<Page<UserDetails>> = {
     url: '/rest/api/3/group/member',
     method: 'GET',
@@ -74,6 +80,7 @@ export async function getUsersFromGroup(client: Client, parameters?: GetUsersFro
       maxResults: parameters?.maxResults,
     },
     schema: PageUserDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -85,7 +92,11 @@ export async function getUsersFromGroup(client: Client, parameters?: GetUsersFro
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Site
  * administration (that is, member of the _site-admin_ [group](https://confluence.atlassian.com/x/24xjL)).
  */
-export async function addUserToGroup(client: Client, parameters: AddUserToGroup): Promise<Group> {
+export async function addUserToGroup(
+  client: Client,
+  parameters: AddUserToGroup,
+  options?: RequestOptions,
+): Promise<Group> {
   const config: SendRequestOptions<Group> = {
     url: '/rest/api/3/group/user',
     method: 'POST',
@@ -97,6 +108,7 @@ export async function addUserToGroup(client: Client, parameters: AddUserToGroup)
       accountId: parameters.accountId,
     },
     schema: GroupSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -108,7 +120,11 @@ export async function addUserToGroup(client: Client, parameters: AddUserToGroup)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Site
  * administration (that is, member of the _site-admin_ [group](https://confluence.atlassian.com/x/24xjL)).
  */
-export async function removeUserFromGroup(client: Client, parameters: RemoveUserFromGroup): Promise<void> {
+export async function removeUserFromGroup(
+  client: Client,
+  parameters: RemoveUserFromGroup,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/group/user',
     method: 'DELETE',
@@ -117,6 +133,7 @@ export async function removeUserFromGroup(client: Client, parameters: RemoveUser
       groupId: parameters.groupId,
       accountId: parameters.accountId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -142,7 +159,11 @@ export async function removeUserFromGroup(client: Client, parameters: RemoveUser
  * _Browse users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg). Without this permission,
  * calls where query is not an exact match to an existing group will return an empty list.
  */
-export async function findGroups(client: Client, parameters?: FindGroups): Promise<FoundGroups> {
+export async function findGroups(
+  client: Client,
+  parameters?: FindGroups,
+  options?: RequestOptions,
+): Promise<FoundGroups> {
   const config: SendRequestOptions<FoundGroups> = {
     url: '/rest/api/3/groups/picker',
     method: 'GET',
@@ -154,6 +175,7 @@ export async function findGroups(client: Client, parameters?: FindGroups): Promi
       caseInsensitive: parameters?.caseInsensitive,
     },
     schema: FoundGroupsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueAttachments.ts
+++ b/src/cloud/api/issueAttachments.ts
@@ -6,7 +6,14 @@ import type { GetAttachmentThumbnail } from '../parameters/getAttachmentThumbnai
 import type { GetAttachment } from '../parameters/getAttachment';
 import type { RemoveAttachment } from '../parameters/removeAttachment';
 import type { AddAttachment } from '../parameters/addAttachment';
-import { type Client, type SendRequestOptions, toFormDataFile, BufferSchema, type Buffer } from '#/core';
+import {
+  type Client,
+  type RequestOptions,
+  type SendRequestOptions,
+  toFormDataFile,
+  BufferSchema,
+  type Buffer,
+} from '#/core';
 import { z } from 'zod';
 
 /**
@@ -28,7 +35,11 @@ import { z } from 'zod';
  *   to view the issue.
  * - If attachments are added in private comments, the comment-level restriction will be applied.
  */
-export async function getAttachmentContent(client: Client, parameters: GetAttachmentContent): Promise<Buffer> {
+export async function getAttachmentContent(
+  client: Client,
+  parameters: GetAttachmentContent,
+  options?: RequestOptions,
+): Promise<Buffer> {
   const config: SendRequestOptions<Buffer> = {
     url: `/rest/api/3/attachment/content/${parameters.id}`,
     method: 'GET',
@@ -36,6 +47,7 @@ export async function getAttachmentContent(client: Client, parameters: GetAttach
       redirect: parameters.redirect,
     },
     schema: BufferSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -51,11 +63,12 @@ export async function getAttachmentContent(client: Client, parameters: GetAttach
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAttachmentMeta(client: Client): Promise<AttachmentSettings> {
+export async function getAttachmentMeta(client: Client, options?: RequestOptions): Promise<AttachmentSettings> {
   const config: SendRequestOptions<AttachmentSettings> = {
     url: '/rest/api/3/attachment/meta',
     method: 'GET',
     schema: AttachmentSettingsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -78,7 +91,11 @@ export async function getAttachmentMeta(client: Client): Promise<AttachmentSetti
  *   to view the issue.
  * - If attachments are added in private comments, the comment-level restriction will be applied.
  */
-export async function getAttachmentThumbnail(client: Client, parameters: GetAttachmentThumbnail): Promise<Buffer> {
+export async function getAttachmentThumbnail(
+  client: Client,
+  parameters: GetAttachmentThumbnail,
+  options?: RequestOptions,
+): Promise<Buffer> {
   const config: SendRequestOptions<Buffer> = {
     url: `/rest/api/3/attachment/thumbnail/${parameters.id}`,
     method: 'GET',
@@ -89,6 +106,7 @@ export async function getAttachmentThumbnail(client: Client, parameters: GetAtta
       height: parameters.height,
     },
     schema: BufferSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -107,11 +125,16 @@ export async function getAttachmentThumbnail(client: Client, parameters: GetAtta
  *   to view the issue.
  * - If attachments are added in private comments, the comment-level restriction will be applied.
  */
-export async function getAttachment(client: Client, parameters: GetAttachment): Promise<AttachmentMetadata> {
+export async function getAttachment(
+  client: Client,
+  parameters: GetAttachment,
+  options?: RequestOptions,
+): Promise<AttachmentMetadata> {
   const config: SendRequestOptions<AttachmentMetadata> = {
     url: `/rest/api/3/attachment/${parameters.id}`,
     method: 'GET',
     schema: AttachmentMetadataSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -130,10 +153,15 @@ export async function getAttachment(client: Client, parameters: GetAttachment): 
  * - _Delete all attachments_ [project permission](https://confluence.atlassian.com/x/yodKLg) to delete an attachment
  *   created by any user.
  */
-export async function removeAttachment(client: Client, parameters: RemoveAttachment): Promise<void> {
+export async function removeAttachment(
+  client: Client,
+  parameters: RemoveAttachment,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/attachment/${parameters.id}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -151,7 +179,11 @@ export async function removeAttachment(client: Client, parameters: RemoveAttachm
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function addAttachment(client: Client, parameters: AddAttachment): Promise<Attachment[]> {
+export async function addAttachment(
+  client: Client,
+  parameters: AddAttachment,
+  options?: RequestOptions,
+): Promise<Attachment[]> {
   const formData = new FormData();
   const items = Array.isArray(parameters.attachments) ? parameters.attachments : [parameters.attachments];
 
@@ -167,6 +199,7 @@ export async function addAttachment(client: Client, parameters: AddAttachment): 
     },
     body: formData,
     schema: z.array(AttachmentSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueBulkOperations.ts
+++ b/src/cloud/api/issueBulkOperations.ts
@@ -14,7 +14,7 @@ import type { SubmitBulkTransition } from '../parameters/submitBulkTransition';
 import type { SubmitBulkUnwatch } from '../parameters/submitBulkUnwatch';
 import type { SubmitBulkWatch } from '../parameters/submitBulkWatch';
 import type { GetBulkOperationProgress } from '../parameters/getBulkOperationProgress';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Use this API to submit a bulk delete request. You can delete up to 1,000 issues in a single operation.
@@ -31,7 +31,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function submitBulkDelete(client: Client, parameters: SubmitBulkDelete): Promise<SubmittedBulkOperation> {
+export async function submitBulkDelete(
+  client: Client,
+  parameters: SubmitBulkDelete,
+  options?: RequestOptions,
+): Promise<SubmittedBulkOperation> {
   const config: SendRequestOptions<SubmittedBulkOperation> = {
     url: '/rest/api/3/bulk/issues/delete',
     method: 'POST',
@@ -40,6 +44,7 @@ export async function submitBulkDelete(client: Client, parameters: SubmitBulkDel
       sendBulkNotification: parameters.sendBulkNotification,
     },
     schema: SubmittedBulkOperationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -63,6 +68,7 @@ export async function submitBulkDelete(client: Client, parameters: SubmitBulkDel
 export async function getBulkEditableFields(
   client: Client,
   parameters: GetBulkEditableFields,
+  options?: RequestOptions,
 ): Promise<BulkEditGetFields> {
   const config: SendRequestOptions<BulkEditGetFields> = {
     url: '/rest/api/3/bulk/issues/fields',
@@ -74,6 +80,7 @@ export async function getBulkEditableFields(
       startingAfter: parameters.startingAfter,
     },
     schema: BulkEditGetFieldsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -95,7 +102,11 @@ export async function getBulkEditableFields(
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function submitBulkEdit(client: Client, parameters: SubmitBulkEdit): Promise<SubmittedBulkOperation> {
+export async function submitBulkEdit(
+  client: Client,
+  parameters: SubmitBulkEdit,
+  options?: RequestOptions,
+): Promise<SubmittedBulkOperation> {
   const config: SendRequestOptions<SubmittedBulkOperation> = {
     url: '/rest/api/3/bulk/issues/fields',
     method: 'POST',
@@ -106,6 +117,7 @@ export async function submitBulkEdit(client: Client, parameters: SubmitBulkEdit)
       sendBulkNotification: parameters.sendBulkNotification,
     },
     schema: SubmittedBulkOperationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -157,7 +169,11 @@ export async function submitBulkEdit(client: Client, parameters: SubmitBulkEdit)
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function submitBulkMove(client: Client, parameters: SubmitBulkMove): Promise<SubmittedBulkOperation> {
+export async function submitBulkMove(
+  client: Client,
+  parameters: SubmitBulkMove,
+  options?: RequestOptions,
+): Promise<SubmittedBulkOperation> {
   const config: SendRequestOptions<SubmittedBulkOperation> = {
     url: '/rest/api/3/bulk/issues/move',
     method: 'POST',
@@ -166,6 +182,7 @@ export async function submitBulkMove(client: Client, parameters: SubmitBulkMove)
       targetToSourcesMapping: parameters.targetToSourcesMapping,
     },
     schema: SubmittedBulkOperationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -197,6 +214,7 @@ export async function submitBulkMove(client: Client, parameters: SubmitBulkMove)
 export async function getAvailableTransitions(
   client: Client,
   parameters: GetAvailableTransitions,
+  options?: RequestOptions,
 ): Promise<BulkTransitionGetAvailableTransitions> {
   const config: SendRequestOptions<BulkTransitionGetAvailableTransitions> = {
     url: '/rest/api/3/bulk/issues/transition',
@@ -207,6 +225,7 @@ export async function getAvailableTransitions(
       startingAfter: parameters.startingAfter,
     },
     schema: BulkTransitionGetAvailableTransitionsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -231,6 +250,7 @@ export async function getAvailableTransitions(
 export async function submitBulkTransition(
   client: Client,
   parameters: SubmitBulkTransition,
+  options?: RequestOptions,
 ): Promise<SubmittedBulkOperation> {
   const config: SendRequestOptions<SubmittedBulkOperation> = {
     url: '/rest/api/3/bulk/issues/transition',
@@ -240,6 +260,7 @@ export async function submitBulkTransition(
       sendBulkNotification: parameters.sendBulkNotification,
     },
     schema: SubmittedBulkOperationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -260,6 +281,7 @@ export async function submitBulkTransition(
 export async function submitBulkUnwatch(
   client: Client,
   parameters: SubmitBulkUnwatch,
+  options?: RequestOptions,
 ): Promise<SubmittedBulkOperation> {
   const config: SendRequestOptions<SubmittedBulkOperation> = {
     url: '/rest/api/3/bulk/issues/unwatch',
@@ -268,6 +290,7 @@ export async function submitBulkUnwatch(
       selectedIssueIdsOrKeys: parameters.selectedIssueIdsOrKeys,
     },
     schema: SubmittedBulkOperationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -285,7 +308,11 @@ export async function submitBulkUnwatch(
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function submitBulkWatch(client: Client, parameters: SubmitBulkWatch): Promise<SubmittedBulkOperation> {
+export async function submitBulkWatch(
+  client: Client,
+  parameters: SubmitBulkWatch,
+  options?: RequestOptions,
+): Promise<SubmittedBulkOperation> {
   const config: SendRequestOptions<SubmittedBulkOperation> = {
     url: '/rest/api/3/bulk/issues/watch',
     method: 'POST',
@@ -293,6 +320,7 @@ export async function submitBulkWatch(client: Client, parameters: SubmitBulkWatc
       selectedIssueIdsOrKeys: parameters.selectedIssueIdsOrKeys,
     },
     schema: SubmittedBulkOperationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -338,11 +366,13 @@ export async function submitBulkWatch(client: Client, parameters: SubmitBulkWatc
 export async function getBulkOperationProgress(
   client: Client,
   parameters: GetBulkOperationProgress,
+  options?: RequestOptions,
 ): Promise<BulkOperationProgress> {
   const config: SendRequestOptions<BulkOperationProgress> = {
     url: `/rest/api/3/bulk/queue/${parameters.taskId}`,
     method: 'GET',
     schema: BulkOperationProgressSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueCommentProperties.ts
+++ b/src/cloud/api/issueCommentProperties.ts
@@ -4,7 +4,7 @@ import type { GetCommentPropertyKeys } from '../parameters/getCommentPropertyKey
 import type { GetCommentProperty } from '../parameters/getCommentProperty';
 import type { SetCommentProperty } from '../parameters/setCommentProperty';
 import type { DeleteCommentProperty } from '../parameters/deleteCommentProperty';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the keys of all the properties of a comment.
@@ -21,11 +21,13 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getCommentPropertyKeys(
   client: Client,
   parameters: GetCommentPropertyKeys,
+  options?: RequestOptions,
 ): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/api/3/comment/${parameters.commentId}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -43,11 +45,16 @@ export async function getCommentPropertyKeys(
  *   to view the issue.
  * - If the comment has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function getCommentProperty(client: Client, parameters: GetCommentProperty): Promise<EntityProperty> {
+export async function getCommentProperty(
+  client: Client,
+  parameters: GetCommentProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/api/3/comment/${parameters.commentId}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -66,11 +73,16 @@ export async function getCommentProperty(client: Client, parameters: GetCommentP
  * - _Edit Own Comments_ [project permission](https://confluence.atlassian.com/x/yodKLg) to create or update the value of
  *   a property on a comment created by the user.
  */
-export async function setCommentProperty(client: Client, parameters: SetCommentProperty): Promise<void> {
+export async function setCommentProperty(
+  client: Client,
+  parameters: SetCommentProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/comment/${parameters.commentId}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -86,10 +98,15 @@ export async function setCommentProperty(client: Client, parameters: SetCommentP
  * - _Edit Own Comments_ [project permission](https://confluence.atlassian.com/x/yodKLg) to delete a property from a
  *   comment created by the user.
  */
-export async function deleteCommentProperty(client: Client, parameters: DeleteCommentProperty): Promise<void> {
+export async function deleteCommentProperty(
+  client: Client,
+  parameters: DeleteCommentProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/comment/${parameters.commentId}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueComments.ts
+++ b/src/cloud/api/issueComments.ts
@@ -8,7 +8,7 @@ import type { AddComment } from '../parameters/addComment';
 import type { GetComment } from '../parameters/getComment';
 import type { UpdateComment } from '../parameters/updateComment';
 import type { DeleteComment } from '../parameters/deleteComment';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of comments
@@ -25,7 +25,11 @@ import type { Client, SendRequestOptions } from '#/core';
  *   to view the issue.
  * - If the comment has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function getCommentsByIds(client: Client, parameters: GetCommentsByIds): Promise<Page<Comment>> {
+export async function getCommentsByIds(
+  client: Client,
+  parameters: GetCommentsByIds,
+  options?: RequestOptions,
+): Promise<Page<Comment>> {
   const config: SendRequestOptions<Page<Comment>> = {
     url: '/rest/api/3/comment/list',
     method: 'POST',
@@ -36,6 +40,7 @@ export async function getCommentsByIds(client: Client, parameters: GetCommentsBy
       ids: parameters.ids,
     },
     schema: PageCommentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -56,7 +61,11 @@ export async function getCommentsByIds(client: Client, parameters: GetCommentsBy
  * - If the comment has visibility restrictions, belongs to the group or has the role visibility is role visibility is
  *   restricted to.
  */
-export async function getComments(client: Client, parameters: GetComments): Promise<PageOfComments> {
+export async function getComments(
+  client: Client,
+  parameters: GetComments,
+  options?: RequestOptions,
+): Promise<PageOfComments> {
   const config: SendRequestOptions<PageOfComments> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/comment`,
     method: 'GET',
@@ -67,6 +76,7 @@ export async function getComments(client: Client, parameters: GetComments): Prom
       expand: parameters.expand,
     },
     schema: PageOfCommentsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -84,19 +94,24 @@ export async function getComments(client: Client, parameters: GetComments): Prom
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function addComment(client: Client, parameters: AddComment): Promise<Comment> {
+export async function addComment(client: Client, parameters: AddComment, options?: RequestOptions): Promise<Comment> {
   if (typeof parameters.body === 'string') {
     const created = await client.sendRequest<{ id: string }>({
       url: `/rest/api/2/issue/${parameters.issueIdOrKey}/comment`,
       method: 'POST',
       body: { body: parameters.body, visibility: parameters.visibility },
+      signal: options?.signal,
     });
 
-    return getComment(client, {
-      issueIdOrKey: parameters.issueIdOrKey,
-      id: created.id,
-      expand: parameters.expand,
-    });
+    return getComment(
+      client,
+      {
+        issueIdOrKey: parameters.issueIdOrKey,
+        id: created.id,
+        expand: parameters.expand,
+      },
+      options,
+    );
   }
 
   const config: SendRequestOptions<Comment> = {
@@ -120,6 +135,7 @@ export async function addComment(client: Client, parameters: AddComment): Promis
       visibility: parameters.visibility,
     },
     schema: CommentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -139,7 +155,7 @@ export async function addComment(client: Client, parameters: AddComment): Promis
  * - If the comment has visibility restrictions, the user belongs to the group or has the role visibility is restricted
  *   to.
  */
-export async function getComment(client: Client, parameters: GetComment): Promise<Comment> {
+export async function getComment(client: Client, parameters: GetComment, options?: RequestOptions): Promise<Comment> {
   const config: SendRequestOptions<Comment> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/comment/${parameters.id}`,
     method: 'GET',
@@ -147,6 +163,7 @@ export async function getComment(client: Client, parameters: GetComment): Promis
       expand: parameters.expand,
     },
     schema: CommentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -171,19 +188,28 @@ export async function getComment(client: Client, parameters: GetComment): Promis
  * **WARNING:** Child comments inherit visibility from their parent comment. Attempting to update a child comment's
  * visibility will result in a 400 (Bad Request) error.
  */
-export async function updateComment(client: Client, parameters: UpdateComment): Promise<Comment> {
+export async function updateComment(
+  client: Client,
+  parameters: UpdateComment,
+  options?: RequestOptions,
+): Promise<Comment> {
   if (typeof parameters.body.body === 'string') {
     await client.sendRequest<unknown>({
       url: `/rest/api/2/issue/${parameters.issueIdOrKey}/comment/${parameters.id}`,
       method: 'PUT',
       body: { body: parameters.body.body, visibility: parameters.body.visibility },
+      signal: options?.signal,
     });
 
-    return getComment(client, {
-      issueIdOrKey: parameters.issueIdOrKey,
-      id: parameters.id,
-      expand: parameters.expand,
-    });
+    return getComment(
+      client,
+      {
+        issueIdOrKey: parameters.issueIdOrKey,
+        id: parameters.id,
+        expand: parameters.expand,
+      },
+      options,
+    );
   }
 
   const config: SendRequestOptions<Comment> = {
@@ -196,6 +222,7 @@ export async function updateComment(client: Client, parameters: UpdateComment): 
     },
     body: parameters.body,
     schema: CommentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -215,10 +242,15 @@ export async function updateComment(client: Client, parameters: UpdateComment): 
  * - If the comment has visibility restrictions, the user belongs to the group or has the role visibility is restricted
  *   to.
  */
-export async function deleteComment(client: Client, parameters: DeleteComment): Promise<void> {
+export async function deleteComment(
+  client: Client,
+  parameters: DeleteComment,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/comment/${parameters.id}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueCustomFieldAssociations.ts
+++ b/src/cloud/api/issueCustomFieldAssociations.ts
@@ -1,6 +1,6 @@
 import type { CreateAssociations } from '../parameters/createAssociations';
 import type { RemoveAssociations } from '../parameters/removeAssociations';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Associates fields with projects.
@@ -20,7 +20,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createAssociations(client: Client, parameters: CreateAssociations): Promise<void> {
+export async function createAssociations(
+  client: Client,
+  parameters: CreateAssociations,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/field/association',
     method: 'PUT',
@@ -28,6 +32,7 @@ export async function createAssociations(client: Client, parameters: CreateAssoc
       associationContexts: parameters.associationContexts,
       fields: parameters.fields,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -50,7 +55,11 @@ export async function createAssociations(client: Client, parameters: CreateAssoc
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function removeAssociations(client: Client, parameters: RemoveAssociations): Promise<void> {
+export async function removeAssociations(
+  client: Client,
+  parameters: RemoveAssociations,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/field/association',
     method: 'DELETE',
@@ -58,6 +67,7 @@ export async function removeAssociations(client: Client, parameters: RemoveAssoc
       associationContexts: parameters.associationContexts,
       fields: parameters.fields,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueCustomFieldConfigurationApps.ts
+++ b/src/cloud/api/issueCustomFieldConfigurationApps.ts
@@ -3,7 +3,7 @@ import type { Page } from '../models/page';
 import type { ContextualConfiguration } from '../models/contextualConfiguration';
 import type { GetCustomFieldConfiguration } from '../parameters/getCustomFieldConfiguration';
 import type { UpdateCustomFieldConfiguration } from '../parameters/updateCustomFieldConfiguration';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of
@@ -27,6 +27,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getCustomFieldConfiguration(
   client: Client,
   parameters: GetCustomFieldConfiguration,
+  options?: RequestOptions,
 ): Promise<Page<ContextualConfiguration>> {
   const config: SendRequestOptions<Page<ContextualConfiguration>> = {
     url: `/rest/api/3/app/field/${parameters.fieldIdOrKey}/context/configuration`,
@@ -41,6 +42,7 @@ export async function getCustomFieldConfiguration(
       maxResults: parameters.maxResults,
     },
     schema: PageContextualConfigurationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -58,6 +60,7 @@ export async function getCustomFieldConfiguration(
 export async function updateCustomFieldConfiguration(
   client: Client,
   parameters: UpdateCustomFieldConfiguration,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/app/field/${parameters.fieldIdOrKey}/context/configuration`,
@@ -65,6 +68,7 @@ export async function updateCustomFieldConfiguration(
     body: {
       configurations: parameters.configurations,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueCustomFieldContexts.ts
+++ b/src/cloud/api/issueCustomFieldContexts.ts
@@ -22,7 +22,7 @@ import type { AddIssueTypesToContext } from '../parameters/addIssueTypesToContex
 import type { RemoveIssueTypesFromContext } from '../parameters/removeIssueTypesFromContext';
 import type { AssignProjectsToCustomFieldContext } from '../parameters/assignProjectsToCustomFieldContext';
 import type { RemoveCustomFieldContextFromProjects } from '../parameters/removeCustomFieldContextFromProjects';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of [
@@ -43,6 +43,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getContextsForField(
   client: Client,
   parameters: GetContextsForField,
+  options?: RequestOptions,
 ): Promise<Page<CustomFieldContext>> {
   const config: SendRequestOptions<Page<CustomFieldContext>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context`,
@@ -55,6 +56,7 @@ export async function getContextsForField(
       maxResults: parameters.maxResults,
     },
     schema: PageCustomFieldContextSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -72,6 +74,7 @@ export async function getContextsForField(
 export async function createCustomFieldContext(
   client: Client,
   parameters: CreateCustomFieldContextParameters,
+  options?: RequestOptions,
 ): Promise<CreateCustomFieldContext> {
   const config: SendRequestOptions<CreateCustomFieldContext> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context`,
@@ -84,6 +87,7 @@ export async function createCustomFieldContext(
       projectIds: parameters.projectIds,
     },
     schema: CreateCustomFieldContextSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -111,6 +115,7 @@ export async function createCustomFieldContext(
 export async function getContextDefaultValues(
   client: Client,
   parameters: GetContextDefaultValues,
+  options?: RequestOptions,
 ): Promise<Page<ContextDefaultValues>> {
   const config: SendRequestOptions<Page<ContextDefaultValues>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/defaultValues`,
@@ -122,6 +127,7 @@ export async function getContextDefaultValues(
       maxResults: parameters.maxResults,
     },
     schema: PageContextDefaultValuesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -138,6 +144,7 @@ export async function getContextDefaultValues(
 export async function getIssueTypeMappingsForContexts(
   client: Client,
   parameters: GetIssueTypeMappingsForContexts,
+  options?: RequestOptions,
 ): Promise<Page<IssueTypeToContextMapping>> {
   const config: SendRequestOptions<Page<IssueTypeToContextMapping>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/issuetypemapping`,
@@ -148,6 +155,7 @@ export async function getIssueTypeMappingsForContexts(
       maxResults: parameters.maxResults,
     },
     schema: PageIssueTypeToContextMappingSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -172,6 +180,7 @@ export async function getIssueTypeMappingsForContexts(
 export async function getCustomFieldContextsForProjectsAndIssueTypes(
   client: Client,
   parameters: GetCustomFieldContextsForProjectsAndIssueTypes,
+  options?: RequestOptions,
 ): Promise<Page<ContextForProjectAndIssueType>> {
   const config: SendRequestOptions<Page<ContextForProjectAndIssueType>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/mapping`,
@@ -184,6 +193,7 @@ export async function getCustomFieldContextsForProjectsAndIssueTypes(
       mappings: parameters.mappings,
     },
     schema: PageContextForProjectAndIssueTypeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -194,12 +204,19 @@ export async function getCustomFieldContextsForProjectsAndIssueTypes(
  * to project mappings for a custom field. The result can be filtered by `contextId`. Otherwise, all mappings are
  * returned. Invalid IDs are ignored.
  *
+ * **Note:** Jira is adding support for multiple field contexts per project. On sites where this is enabled, a custom
+ * field can have more than one context associated with the same project, so this operation can return several mappings
+ * that share the same `projectId`, each with a different `contextId`. Do not assume that a project appears at most once
+ * in the response. See [CHANGE-3082](https://developer.atlassian.com/cloud/jira/platform/changelog/#CHANGE-3082) for
+ * more details.
+ *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
 export async function getProjectContextMapping(
   client: Client,
   parameters: GetProjectContextMapping,
+  options?: RequestOptions,
 ): Promise<Page<CustomFieldContextProjectMapping>> {
   const config: SendRequestOptions<Page<CustomFieldContextProjectMapping>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/projectmapping`,
@@ -210,6 +227,7 @@ export async function getProjectContextMapping(
       maxResults: parameters.maxResults,
     },
     schema: PageCustomFieldContextProjectMappingSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -222,7 +240,11 @@ export async function getProjectContextMapping(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateCustomFieldContext(client: Client, parameters: UpdateCustomFieldContext): Promise<void> {
+export async function updateCustomFieldContext(
+  client: Client,
+  parameters: UpdateCustomFieldContext,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}`,
     method: 'PUT',
@@ -230,6 +252,7 @@ export async function updateCustomFieldContext(client: Client, parameters: Updat
       description: parameters.description,
       name: parameters.name,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -245,10 +268,15 @@ export async function updateCustomFieldContext(client: Client, parameters: Updat
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteCustomFieldContext(client: Client, parameters: DeleteCustomFieldContext): Promise<void> {
+export async function deleteCustomFieldContext(
+  client: Client,
+  parameters: DeleteCustomFieldContext,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -268,13 +296,18 @@ export async function deleteCustomFieldContext(client: Client, parameters: Delet
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function addIssueTypesToContext(client: Client, parameters: AddIssueTypesToContext): Promise<void> {
+export async function addIssueTypesToContext(
+  client: Client,
+  parameters: AddIssueTypesToContext,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/issuetype`,
     method: 'PUT',
     body: {
       issueTypeIds: parameters.issueTypeIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -291,6 +324,7 @@ export async function addIssueTypesToContext(client: Client, parameters: AddIssu
 export async function removeIssueTypesFromContext(
   client: Client,
   parameters: RemoveIssueTypesFromContext,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/issuetype/remove`,
@@ -298,6 +332,7 @@ export async function removeIssueTypesFromContext(
     body: {
       issueTypeIds: parameters.issueTypeIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -317,6 +352,7 @@ export async function removeIssueTypesFromContext(
 export async function assignProjectsToCustomFieldContext(
   client: Client,
   parameters: AssignProjectsToCustomFieldContext,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/project`,
@@ -324,6 +360,7 @@ export async function assignProjectsToCustomFieldContext(
     body: {
       projectIds: parameters.projectIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -344,6 +381,7 @@ export async function assignProjectsToCustomFieldContext(
 export async function removeCustomFieldContextFromProjects(
   client: Client,
   parameters: RemoveCustomFieldContextFromProjects,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/project/remove`,
@@ -351,6 +389,7 @@ export async function removeCustomFieldContextFromProjects(
     body: {
       projectIds: parameters.projectIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueCustomFieldOptions.ts
+++ b/src/cloud/api/issueCustomFieldOptions.ts
@@ -21,7 +21,7 @@ import type { UpdateCustomFieldOption } from '../parameters/updateCustomFieldOpt
 import type { ReorderCustomFieldOptions } from '../parameters/reorderCustomFieldOptions';
 import type { DeleteCustomFieldOption } from '../parameters/deleteCustomFieldOption';
 import type { ReplaceCustomFieldOption } from '../parameters/replaceCustomFieldOption';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a custom field option. For example, an option in a select list.
@@ -44,11 +44,13 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getCustomFieldOption(
   client: Client,
   parameters: GetCustomFieldOption,
+  options?: RequestOptions,
 ): Promise<CustomFieldOption> {
   const config: SendRequestOptions<CustomFieldOption> = {
     url: `/rest/api/3/customFieldOption/${parameters.id}`,
     method: 'GET',
     schema: CustomFieldOptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -71,6 +73,7 @@ export async function getCustomFieldOption(
 export async function getOptionsForContext(
   client: Client,
   parameters: GetOptionsForContext,
+  options?: RequestOptions,
 ): Promise<Page<CustomFieldContextOption>> {
   const config: SendRequestOptions<Page<CustomFieldContextOption>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/option`,
@@ -82,6 +85,7 @@ export async function getOptionsForContext(
       maxResults: parameters.maxResults,
     },
     schema: PageCustomFieldContextOptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -105,6 +109,7 @@ export async function getOptionsForContext(
 export async function createCustomFieldOption(
   client: Client,
   parameters: CreateCustomFieldOption,
+  options?: RequestOptions,
 ): Promise<CustomFieldCreatedContextOptionsList> {
   const config: SendRequestOptions<CustomFieldCreatedContextOptionsList> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/option`,
@@ -113,6 +118,7 @@ export async function createCustomFieldOption(
       options: parameters.options,
     },
     schema: CustomFieldCreatedContextOptionsListSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -135,6 +141,7 @@ export async function createCustomFieldOption(
 export async function updateCustomFieldOption(
   client: Client,
   parameters: UpdateCustomFieldOption,
+  options?: RequestOptions,
 ): Promise<CustomFieldUpdatedContextOptionsList> {
   const config: SendRequestOptions<CustomFieldUpdatedContextOptionsList> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/option`,
@@ -143,6 +150,7 @@ export async function updateCustomFieldOption(
       options: parameters.options,
     },
     schema: CustomFieldUpdatedContextOptionsListSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -159,7 +167,11 @@ export async function updateCustomFieldOption(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function reorderCustomFieldOptions(client: Client, parameters: ReorderCustomFieldOptions): Promise<void> {
+export async function reorderCustomFieldOptions(
+  client: Client,
+  parameters: ReorderCustomFieldOptions,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/option/move`,
     method: 'PUT',
@@ -168,6 +180,7 @@ export async function reorderCustomFieldOptions(client: Client, parameters: Reor
       customFieldOptionIds: parameters.customFieldOptionIds,
       position: parameters.position,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -186,10 +199,15 @@ export async function reorderCustomFieldOptions(client: Client, parameters: Reor
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteCustomFieldOption(client: Client, parameters: DeleteCustomFieldOption): Promise<void> {
+export async function deleteCustomFieldOption(
+  client: Client,
+  parameters: DeleteCustomFieldOption,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/option/${parameters.optionId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -209,6 +227,7 @@ export async function deleteCustomFieldOption(client: Client, parameters: Delete
 export async function replaceCustomFieldOption(
   client: Client,
   parameters: ReplaceCustomFieldOption,
+  options?: RequestOptions,
 ): Promise<TaskProgressRemoveOptionFromIssuesResult> {
   const config: SendRequestOptions<TaskProgressRemoveOptionFromIssuesResult> = {
     url: `/rest/api/3/field/${parameters.fieldId}/context/${parameters.contextId}/option/${parameters.optionId}/issue`,
@@ -218,6 +237,7 @@ export async function replaceCustomFieldOption(
       jql: parameters.jql,
     },
     schema: TaskProgressRemoveOptionFromIssuesResultSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueCustomFieldOptionsApps.ts
+++ b/src/cloud/api/issueCustomFieldOptionsApps.ts
@@ -13,7 +13,7 @@ import type { GetIssueFieldOption } from '../parameters/getIssueFieldOption';
 import type { UpdateIssueFieldOption } from '../parameters/updateIssueFieldOption';
 import type { DeleteIssueFieldOption } from '../parameters/deleteIssueFieldOption';
 import type { ReplaceIssueFieldOption } from '../parameters/replaceIssueFieldOption';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of all the
@@ -33,6 +33,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getAllIssueFieldOptions(
   client: Client,
   parameters: GetAllIssueFieldOptions,
+  options?: RequestOptions,
 ): Promise<Page<IssueFieldOption>> {
   const config: SendRequestOptions<Page<IssueFieldOption>> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option`,
@@ -42,6 +43,7 @@ export async function getAllIssueFieldOptions(
       maxResults: parameters.maxResults,
     },
     schema: PageIssueFieldOptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -64,6 +66,7 @@ export async function getAllIssueFieldOptions(
 export async function createIssueFieldOption(
   client: Client,
   parameters: CreateIssueFieldOption,
+  options?: RequestOptions,
 ): Promise<IssueFieldOption> {
   const config: SendRequestOptions<IssueFieldOption> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option`,
@@ -74,6 +77,7 @@ export async function createIssueFieldOption(
       value: parameters.value,
     },
     schema: IssueFieldOptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -94,6 +98,7 @@ export async function createIssueFieldOption(
 export async function getSelectableIssueFieldOptions(
   client: Client,
   parameters: GetSelectableIssueFieldOptions,
+  options?: RequestOptions,
 ): Promise<Page<IssueFieldOption>> {
   const config: SendRequestOptions<Page<IssueFieldOption>> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option/suggestions/edit`,
@@ -104,6 +109,7 @@ export async function getSelectableIssueFieldOptions(
       projectId: parameters.projectId,
     },
     schema: PageIssueFieldOptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -124,6 +130,7 @@ export async function getSelectableIssueFieldOptions(
 export async function getVisibleIssueFieldOptions(
   client: Client,
   parameters: GetVisibleIssueFieldOptions,
+  options?: RequestOptions,
 ): Promise<Page<IssueFieldOption>> {
   const config: SendRequestOptions<Page<IssueFieldOption>> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option/suggestions/search`,
@@ -134,6 +141,7 @@ export async function getVisibleIssueFieldOptions(
       projectId: parameters.projectId,
     },
     schema: PageIssueFieldOptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -151,11 +159,16 @@ export async function getVisibleIssueFieldOptions(
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg). Jira permissions are not required
  * for the app providing the field.
  */
-export async function getIssueFieldOption(client: Client, parameters: GetIssueFieldOption): Promise<IssueFieldOption> {
+export async function getIssueFieldOption(
+  client: Client,
+  parameters: GetIssueFieldOption,
+  options?: RequestOptions,
+): Promise<IssueFieldOption> {
   const config: SendRequestOptions<IssueFieldOption> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option/${parameters.optionId}`,
     method: 'GET',
     schema: IssueFieldOptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -178,6 +191,7 @@ export async function getIssueFieldOption(client: Client, parameters: GetIssueFi
 export async function updateIssueFieldOption(
   client: Client,
   parameters: UpdateIssueFieldOption,
+  options?: RequestOptions,
 ): Promise<IssueFieldOption> {
   const config: SendRequestOptions<IssueFieldOption> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option/${parameters.optionId}`,
@@ -189,6 +203,7 @@ export async function updateIssueFieldOption(
       value: parameters.value,
     },
     schema: IssueFieldOptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -206,10 +221,15 @@ export async function updateIssueFieldOption(
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg). Jira permissions are not required
  * for the app providing the field.
  */
-export async function deleteIssueFieldOption(client: Client, parameters: DeleteIssueFieldOption): Promise<void> {
+export async function deleteIssueFieldOption(
+  client: Client,
+  parameters: DeleteIssueFieldOption,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option/${parameters.optionId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -237,6 +257,7 @@ export async function deleteIssueFieldOption(client: Client, parameters: DeleteI
 export async function replaceIssueFieldOption(
   client: Client,
   parameters: ReplaceIssueFieldOption,
+  options?: RequestOptions,
 ): Promise<TaskProgressRemoveOptionFromIssuesResult> {
   const config: SendRequestOptions<TaskProgressRemoveOptionFromIssuesResult> = {
     url: `/rest/api/3/field/${parameters.fieldKey}/option/${parameters.optionId}/issue`,
@@ -248,6 +269,7 @@ export async function replaceIssueFieldOption(
       overrideEditableFlag: parameters.overrideEditableFlag,
     },
     schema: TaskProgressRemoveOptionFromIssuesResultSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueCustomFieldValuesApps.ts
+++ b/src/cloud/api/issueCustomFieldValuesApps.ts
@@ -1,6 +1,6 @@
 import type { UpdateMultipleCustomFieldValues } from '../parameters/updateMultipleCustomFieldValues';
 import type { UpdateCustomFieldValue } from '../parameters/updateCustomFieldValue';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Updates the value of one or more custom fields on one or more issues. Combinations of custom field and issue should
@@ -20,6 +20,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function updateMultipleCustomFieldValues(
   client: Client,
   parameters: UpdateMultipleCustomFieldValues,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/app/field/value',
@@ -31,6 +32,7 @@ export async function updateMultipleCustomFieldValues(
     body: {
       updates: parameters.updates,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -50,7 +52,11 @@ export async function updateMultipleCustomFieldValues(
  * The new `write:app-data:jira` OAuth scope is 100% optional now, and not using it won't break your app. However, we
  * recommend adding it to your app's scope list because we will eventually make it mandatory.
  */
-export async function updateCustomFieldValue(client: Client, parameters: UpdateCustomFieldValue): Promise<void> {
+export async function updateCustomFieldValue(
+  client: Client,
+  parameters: UpdateCustomFieldValue,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/app/field/${parameters.fieldIdOrKey}/value`,
     method: 'PUT',
@@ -61,6 +67,7 @@ export async function updateCustomFieldValue(client: Client, parameters: UpdateC
     body: {
       updates: parameters.updates,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueFields.ts
+++ b/src/cloud/api/issueFields.ts
@@ -10,7 +10,7 @@ import type { UpdateCustomField } from '../parameters/updateCustomField';
 import type { DeleteCustomField } from '../parameters/deleteCustomField';
 import type { RestoreCustomField } from '../parameters/restoreCustomField';
 import type { TrashCustomField } from '../parameters/trashCustomField';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -29,11 +29,12 @@ import { z } from 'zod';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getFields(client: Client): Promise<FieldDetails[]> {
+export async function getFields(client: Client, options?: RequestOptions): Promise<FieldDetails[]> {
   const config: SendRequestOptions<FieldDetails[]> = {
     url: '/rest/api/3/field',
     method: 'GET',
     schema: z.array(FieldDetailsSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -45,7 +46,11 @@ export async function getFields(client: Client): Promise<FieldDetails[]> {
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createCustomField(client: Client, parameters: CreateCustomField): Promise<FieldDetails> {
+export async function createCustomField(
+  client: Client,
+  parameters: CreateCustomField,
+  options?: RequestOptions,
+): Promise<FieldDetails> {
   const config: SendRequestOptions<FieldDetails> = {
     url: '/rest/api/3/field',
     method: 'POST',
@@ -56,6 +61,7 @@ export async function createCustomField(client: Client, parameters: CreateCustom
       type: parameters.type,
     },
     schema: FieldDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -75,7 +81,11 @@ export async function createCustomField(client: Client, parameters: CreateCustom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getFieldsPaginated(client: Client, parameters?: GetFieldsPaginated): Promise<Page<Field>> {
+export async function getFieldsPaginated(
+  client: Client,
+  parameters?: GetFieldsPaginated,
+  options?: RequestOptions,
+): Promise<Page<Field>> {
   const config: SendRequestOptions<Page<Field>> = {
     url: '/rest/api/3/field/search',
     method: 'GET',
@@ -90,6 +100,7 @@ export async function getFieldsPaginated(client: Client, parameters?: GetFieldsP
       projectIds: parameters?.projectIds,
     },
     schema: PageFieldSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -107,6 +118,7 @@ export async function getFieldsPaginated(client: Client, parameters?: GetFieldsP
 export async function getTrashedFieldsPaginated(
   client: Client,
   parameters?: GetTrashedFieldsPaginated,
+  options?: RequestOptions,
 ): Promise<Page<Field>> {
   const config: SendRequestOptions<Page<Field>> = {
     url: '/rest/api/3/field/search/trashed',
@@ -120,6 +132,7 @@ export async function getTrashedFieldsPaginated(
       orderBy: parameters?.orderBy,
     },
     schema: PageFieldSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -131,7 +144,11 @@ export async function getTrashedFieldsPaginated(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateCustomField(client: Client, parameters: UpdateCustomField): Promise<void> {
+export async function updateCustomField(
+  client: Client,
+  parameters: UpdateCustomField,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.fieldId}`,
     method: 'PUT',
@@ -140,6 +157,7 @@ export async function updateCustomField(client: Client, parameters: UpdateCustom
       name: parameters.name,
       searcherKey: parameters.searcherKey,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -157,11 +175,16 @@ export async function updateCustomField(client: Client, parameters: UpdateCustom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteCustomField(client: Client, parameters: DeleteCustomField): Promise<TaskProgressObject> {
+export async function deleteCustomField(
+  client: Client,
+  parameters: DeleteCustomField,
+  options?: RequestOptions,
+): Promise<TaskProgressObject> {
   const config: SendRequestOptions<TaskProgressObject> = {
     url: `/rest/api/3/field/${parameters.id}`,
     method: 'DELETE',
     schema: TaskProgressObjectSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -174,10 +197,15 @@ export async function deleteCustomField(client: Client, parameters: DeleteCustom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function restoreCustomField(client: Client, parameters: RestoreCustomField): Promise<void> {
+export async function restoreCustomField(
+  client: Client,
+  parameters: RestoreCustomField,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.id}/restore`,
     method: 'POST',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -190,10 +218,15 @@ export async function restoreCustomField(client: Client, parameters: RestoreCust
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function trashCustomField(client: Client, parameters: TrashCustomField): Promise<void> {
+export async function trashCustomField(
+  client: Client,
+  parameters: TrashCustomField,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/field/${parameters.id}/trash`,
     method: 'POST',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueLinkTypes.ts
+++ b/src/cloud/api/issueLinkTypes.ts
@@ -4,7 +4,7 @@ import type { CreateIssueLinkType } from '../parameters/createIssueLinkType';
 import type { GetIssueLinkType } from '../parameters/getIssueLinkType';
 import type { UpdateIssueLinkType } from '../parameters/updateIssueLinkType';
 import type { DeleteIssueLinkType } from '../parameters/deleteIssueLinkType';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a list of all issue link types.
@@ -16,11 +16,12 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for a project in the site.
  */
-export async function getIssueLinkTypes(client: Client): Promise<IssueLinkTypes> {
+export async function getIssueLinkTypes(client: Client, options?: RequestOptions): Promise<IssueLinkTypes> {
   const config: SendRequestOptions<IssueLinkTypes> = {
     url: '/rest/api/3/issueLinkType',
     method: 'GET',
     schema: IssueLinkTypesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -35,7 +36,11 @@ export async function getIssueLinkTypes(client: Client): Promise<IssueLinkTypes>
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createIssueLinkType(client: Client, parameters: CreateIssueLinkType): Promise<IssueLinkType> {
+export async function createIssueLinkType(
+  client: Client,
+  parameters: CreateIssueLinkType,
+  options?: RequestOptions,
+): Promise<IssueLinkType> {
   const config: SendRequestOptions<IssueLinkType> = {
     url: '/rest/api/3/issueLinkType',
     method: 'POST',
@@ -47,6 +52,7 @@ export async function createIssueLinkType(client: Client, parameters: CreateIssu
       self: parameters.self,
     },
     schema: IssueLinkTypeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -62,11 +68,16 @@ export async function createIssueLinkType(client: Client, parameters: CreateIssu
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for a project in the site.
  */
-export async function getIssueLinkType(client: Client, parameters: GetIssueLinkType): Promise<IssueLinkType> {
+export async function getIssueLinkType(
+  client: Client,
+  parameters: GetIssueLinkType,
+  options?: RequestOptions,
+): Promise<IssueLinkType> {
   const config: SendRequestOptions<IssueLinkType> = {
     url: `/rest/api/3/issueLinkType/${parameters.issueLinkTypeId}`,
     method: 'GET',
     schema: IssueLinkTypeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -80,7 +91,11 @@ export async function getIssueLinkType(client: Client, parameters: GetIssueLinkT
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateIssueLinkType(client: Client, parameters: UpdateIssueLinkType): Promise<IssueLinkType> {
+export async function updateIssueLinkType(
+  client: Client,
+  parameters: UpdateIssueLinkType,
+  options?: RequestOptions,
+): Promise<IssueLinkType> {
   const config: SendRequestOptions<IssueLinkType> = {
     url: `/rest/api/3/issueLinkType/${parameters.issueLinkTypeId}`,
     method: 'PUT',
@@ -92,6 +107,7 @@ export async function updateIssueLinkType(client: Client, parameters: UpdateIssu
       self: parameters.self,
     },
     schema: IssueLinkTypeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -105,10 +121,15 @@ export async function updateIssueLinkType(client: Client, parameters: UpdateIssu
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteIssueLinkType(client: Client, parameters: DeleteIssueLinkType): Promise<void> {
+export async function deleteIssueLinkType(
+  client: Client,
+  parameters: DeleteIssueLinkType,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issueLinkType/${parameters.issueLinkTypeId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueLinks.ts
+++ b/src/cloud/api/issueLinks.ts
@@ -2,7 +2,7 @@ import { IssueLinkSchema, type IssueLink } from '../models/issueLink';
 import type { LinkIssues } from '../parameters/linkIssues';
 import type { GetIssueLink } from '../parameters/getIssueLink';
 import type { DeleteIssueLink } from '../parameters/deleteIssueLink';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Creates a link between two issues. Use this operation to indicate a relationship between two issues and optionally
@@ -27,7 +27,7 @@ import type { Client, SendRequestOptions } from '#/core';
  *   to view the issue.
  * - If the comment has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function linkIssues(client: Client, parameters: LinkIssues): Promise<void> {
+export async function linkIssues(client: Client, parameters: LinkIssues, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/issueLink',
     method: 'POST',
@@ -37,6 +37,7 @@ export async function linkIssues(client: Client, parameters: LinkIssues): Promis
       outwardIssue: parameters.outwardIssue,
       type: parameters.type,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -54,11 +55,16 @@ export async function linkIssues(client: Client, parameters: LinkIssues): Promis
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, permission to view both of the
  *   issues.
  */
-export async function getIssueLink(client: Client, parameters: GetIssueLink): Promise<IssueLink> {
+export async function getIssueLink(
+  client: Client,
+  parameters: GetIssueLink,
+  options?: RequestOptions,
+): Promise<IssueLink> {
   const config: SendRequestOptions<IssueLink> = {
     url: `/rest/api/3/issueLink/${parameters.linkId}`,
     method: 'GET',
     schema: IssueLinkSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -78,10 +84,15 @@ export async function getIssueLink(client: Client, parameters: GetIssueLink): Pr
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, permission to view both of the
  *   issues.
  */
-export async function deleteIssueLink(client: Client, parameters: DeleteIssueLink): Promise<void> {
+export async function deleteIssueLink(
+  client: Client,
+  parameters: DeleteIssueLink,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issueLink/${parameters.linkId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueNavigatorSettings.ts
+++ b/src/cloud/api/issueNavigatorSettings.ts
@@ -1,6 +1,6 @@
 import { ColumnItemSchema, type ColumnItem } from '../models/columnItem';
 import type { SetIssueNavigatorDefaultColumns } from '../parameters/setIssueNavigatorDefaultColumns';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -9,11 +9,12 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getIssueNavigatorDefaultColumns(client: Client): Promise<ColumnItem[]> {
+export async function getIssueNavigatorDefaultColumns(client: Client, options?: RequestOptions): Promise<ColumnItem[]> {
   const config: SendRequestOptions<ColumnItem[]> = {
     url: '/rest/api/3/settings/columns',
     method: 'GET',
     schema: z.array(ColumnItemSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -39,6 +40,7 @@ export async function getIssueNavigatorDefaultColumns(client: Client): Promise<C
 export async function setIssueNavigatorDefaultColumns(
   client: Client,
   parameters: SetIssueNavigatorDefaultColumns,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/settings/columns',
@@ -46,6 +48,7 @@ export async function setIssueNavigatorDefaultColumns(
     body: {
       columns: parameters.columns,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueNotificationSchemes.ts
+++ b/src/cloud/api/issueNotificationSchemes.ts
@@ -8,7 +8,7 @@ import type { GetNotificationSchemeToProjectMappings } from '../parameters/getNo
 import type { GetNotificationScheme } from '../parameters/getNotificationScheme';
 import type { AddNotifications } from '../parameters/addNotifications';
 import type { RemoveNotificationFromNotificationScheme } from '../parameters/removeNotificationFromNotificationScheme';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of
@@ -23,6 +23,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getNotificationSchemes(
   client: Client,
   parameters?: GetNotificationSchemes,
+  options?: RequestOptions,
 ): Promise<Page<NotificationScheme>> {
   const config: SendRequestOptions<Page<NotificationScheme>> = {
     url: '/rest/api/3/notificationscheme',
@@ -36,6 +37,7 @@ export async function getNotificationSchemes(
       expand: parameters?.expand,
     },
     schema: PageNotificationSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -54,6 +56,7 @@ export async function getNotificationSchemes(
 export async function getNotificationSchemeToProjectMappings(
   client: Client,
   parameters?: GetNotificationSchemeToProjectMappings,
+  options?: RequestOptions,
 ): Promise<Page<NotificationSchemeAndProjectMapping>> {
   const config: SendRequestOptions<Page<NotificationSchemeAndProjectMapping>> = {
     url: '/rest/api/3/notificationscheme/project',
@@ -65,6 +68,7 @@ export async function getNotificationSchemeToProjectMappings(
       projectId: parameters?.projectId,
     },
     schema: NotificationSchemeAndProjectMappingPageSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -81,6 +85,7 @@ export async function getNotificationSchemeToProjectMappings(
 export async function getNotificationScheme(
   client: Client,
   parameters: GetNotificationScheme,
+  options?: RequestOptions,
 ): Promise<NotificationScheme> {
   const config: SendRequestOptions<NotificationScheme> = {
     url: `/rest/api/3/notificationscheme/${parameters.id}`,
@@ -89,6 +94,7 @@ export async function getNotificationScheme(
       expand: parameters.expand,
     },
     schema: NotificationSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -103,13 +109,18 @@ export async function getNotificationScheme(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function addNotifications(client: Client, parameters: AddNotifications): Promise<void> {
+export async function addNotifications(
+  client: Client,
+  parameters: AddNotifications,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/notificationscheme/${parameters.id}/notification`,
     method: 'PUT',
     body: {
       notificationSchemeEvents: parameters.notificationSchemeEvents,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -124,10 +135,12 @@ export async function addNotifications(client: Client, parameters: AddNotificati
 export async function removeNotificationFromNotificationScheme(
   client: Client,
   parameters: RemoveNotificationFromNotificationScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/notificationscheme/${parameters.notificationSchemeId}/notification/${parameters.notificationId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issuePanels.ts
+++ b/src/cloud/api/issuePanels.ts
@@ -3,7 +3,7 @@ import {
   type ForgePanelProjectPinAsyncResponse,
 } from '../models/forgePanelProjectPinAsyncResponse';
 import type { BulkPinUnpinProjectsAsync } from '../parameters/bulkPinUnpinProjectsAsync';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Bulk pin or unpin an issue panel (added by a Forge app) to or from multiple projects.
@@ -18,6 +18,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function bulkPinUnpinProjectsAsync(
   client: Client,
   parameters: BulkPinUnpinProjectsAsync,
+  options?: RequestOptions,
 ): Promise<ForgePanelProjectPinAsyncResponse> {
   const config: SendRequestOptions<ForgePanelProjectPinAsyncResponse> = {
     url: '/rest/api/3/forge/panel/action/bulk/async',
@@ -27,6 +28,7 @@ export async function bulkPinUnpinProjectsAsync(
       projectList: parameters.projectList,
     },
     schema: ForgePanelProjectPinAsyncResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issuePriorities.ts
+++ b/src/cloud/api/issuePriorities.ts
@@ -10,7 +10,7 @@ import type { SearchPriorities } from '../parameters/searchPriorities';
 import type { GetPriority } from '../parameters/getPriority';
 import type { UpdatePriority } from '../parameters/updatePriority';
 import type { DeletePriority } from '../parameters/deletePriority';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Creates an issue priority.
@@ -21,7 +21,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createPriority(client: Client, parameters: CreatePriority): Promise<PriorityId> {
+export async function createPriority(
+  client: Client,
+  parameters: CreatePriority,
+  options?: RequestOptions,
+): Promise<PriorityId> {
   const config: SendRequestOptions<PriorityId> = {
     url: '/rest/api/3/priority',
     method: 'POST',
@@ -33,6 +37,7 @@ export async function createPriority(client: Client, parameters: CreatePriority)
       statusColor: parameters.statusColor,
     },
     schema: PriorityIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -44,13 +49,18 @@ export async function createPriority(client: Client, parameters: CreatePriority)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function setDefaultPriority(client: Client, parameters: SetDefaultPriority): Promise<void> {
+export async function setDefaultPriority(
+  client: Client,
+  parameters: SetDefaultPriority,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/priority/default',
     method: 'PUT',
     body: {
       id: parameters.id,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -62,7 +72,11 @@ export async function setDefaultPriority(client: Client, parameters: SetDefaultP
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function movePriorities(client: Client, parameters: MovePriorities): Promise<void> {
+export async function movePriorities(
+  client: Client,
+  parameters: MovePriorities,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/priority/move',
     method: 'PUT',
@@ -71,6 +85,7 @@ export async function movePriorities(client: Client, parameters: MovePriorities)
       ids: parameters.ids,
       position: parameters.position,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -95,7 +110,11 @@ export async function movePriorities(client: Client, parameters: MovePriorities)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function searchPriorities(client: Client, parameters?: SearchPriorities): Promise<Page<Priority>> {
+export async function searchPriorities(
+  client: Client,
+  parameters?: SearchPriorities,
+  options?: RequestOptions,
+): Promise<Page<Priority>> {
   const config: SendRequestOptions<Page<Priority>> = {
     url: '/rest/api/3/priority/search',
     method: 'GET',
@@ -109,6 +128,7 @@ export async function searchPriorities(client: Client, parameters?: SearchPriori
       expand: parameters?.expand,
     },
     schema: PagePrioritySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -122,11 +142,16 @@ export async function searchPriorities(client: Client, parameters?: SearchPriori
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getPriority(client: Client, parameters: GetPriority): Promise<Priority> {
+export async function getPriority(
+  client: Client,
+  parameters: GetPriority,
+  options?: RequestOptions,
+): Promise<Priority> {
   const config: SendRequestOptions<Priority> = {
     url: `/rest/api/3/priority/${parameters.id}`,
     method: 'GET',
     schema: PrioritySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -143,7 +168,11 @@ export async function getPriority(client: Client, parameters: GetPriority): Prom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updatePriority(client: Client, parameters: UpdatePriority): Promise<void> {
+export async function updatePriority(
+  client: Client,
+  parameters: UpdatePriority,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/priority/${parameters.id}`,
     method: 'PUT',
@@ -154,6 +183,7 @@ export async function updatePriority(client: Client, parameters: UpdatePriority)
       name: parameters.name,
       statusColor: parameters.statusColor,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -170,11 +200,16 @@ export async function updatePriority(client: Client, parameters: UpdatePriority)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deletePriority(client: Client, parameters: DeletePriority): Promise<TaskProgressObject> {
+export async function deletePriority(
+  client: Client,
+  parameters: DeletePriority,
+  options?: RequestOptions,
+): Promise<TaskProgressObject> {
   const config: SendRequestOptions<TaskProgressObject> = {
     url: `/rest/api/3/priority/${parameters.id}`,
     method: 'DELETE',
     schema: TaskProgressObjectSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueProperties.ts
+++ b/src/cloud/api/issueProperties.ts
@@ -8,7 +8,7 @@ import type { GetIssuePropertyKeys } from '../parameters/getIssuePropertyKeys';
 import type { GetIssueProperty } from '../parameters/getIssueProperty';
 import type { SetIssueProperty } from '../parameters/setIssueProperty';
 import type { DeleteIssueProperty } from '../parameters/deleteIssueProperty';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Sets or updates a list of entity property values on issues. A list of up to 10 entity properties can be specified
@@ -36,6 +36,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function bulkSetIssuesPropertiesList(
   client: Client,
   parameters: BulkSetIssuesPropertiesList,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/issue/properties',
@@ -44,6 +45,7 @@ export async function bulkSetIssuesPropertiesList(
       entitiesIds: parameters.entitiesIds,
       properties: parameters.properties,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -73,6 +75,7 @@ export async function bulkSetIssuesPropertiesList(
 export async function bulkSetIssuePropertiesByIssue(
   client: Client,
   parameters: BulkSetIssuePropertiesByIssue,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/issue/properties/multi',
@@ -80,6 +83,7 @@ export async function bulkSetIssuePropertiesByIssue(
     body: {
       issues: parameters.issues,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -129,7 +133,11 @@ export async function bulkSetIssuePropertiesByIssue(
  *   to view the issue.
  * - _Edit issues_ [project permission](https://confluence.atlassian.com/x/yodKLg) for each issue.
  */
-export async function bulkSetIssueProperty(client: Client, parameters: BulkSetIssueProperty): Promise<void> {
+export async function bulkSetIssueProperty(
+  client: Client,
+  parameters: BulkSetIssueProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/properties/${parameters.propertyKey}`,
     method: 'PUT',
@@ -138,6 +146,7 @@ export async function bulkSetIssueProperty(client: Client, parameters: BulkSetIs
       filter: parameters.filter,
       value: parameters.value,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -174,7 +183,11 @@ export async function bulkSetIssueProperty(client: Client, parameters: BulkSetIs
  *   to view the issue.
  * - _Edit issues_ [project permission](https://confluence.atlassian.com/x/yodKLg) for each issue.
  */
-export async function bulkDeleteIssueProperty(client: Client, parameters: BulkDeleteIssueProperty): Promise<void> {
+export async function bulkDeleteIssueProperty(
+  client: Client,
+  parameters: BulkDeleteIssueProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/properties/${parameters.propertyKey}`,
     method: 'DELETE',
@@ -182,6 +195,7 @@ export async function bulkDeleteIssueProperty(client: Client, parameters: BulkDe
       currentValue: parameters.currentValue,
       entityIds: parameters.entityIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -200,11 +214,16 @@ export async function bulkDeleteIssueProperty(client: Client, parameters: BulkDe
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function getIssuePropertyKeys(client: Client, parameters: GetIssuePropertyKeys): Promise<PropertyKeys> {
+export async function getIssuePropertyKeys(
+  client: Client,
+  parameters: GetIssuePropertyKeys,
+  options?: RequestOptions,
+): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -222,11 +241,16 @@ export async function getIssuePropertyKeys(client: Client, parameters: GetIssueP
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function getIssueProperty(client: Client, parameters: GetIssueProperty): Promise<EntityProperty> {
+export async function getIssueProperty(
+  client: Client,
+  parameters: GetIssueProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -247,11 +271,16 @@ export async function getIssueProperty(client: Client, parameters: GetIssuePrope
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function setIssueProperty(client: Client, parameters: SetIssueProperty): Promise<void> {
+export async function setIssueProperty(
+  client: Client,
+  parameters: SetIssueProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -269,10 +298,15 @@ export async function setIssueProperty(client: Client, parameters: SetIssuePrope
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function deleteIssueProperty(client: Client, parameters: DeleteIssueProperty): Promise<void> {
+export async function deleteIssueProperty(
+  client: Client,
+  parameters: DeleteIssueProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueRedaction.ts
+++ b/src/cloud/api/issueRedaction.ts
@@ -4,7 +4,7 @@ import {
 } from '../models/redactionJobStatusResponse';
 import type { Redact } from '../parameters/redact';
 import type { GetRedactionStatus } from '../parameters/getRedactionStatus';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -13,7 +13,7 @@ import { z } from 'zod';
  *
  * The redaction status can be polled using the job id.
  */
-export async function redact(client: Client, parameters: Redact): Promise<string> {
+export async function redact(client: Client, parameters: Redact, options?: RequestOptions): Promise<string> {
   const config: SendRequestOptions<string> = {
     url: '/rest/api/3/redact',
     method: 'POST',
@@ -21,6 +21,7 @@ export async function redact(client: Client, parameters: Redact): Promise<string
       redactions: parameters.redactions,
     },
     schema: z.string(),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -38,11 +39,13 @@ export async function redact(client: Client, parameters: Redact): Promise<string
 export async function getRedactionStatus(
   client: Client,
   parameters: GetRedactionStatus,
+  options?: RequestOptions,
 ): Promise<RedactionJobStatusResponse> {
   const config: SendRequestOptions<RedactionJobStatusResponse> = {
     url: `/rest/api/3/redact/status/${parameters.jobId}`,
     method: 'GET',
     schema: RedactionJobStatusResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueRemoteLinks.ts
+++ b/src/cloud/api/issueRemoteLinks.ts
@@ -7,7 +7,7 @@ import type { DeleteRemoteIssueLinkByGlobalId } from '../parameters/deleteRemote
 import type { GetRemoteIssueLinkById } from '../parameters/getRemoteIssueLinkById';
 import type { UpdateRemoteIssueLink } from '../parameters/updateRemoteIssueLink';
 import type { DeleteRemoteIssueLinkById } from '../parameters/deleteRemoteIssueLinkById';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the remote issue links for an issue. When a remote issue link global ID is provided the record with that
@@ -29,6 +29,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getRemoteIssueLinks(
   client: Client,
   parameters: GetRemoteIssueLinksParameters,
+  options?: RequestOptions,
 ): Promise<GetRemoteIssueLinks> {
   const config: SendRequestOptions<GetRemoteIssueLinks> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/remotelink`,
@@ -37,6 +38,7 @@ export async function getRemoteIssueLinks(
       globalId: parameters.globalId,
     },
     schema: GetRemoteIssueLinksSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -62,6 +64,7 @@ export async function getRemoteIssueLinks(
 export async function createOrUpdateRemoteIssueLink(
   client: Client,
   parameters: CreateOrUpdateRemoteIssueLink,
+  options?: RequestOptions,
 ): Promise<RemoteIssueLinkIdentifies> {
   const config: SendRequestOptions<RemoteIssueLinkIdentifies> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/remotelink`,
@@ -73,6 +76,7 @@ export async function createOrUpdateRemoteIssueLink(
       relationship: parameters.relationship,
     },
     schema: RemoteIssueLinkIdentifiesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -97,6 +101,7 @@ export async function createOrUpdateRemoteIssueLink(
 export async function deleteRemoteIssueLinkByGlobalId(
   client: Client,
   parameters: DeleteRemoteIssueLinkByGlobalId,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/remotelink`,
@@ -104,6 +109,7 @@ export async function deleteRemoteIssueLinkByGlobalId(
     searchParams: {
       globalId: parameters.globalId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -126,11 +132,13 @@ export async function deleteRemoteIssueLinkByGlobalId(
 export async function getRemoteIssueLinkById(
   client: Client,
   parameters: GetRemoteIssueLinkById,
+  options?: RequestOptions,
 ): Promise<RemoteIssueLink> {
   const config: SendRequestOptions<RemoteIssueLink> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/remotelink/${parameters.linkId}`,
     method: 'GET',
     schema: RemoteIssueLinkSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -152,7 +160,11 @@ export async function getRemoteIssueLinkById(
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function updateRemoteIssueLink(client: Client, parameters: UpdateRemoteIssueLink): Promise<void> {
+export async function updateRemoteIssueLink(
+  client: Client,
+  parameters: UpdateRemoteIssueLink,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/remotelink/${parameters.linkId}`,
     method: 'PUT',
@@ -162,6 +174,7 @@ export async function updateRemoteIssueLink(client: Client, parameters: UpdateRe
       object: parameters.object,
       relationship: parameters.relationship,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -181,10 +194,15 @@ export async function updateRemoteIssueLink(client: Client, parameters: UpdateRe
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function deleteRemoteIssueLinkById(client: Client, parameters: DeleteRemoteIssueLinkById): Promise<void> {
+export async function deleteRemoteIssueLinkById(
+  client: Client,
+  parameters: DeleteRemoteIssueLinkById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/remotelink/${parameters.linkId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueResolutions.ts
+++ b/src/cloud/api/issueResolutions.ts
@@ -1,6 +1,6 @@
 import { ResolutionSchema, type Resolution } from '../models/resolution';
 import type { GetResolution } from '../parameters/getResolution';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns an issue resolution value.
@@ -8,11 +8,16 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getResolution(client: Client, parameters: GetResolution): Promise<Resolution> {
+export async function getResolution(
+  client: Client,
+  parameters: GetResolution,
+  options?: RequestOptions,
+): Promise<Resolution> {
   const config: SendRequestOptions<Resolution> = {
     url: `/rest/api/3/resolution/${parameters.id}`,
     method: 'GET',
     schema: ResolutionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueSearch.ts
+++ b/src/cloud/api/issueSearch.ts
@@ -7,7 +7,7 @@ import type { MatchIssues } from '../parameters/matchIssues';
 import type { CountIssues } from '../parameters/countIssues';
 import type { SearchAndReconsileIssuesUsingJql } from '../parameters/searchAndReconsileIssuesUsingJql';
 import type { SearchAndReconsileIssuesUsingJqlPost } from '../parameters/searchAndReconsileIssuesUsingJqlPost';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns lists of issues matching a query string. Use this resource to provide auto-completion suggestions when the
@@ -27,6 +27,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getIssuePickerResource(
   client: Client,
   parameters?: GetIssuePickerResource,
+  options?: RequestOptions,
 ): Promise<IssuePickerSuggestions> {
   const config: SendRequestOptions<IssuePickerSuggestions> = {
     url: '/rest/api/3/issue/picker',
@@ -40,6 +41,7 @@ export async function getIssuePickerResource(
       showSubTaskParent: parameters?.showSubTaskParent,
     },
     schema: IssuePickerSuggestionsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -56,7 +58,11 @@ export async function getIssuePickerResource(
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function matchIssues(client: Client, parameters: MatchIssues): Promise<IssueMatches> {
+export async function matchIssues(
+  client: Client,
+  parameters: MatchIssues,
+  options?: RequestOptions,
+): Promise<IssueMatches> {
   const config: SendRequestOptions<IssueMatches> = {
     url: '/rest/api/3/jql/match',
     method: 'POST',
@@ -65,6 +71,7 @@ export async function matchIssues(client: Client, parameters: MatchIssues): Prom
       jqls: parameters.jqls,
     },
     schema: IssueMatchesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -84,7 +91,11 @@ export async function matchIssues(client: Client, parameters: MatchIssues): Prom
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function countIssues(client: Client, parameters: CountIssues): Promise<JQLCountResults> {
+export async function countIssues(
+  client: Client,
+  parameters: CountIssues,
+  options?: RequestOptions,
+): Promise<JQLCountResults> {
   const config: SendRequestOptions<JQLCountResults> = {
     url: '/rest/api/3/search/approximate-count',
     method: 'POST',
@@ -92,6 +103,7 @@ export async function countIssues(client: Client, parameters: CountIssues): Prom
       jql: parameters.jql,
     },
     schema: JQLCountResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -119,6 +131,7 @@ export async function countIssues(client: Client, parameters: CountIssues): Prom
 export async function searchAndReconsileIssuesUsingJql(
   client: Client,
   parameters?: SearchAndReconsileIssuesUsingJql,
+  options?: RequestOptions,
 ): Promise<SearchAndReconcileResults> {
   const config: SendRequestOptions<SearchAndReconcileResults> = {
     url: '/rest/api/3/search/jql',
@@ -135,6 +148,7 @@ export async function searchAndReconsileIssuesUsingJql(
       reconcileIssues: parameters?.reconcileIssues,
     },
     schema: SearchAndReconcileResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -158,6 +172,7 @@ export async function searchAndReconsileIssuesUsingJql(
 export async function searchAndReconsileIssuesUsingJqlPost(
   client: Client,
   parameters: SearchAndReconsileIssuesUsingJqlPost,
+  options?: RequestOptions,
 ): Promise<SearchAndReconcileResults> {
   const config: SendRequestOptions<SearchAndReconcileResults> = {
     url: '/rest/api/3/search/jql',
@@ -173,6 +188,7 @@ export async function searchAndReconsileIssuesUsingJqlPost(
       reconcileIssues: parameters.reconcileIssues,
     },
     schema: SearchAndReconcileResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueSecurityLevel.ts
+++ b/src/cloud/api/issueSecurityLevel.ts
@@ -4,7 +4,7 @@ import type { IssueSecurityLevelMember } from '../models/issueSecurityLevelMembe
 import { SecurityLevelSchema, type SecurityLevel } from '../models/securityLevel';
 import type { GetIssueSecurityLevelMembers } from '../parameters/getIssueSecurityLevelMembers';
 import type { GetIssueSecurityLevel } from '../parameters/getIssueSecurityLevel';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns issue security level members.
@@ -17,6 +17,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getIssueSecurityLevelMembers(
   client: Client,
   parameters: GetIssueSecurityLevelMembers,
+  options?: RequestOptions,
 ): Promise<Page<IssueSecurityLevelMember>> {
   const config: SendRequestOptions<Page<IssueSecurityLevelMember>> = {
     url: `/rest/api/3/issuesecurityschemes/${parameters.issueSecuritySchemeId}/members`,
@@ -28,6 +29,7 @@ export async function getIssueSecurityLevelMembers(
       expand: parameters.expand,
     },
     schema: PageIssueSecurityLevelMemberSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -44,11 +46,16 @@ export async function getIssueSecurityLevelMembers(
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getIssueSecurityLevel(client: Client, parameters: GetIssueSecurityLevel): Promise<SecurityLevel> {
+export async function getIssueSecurityLevel(
+  client: Client,
+  parameters: GetIssueSecurityLevel,
+  options?: RequestOptions,
+): Promise<SecurityLevel> {
   const config: SendRequestOptions<SecurityLevel> = {
     url: `/rest/api/3/securitylevel/${parameters.id}`,
     method: 'GET',
     schema: SecurityLevelSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueSecuritySchemes.ts
+++ b/src/cloud/api/issueSecuritySchemes.ts
@@ -1,7 +1,7 @@
 import { SecuritySchemesSchema, type SecuritySchemes } from '../models/securitySchemes';
 import { SecuritySchemeSchema, type SecurityScheme } from '../models/securityScheme';
 import type { GetIssueSecurityScheme } from '../parameters/getIssueSecurityScheme';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns all [issue security schemes](https://confluence.atlassian.com/x/J4lKLg).
@@ -9,11 +9,12 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getIssueSecuritySchemes(client: Client): Promise<SecuritySchemes> {
+export async function getIssueSecuritySchemes(client: Client, options?: RequestOptions): Promise<SecuritySchemes> {
   const config: SendRequestOptions<SecuritySchemes> = {
     url: '/rest/api/3/issuesecurityschemes',
     method: 'GET',
     schema: SecuritySchemesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -31,11 +32,13 @@ export async function getIssueSecuritySchemes(client: Client): Promise<SecurityS
 export async function getIssueSecurityScheme(
   client: Client,
   parameters: GetIssueSecurityScheme,
+  options?: RequestOptions,
 ): Promise<SecurityScheme> {
   const config: SendRequestOptions<SecurityScheme> = {
     url: `/rest/api/3/issuesecurityschemes/${parameters.id}`,
     method: 'GET',
     schema: SecuritySchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueTypeProperties.ts
+++ b/src/cloud/api/issueTypeProperties.ts
@@ -4,7 +4,7 @@ import type { GetIssueTypePropertyKeys } from '../parameters/getIssueTypePropert
 import type { GetIssueTypeProperty } from '../parameters/getIssueTypeProperty';
 import type { SetIssueTypeProperty } from '../parameters/setIssueTypeProperty';
 import type { DeleteIssueTypeProperty } from '../parameters/deleteIssueTypeProperty';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns all the [issue type
@@ -23,11 +23,13 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getIssueTypePropertyKeys(
   client: Client,
   parameters: GetIssueTypePropertyKeys,
+  options?: RequestOptions,
 ): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/api/3/issuetype/${parameters.issueTypeId}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -46,11 +48,16 @@ export async function getIssueTypePropertyKeys(
  * - _Browse projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) to get the details of any issue
  *   types associated with the projects the user has permission to browse.
  */
-export async function getIssueTypeProperty(client: Client, parameters: GetIssueTypeProperty): Promise<EntityProperty> {
+export async function getIssueTypeProperty(
+  client: Client,
+  parameters: GetIssueTypeProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/api/3/issuetype/${parameters.issueTypeId}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -67,11 +74,16 @@ export async function getIssueTypeProperty(client: Client, parameters: GetIssueT
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function setIssueTypeProperty(client: Client, parameters: SetIssueTypeProperty): Promise<void> {
+export async function setIssueTypeProperty(
+  client: Client,
+  parameters: SetIssueTypeProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetype/${parameters.issueTypeId}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -84,10 +96,15 @@ export async function setIssueTypeProperty(client: Client, parameters: SetIssueT
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteIssueTypeProperty(client: Client, parameters: DeleteIssueTypeProperty): Promise<void> {
+export async function deleteIssueTypeProperty(
+  client: Client,
+  parameters: DeleteIssueTypeProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetype/${parameters.issueTypeId}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueTypeSchemes.ts
+++ b/src/cloud/api/issueTypeSchemes.ts
@@ -16,7 +16,7 @@ import type { DeleteIssueTypeScheme } from '../parameters/deleteIssueTypeScheme'
 import type { AddIssueTypesToIssueTypeScheme } from '../parameters/addIssueTypesToIssueTypeScheme';
 import type { ReorderIssueTypesInIssueTypeScheme } from '../parameters/reorderIssueTypesInIssueTypeScheme';
 import type { RemoveIssueTypeFromIssueTypeScheme } from '../parameters/removeIssueTypeFromIssueTypeScheme';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of issue
@@ -30,6 +30,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getAllIssueTypeSchemes(
   client: Client,
   parameters?: GetAllIssueTypeSchemes,
+  options?: RequestOptions,
 ): Promise<Page<IssueTypeScheme>> {
   const config: SendRequestOptions<Page<IssueTypeScheme>> = {
     url: '/rest/api/3/issuetypescheme',
@@ -43,6 +44,7 @@ export async function getAllIssueTypeSchemes(
       queryString: parameters?.queryString,
     },
     schema: PageIssueTypeSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -57,6 +59,7 @@ export async function getAllIssueTypeSchemes(
 export async function createIssueTypeScheme(
   client: Client,
   parameters: CreateIssueTypeScheme,
+  options?: RequestOptions,
 ): Promise<IssueTypeSchemeID> {
   const config: SendRequestOptions<IssueTypeSchemeID> = {
     url: '/rest/api/3/issuetypescheme',
@@ -68,6 +71,7 @@ export async function createIssueTypeScheme(
       name: parameters.name,
     },
     schema: IssueTypeSchemeIDSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -85,6 +89,7 @@ export async function createIssueTypeScheme(
 export async function getIssueTypeSchemesMapping(
   client: Client,
   parameters?: GetIssueTypeSchemesMapping,
+  options?: RequestOptions,
 ): Promise<Page<IssueTypeSchemeMapping>> {
   const config: SendRequestOptions<Page<IssueTypeSchemeMapping>> = {
     url: '/rest/api/3/issuetypescheme/mapping',
@@ -95,6 +100,7 @@ export async function getIssueTypeSchemesMapping(
       issueTypeSchemeId: parameters?.issueTypeSchemeId,
     },
     schema: PageIssueTypeSchemeMappingSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -112,6 +118,7 @@ export async function getIssueTypeSchemesMapping(
 export async function getIssueTypeSchemeForProjects(
   client: Client,
   parameters: GetIssueTypeSchemeForProjects,
+  options?: RequestOptions,
 ): Promise<Page<IssueTypeSchemeProjects>> {
   const config: SendRequestOptions<Page<IssueTypeSchemeProjects>> = {
     url: '/rest/api/3/issuetypescheme/project',
@@ -122,6 +129,7 @@ export async function getIssueTypeSchemeForProjects(
       projectId: parameters.projectId,
     },
     schema: PageIssueTypeSchemeProjectsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -141,6 +149,7 @@ export async function getIssueTypeSchemeForProjects(
 export async function assignIssueTypeSchemeToProject(
   client: Client,
   parameters: AssignIssueTypeSchemeToProject,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/issuetypescheme/project',
@@ -149,6 +158,7 @@ export async function assignIssueTypeSchemeToProject(
       issueTypeSchemeId: parameters.issueTypeSchemeId,
       projectId: parameters.projectId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -160,7 +170,11 @@ export async function assignIssueTypeSchemeToProject(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateIssueTypeScheme(client: Client, parameters: UpdateIssueTypeScheme): Promise<void> {
+export async function updateIssueTypeScheme(
+  client: Client,
+  parameters: UpdateIssueTypeScheme,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescheme/${parameters.issueTypeSchemeId}`,
     method: 'PUT',
@@ -169,6 +183,7 @@ export async function updateIssueTypeScheme(client: Client, parameters: UpdateIs
       description: parameters.description,
       name: parameters.name,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -191,10 +206,15 @@ export async function updateIssueTypeScheme(client: Client, parameters: UpdateIs
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteIssueTypeScheme(client: Client, parameters: DeleteIssueTypeScheme): Promise<void> {
+export async function deleteIssueTypeScheme(
+  client: Client,
+  parameters: DeleteIssueTypeScheme,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescheme/${parameters.issueTypeSchemeId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -213,6 +233,7 @@ export async function deleteIssueTypeScheme(client: Client, parameters: DeleteIs
 export async function addIssueTypesToIssueTypeScheme(
   client: Client,
   parameters: AddIssueTypesToIssueTypeScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescheme/${parameters.issueTypeSchemeId}/issuetype`,
@@ -220,6 +241,7 @@ export async function addIssueTypesToIssueTypeScheme(
     body: {
       issueTypeIds: parameters.issueTypeIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -240,6 +262,7 @@ export async function addIssueTypesToIssueTypeScheme(
 export async function reorderIssueTypesInIssueTypeScheme(
   client: Client,
   parameters: ReorderIssueTypesInIssueTypeScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescheme/${parameters.issueTypeSchemeId}/issuetype/move`,
@@ -249,6 +272,7 @@ export async function reorderIssueTypesInIssueTypeScheme(
       issueTypeIds: parameters.issueTypeIds,
       position: parameters.position,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -269,10 +293,12 @@ export async function reorderIssueTypesInIssueTypeScheme(
 export async function removeIssueTypeFromIssueTypeScheme(
   client: Client,
   parameters: RemoveIssueTypeFromIssueTypeScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescheme/${parameters.issueTypeSchemeId}/issuetype/${parameters.issueTypeId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueTypeScreenSchemes.ts
+++ b/src/cloud/api/issueTypeScreenSchemes.ts
@@ -19,7 +19,7 @@ import type { AppendMappingsForIssueTypeScreenScheme } from '../parameters/appen
 import type { UpdateDefaultScreenScheme } from '../parameters/updateDefaultScreenScheme';
 import type { RemoveMappingsFromIssueTypeScreenScheme } from '../parameters/removeMappingsFromIssueTypeScreenScheme';
 import type { GetProjectsForIssueTypeScreenScheme } from '../parameters/getProjectsForIssueTypeScreenScheme';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of issue
@@ -33,6 +33,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getIssueTypeScreenSchemes(
   client: Client,
   parameters?: GetIssueTypeScreenSchemes,
+  options?: RequestOptions,
 ): Promise<Page<IssueTypeScreenScheme>> {
   const config: SendRequestOptions<Page<IssueTypeScreenScheme>> = {
     url: '/rest/api/3/issuetypescreenscheme',
@@ -46,6 +47,7 @@ export async function getIssueTypeScreenSchemes(
       expand: parameters?.expand,
     },
     schema: PageIssueTypeScreenSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -60,6 +62,7 @@ export async function getIssueTypeScreenSchemes(
 export async function createIssueTypeScreenScheme(
   client: Client,
   parameters: CreateIssueTypeScreenScheme,
+  options?: RequestOptions,
 ): Promise<IssueTypeScreenSchemeId> {
   const config: SendRequestOptions<IssueTypeScreenSchemeId> = {
     url: '/rest/api/3/issuetypescreenscheme',
@@ -70,6 +73,7 @@ export async function createIssueTypeScreenScheme(
       name: parameters.name,
     },
     schema: IssueTypeScreenSchemeIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -87,6 +91,7 @@ export async function createIssueTypeScreenScheme(
 export async function getIssueTypeScreenSchemeMappings(
   client: Client,
   parameters?: GetIssueTypeScreenSchemeMappings,
+  options?: RequestOptions,
 ): Promise<Page<IssueTypeScreenSchemeItem>> {
   const config: SendRequestOptions<Page<IssueTypeScreenSchemeItem>> = {
     url: '/rest/api/3/issuetypescreenscheme/mapping',
@@ -97,6 +102,7 @@ export async function getIssueTypeScreenSchemeMappings(
       issueTypeScreenSchemeId: parameters?.issueTypeScreenSchemeId,
     },
     schema: PageIssueTypeScreenSchemeItemSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -114,6 +120,7 @@ export async function getIssueTypeScreenSchemeMappings(
 export async function getIssueTypeScreenSchemeProjectAssociations(
   client: Client,
   parameters: GetIssueTypeScreenSchemeProjectAssociations,
+  options?: RequestOptions,
 ): Promise<Page<IssueTypeScreenSchemesProjects>> {
   const config: SendRequestOptions<Page<IssueTypeScreenSchemesProjects>> = {
     url: '/rest/api/3/issuetypescreenscheme/project',
@@ -124,6 +131,7 @@ export async function getIssueTypeScreenSchemeProjectAssociations(
       projectId: parameters.projectId,
     },
     schema: PageIssueTypeScreenSchemesProjectsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -140,6 +148,7 @@ export async function getIssueTypeScreenSchemeProjectAssociations(
 export async function assignIssueTypeScreenSchemeToProject(
   client: Client,
   parameters: AssignIssueTypeScreenSchemeToProject,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/issuetypescreenscheme/project',
@@ -148,6 +157,7 @@ export async function assignIssueTypeScreenSchemeToProject(
       issueTypeScreenSchemeId: parameters.issueTypeScreenSchemeId,
       projectId: parameters.projectId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -162,6 +172,7 @@ export async function assignIssueTypeScreenSchemeToProject(
 export async function updateIssueTypeScreenScheme(
   client: Client,
   parameters: UpdateIssueTypeScreenScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescreenscheme/${parameters.issueTypeScreenSchemeId}`,
@@ -170,6 +181,7 @@ export async function updateIssueTypeScreenScheme(
       description: parameters.description,
       name: parameters.name,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -184,10 +196,12 @@ export async function updateIssueTypeScreenScheme(
 export async function deleteIssueTypeScreenScheme(
   client: Client,
   parameters: DeleteIssueTypeScreenScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescreenscheme/${parameters.issueTypeScreenSchemeId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -202,6 +216,7 @@ export async function deleteIssueTypeScreenScheme(
 export async function appendMappingsForIssueTypeScreenScheme(
   client: Client,
   parameters: AppendMappingsForIssueTypeScreenScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescreenscheme/${parameters.issueTypeScreenSchemeId}/mapping`,
@@ -209,6 +224,7 @@ export async function appendMappingsForIssueTypeScreenScheme(
     body: {
       issueTypeMappings: parameters.issueTypeMappings,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -221,13 +237,18 @@ export async function appendMappingsForIssueTypeScreenScheme(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateDefaultScreenScheme(client: Client, parameters: UpdateDefaultScreenScheme): Promise<void> {
+export async function updateDefaultScreenScheme(
+  client: Client,
+  parameters: UpdateDefaultScreenScheme,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescreenscheme/${parameters.issueTypeScreenSchemeId}/mapping/default`,
     method: 'PUT',
     body: {
       screenSchemeId: parameters.screenSchemeId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -242,6 +263,7 @@ export async function updateDefaultScreenScheme(client: Client, parameters: Upda
 export async function removeMappingsFromIssueTypeScreenScheme(
   client: Client,
   parameters: RemoveMappingsFromIssueTypeScreenScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetypescreenscheme/${parameters.issueTypeScreenSchemeId}/mapping/remove`,
@@ -249,6 +271,7 @@ export async function removeMappingsFromIssueTypeScreenScheme(
     body: {
       issueTypeIds: parameters.issueTypeIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -266,6 +289,7 @@ export async function removeMappingsFromIssueTypeScreenScheme(
 export async function getProjectsForIssueTypeScreenScheme(
   client: Client,
   parameters: GetProjectsForIssueTypeScreenScheme,
+  options?: RequestOptions,
 ): Promise<Page<ProjectDetails>> {
   const config: SendRequestOptions<Page<ProjectDetails>> = {
     url: `/rest/api/3/issuetypescreenscheme/${parameters.issueTypeScreenSchemeId}/project`,
@@ -276,6 +300,7 @@ export async function getProjectsForIssueTypeScreenScheme(
       query: parameters.query,
     },
     schema: PageProjectDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueTypes.ts
+++ b/src/cloud/api/issueTypes.ts
@@ -6,7 +6,7 @@ import type { UpdateIssueType } from '../parameters/updateIssueType';
 import type { DeleteIssueType } from '../parameters/deleteIssueType';
 import type { GetAlternativeIssueTypes } from '../parameters/getAlternativeIssueTypes';
 import type { CreateIssueTypeAvatar } from '../parameters/createIssueTypeAvatar';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -24,11 +24,12 @@ import { z } from 'zod';
  * - If the user is anonymous then they will be able to access projects with the _Browse projects_ for anonymous users
  * - If the user authentication is incorrect they will fall back to anonymous
  */
-export async function getIssueAllTypes(client: Client): Promise<IssueTypeDetails[]> {
+export async function getIssueAllTypes(client: Client, options?: RequestOptions): Promise<IssueTypeDetails[]> {
   const config: SendRequestOptions<IssueTypeDetails[]> = {
     url: '/rest/api/3/issuetype',
     method: 'GET',
     schema: z.array(IssueTypeDetailsSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -40,7 +41,11 @@ export async function getIssueAllTypes(client: Client): Promise<IssueTypeDetails
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createIssueType(client: Client, parameters: CreateIssueType): Promise<IssueTypeDetails> {
+export async function createIssueType(
+  client: Client,
+  parameters: CreateIssueType,
+  options?: RequestOptions,
+): Promise<IssueTypeDetails> {
   const config: SendRequestOptions<IssueTypeDetails> = {
     url: '/rest/api/3/issuetype',
     method: 'POST',
@@ -50,6 +55,7 @@ export async function createIssueType(client: Client, parameters: CreateIssueTyp
       name: parameters.name,
     },
     schema: IssueTypeDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -64,11 +70,16 @@ export async function createIssueType(client: Client, parameters: CreateIssueTyp
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) in a project the issue type is associated
  * with or _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getIssueType(client: Client, parameters: GetIssueType): Promise<IssueTypeDetails> {
+export async function getIssueType(
+  client: Client,
+  parameters: GetIssueType,
+  options?: RequestOptions,
+): Promise<IssueTypeDetails> {
   const config: SendRequestOptions<IssueTypeDetails> = {
     url: `/rest/api/3/issuetype/${parameters.id}`,
     method: 'GET',
     schema: IssueTypeDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -80,7 +91,11 @@ export async function getIssueType(client: Client, parameters: GetIssueType): Pr
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateIssueType(client: Client, parameters: UpdateIssueType): Promise<IssueTypeDetails> {
+export async function updateIssueType(
+  client: Client,
+  parameters: UpdateIssueType,
+  options?: RequestOptions,
+): Promise<IssueTypeDetails> {
   const config: SendRequestOptions<IssueTypeDetails> = {
     url: `/rest/api/3/issuetype/${parameters.id}`,
     method: 'PUT',
@@ -90,6 +105,7 @@ export async function updateIssueType(client: Client, parameters: UpdateIssueTyp
       name: parameters.name,
     },
     schema: IssueTypeDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -104,13 +120,18 @@ export async function updateIssueType(client: Client, parameters: UpdateIssueTyp
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteIssueType(client: Client, parameters: DeleteIssueType): Promise<void> {
+export async function deleteIssueType(
+  client: Client,
+  parameters: DeleteIssueType,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issuetype/${parameters.id}`,
     method: 'DELETE',
     searchParams: {
       alternativeIssueTypeId: parameters.alternativeIssueTypeId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -127,11 +148,13 @@ export async function deleteIssueType(client: Client, parameters: DeleteIssueTyp
 export async function getAlternativeIssueTypes(
   client: Client,
   parameters: GetAlternativeIssueTypes,
+  options?: RequestOptions,
 ): Promise<IssueTypeDetails[]> {
   const config: SendRequestOptions<IssueTypeDetails[]> = {
     url: `/rest/api/3/issuetype/${parameters.id}/alternatives`,
     method: 'GET',
     schema: z.array(IssueTypeDetailsSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -162,7 +185,11 @@ export async function getAlternativeIssueTypes(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createIssueTypeAvatar(client: Client, parameters: CreateIssueTypeAvatar): Promise<Avatar> {
+export async function createIssueTypeAvatar(
+  client: Client,
+  parameters: CreateIssueTypeAvatar,
+  options?: RequestOptions,
+): Promise<Avatar> {
   const config: SendRequestOptions<Avatar> = {
     url: `/rest/api/3/issuetype/${parameters.id}/avatar2`,
     method: 'POST',
@@ -176,6 +203,7 @@ export async function createIssueTypeAvatar(client: Client, parameters: CreateIs
     },
     body: parameters.body,
     schema: AvatarSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueVotes.ts
+++ b/src/cloud/api/issueVotes.ts
@@ -2,7 +2,7 @@ import { VotesSchema, type Votes } from '../models/votes';
 import type { GetVotes } from '../parameters/getVotes';
 import type { AddVote } from '../parameters/addVote';
 import type { RemoveVote } from '../parameters/removeVote';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns details about the votes on an issue.
@@ -23,11 +23,12 @@ import type { Client, SendRequestOptions } from '#/core';
  * Note that users with the necessary permissions for this operation but without the _View voters and watchers_ project
  * permissions are not returned details in the `voters` field.
  */
-export async function getVotes(client: Client, parameters: GetVotes): Promise<Votes> {
+export async function getVotes(client: Client, parameters: GetVotes, options?: RequestOptions): Promise<Votes> {
   const config: SendRequestOptions<Votes> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/votes`,
     method: 'GET',
     schema: VotesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -47,10 +48,11 @@ export async function getVotes(client: Client, parameters: GetVotes): Promise<Vo
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function addVote(client: Client, parameters: AddVote): Promise<void> {
+export async function addVote(client: Client, parameters: AddVote, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/votes`,
     method: 'POST',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -70,10 +72,11 @@ export async function addVote(client: Client, parameters: AddVote): Promise<void
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function removeVote(client: Client, parameters: RemoveVote): Promise<void> {
+export async function removeVote(client: Client, parameters: RemoveVote, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/votes`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueWatchers.ts
+++ b/src/cloud/api/issueWatchers.ts
@@ -4,7 +4,7 @@ import type { GetIsWatchingIssueBulk } from '../parameters/getIsWatchingIssueBul
 import type { GetIssueWatchers } from '../parameters/getIssueWatchers';
 import type { AddWatcher } from '../parameters/addWatcher';
 import type { RemoveWatcher } from '../parameters/removeWatcher';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns, for the user, details of the watched status of issues from a list. If an issue ID is invalid, the returned
@@ -24,6 +24,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getIsWatchingIssueBulk(
   client: Client,
   parameters: GetIsWatchingIssueBulk,
+  options?: RequestOptions,
 ): Promise<BulkIssueIsWatching> {
   const config: SendRequestOptions<BulkIssueIsWatching> = {
     url: '/rest/api/3/issue/watching',
@@ -32,6 +33,7 @@ export async function getIsWatchingIssueBulk(
       issueIds: parameters.issueIds,
     },
     schema: BulkIssueIsWatchingSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -55,11 +57,16 @@ export async function getIsWatchingIssueBulk(
  * - To see details of users on the watchlist other than themselves, _View voters and watchers_ [project
  *   permission](https://confluence.atlassian.com/x/yodKLg) for the project that the issue is in.
  */
-export async function getIssueWatchers(client: Client, parameters: GetIssueWatchers): Promise<Watchers> {
+export async function getIssueWatchers(
+  client: Client,
+  parameters: GetIssueWatchers,
+  options?: RequestOptions,
+): Promise<Watchers> {
   const config: SendRequestOptions<Watchers> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/watchers`,
     method: 'GET',
     schema: WatchersSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -82,11 +89,12 @@ export async function getIssueWatchers(client: Client, parameters: GetIssueWatch
  * - To add users other than themselves to the watchlist, _Manage watcher list_ [project
  *   permission](https://confluence.atlassian.com/x/yodKLg) for the project that the issue is in.
  */
-export async function addWatcher(client: Client, parameters: AddWatcher): Promise<void> {
+export async function addWatcher(client: Client, parameters: AddWatcher, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/watchers`,
     method: 'POST',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -108,13 +116,18 @@ export async function addWatcher(client: Client, parameters: AddWatcher): Promis
  * - To remove users other than themselves from the watchlist, _Manage watcher list_ [project
  *   permission](https://confluence.atlassian.com/x/yodKLg) for the project that the issue is in.
  */
-export async function removeWatcher(client: Client, parameters: RemoveWatcher): Promise<void> {
+export async function removeWatcher(
+  client: Client,
+  parameters: RemoveWatcher,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/watchers`,
     method: 'DELETE',
     searchParams: {
       accountId: parameters.accountId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueWorklogProperties.ts
+++ b/src/cloud/api/issueWorklogProperties.ts
@@ -4,7 +4,7 @@ import type { GetWorklogPropertyKeys } from '../parameters/getWorklogPropertyKey
 import type { GetWorklogProperty } from '../parameters/getWorklogProperty';
 import type { SetWorklogProperty } from '../parameters/setWorklogProperty';
 import type { DeleteWorklogProperty } from '../parameters/deleteWorklogProperty';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the keys of all properties for a worklog.
@@ -22,11 +22,13 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getWorklogPropertyKeys(
   client: Client,
   parameters: GetWorklogPropertyKeys,
+  options?: RequestOptions,
 ): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/worklog/${parameters.worklogId}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -45,11 +47,16 @@ export async function getWorklogPropertyKeys(
  *   to view the issue.
  * - If the worklog has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function getWorklogProperty(client: Client, parameters: GetWorklogProperty): Promise<EntityProperty> {
+export async function getWorklogProperty(
+  client: Client,
+  parameters: GetWorklogProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/worklog/${parameters.worklogId}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -73,11 +80,16 @@ export async function getWorklogProperty(client: Client, parameters: GetWorklogP
  *   own worklogs_ to update worklogs created by the user.
  * - If the worklog has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function setWorklogProperty(client: Client, parameters: SetWorklogProperty): Promise<void> {
+export async function setWorklogProperty(
+  client: Client,
+  parameters: SetWorklogProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/worklog/${parameters.worklogId}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -96,10 +108,15 @@ export async function setWorklogProperty(client: Client, parameters: SetWorklogP
  *   to view the issue.
  * - If the worklog has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function deleteWorklogProperty(client: Client, parameters: DeleteWorklogProperty): Promise<void> {
+export async function deleteWorklogProperty(
+  client: Client,
+  parameters: DeleteWorklogProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/worklog/${parameters.worklogId}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issueWorklogs.ts
+++ b/src/cloud/api/issueWorklogs.ts
@@ -9,7 +9,7 @@ import type { DeleteWorklog } from '../parameters/deleteWorklog';
 import type { GetIdsOfWorklogsDeletedSince } from '../parameters/getIdsOfWorklogsDeletedSince';
 import type { GetWorklogsForIds } from '../parameters/getWorklogsForIds';
 import type { GetIdsOfWorklogsModifiedSince } from '../parameters/getIdsOfWorklogsModifiedSince';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -30,7 +30,11 @@ import { z } from 'zod';
  *   to view the issue.
  * - If the worklog has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function getIssueWorklog(client: Client, parameters: GetIssueWorklog): Promise<PageOfWorklogs> {
+export async function getIssueWorklog(
+  client: Client,
+  parameters: GetIssueWorklog,
+  options?: RequestOptions,
+): Promise<PageOfWorklogs> {
   const config: SendRequestOptions<PageOfWorklogs> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/worklog`,
     method: 'GET',
@@ -42,6 +46,7 @@ export async function getIssueWorklog(client: Client, parameters: GetIssueWorklo
       expand: parameters.expand,
     },
     schema: PageOfWorklogsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -62,7 +67,7 @@ export async function getIssueWorklog(client: Client, parameters: GetIssueWorklo
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function addWorklog(client: Client, parameters: AddWorklog): Promise<Worklog> {
+export async function addWorklog(client: Client, parameters: AddWorklog, options?: RequestOptions): Promise<Worklog> {
   if (typeof parameters.comment === 'string') {
     const created = await client.sendRequest<{ id: string }>({
       url: `/rest/api/2/issue/${parameters.issueIdOrKey}/worklog`,
@@ -74,13 +79,18 @@ export async function addWorklog(client: Client, parameters: AddWorklog): Promis
         timeSpentSeconds: parameters.timeSpentSeconds,
         visibility: parameters.visibility,
       },
+      signal: options?.signal,
     });
 
-    return getWorklog(client, {
-      issueIdOrKey: parameters.issueIdOrKey,
-      id: created.id,
-      expand: parameters.expand,
-    });
+    return getWorklog(
+      client,
+      {
+        issueIdOrKey: parameters.issueIdOrKey,
+        id: created.id,
+        expand: parameters.expand,
+      },
+      options,
+    );
   }
 
   const config: SendRequestOptions<Worklog> = {
@@ -110,6 +120,7 @@ export async function addWorklog(client: Client, parameters: AddWorklog): Promis
       visibility: parameters.visibility,
     },
     schema: WorklogSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -131,7 +142,7 @@ export async function addWorklog(client: Client, parameters: AddWorklog): Promis
  *   to view the issue.
  * - If the worklog has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function getWorklog(client: Client, parameters: GetWorklog): Promise<Worklog> {
+export async function getWorklog(client: Client, parameters: GetWorklog, options?: RequestOptions): Promise<Worklog> {
   const config: SendRequestOptions<Worklog> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/worklog/${parameters.id}`,
     method: 'GET',
@@ -139,6 +150,7 @@ export async function getWorklog(client: Client, parameters: GetWorklog): Promis
       expand: parameters.expand,
     },
     schema: WorklogSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -162,7 +174,11 @@ export async function getWorklog(client: Client, parameters: GetWorklog): Promis
  *   own worklogs_ to update worklogs created by the user.
  * - If the worklog has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function updateWorklog(client: Client, parameters: UpdateWorklog): Promise<Worklog> {
+export async function updateWorklog(
+  client: Client,
+  parameters: UpdateWorklog,
+  options?: RequestOptions,
+): Promise<Worklog> {
   if (typeof parameters.body.comment === 'string') {
     await client.sendRequest<unknown>({
       url: `/rest/api/2/issue/${parameters.issueIdOrKey}/worklog/${parameters.id}`,
@@ -174,13 +190,18 @@ export async function updateWorklog(client: Client, parameters: UpdateWorklog): 
         timeSpentSeconds: parameters.body.timeSpentSeconds,
         visibility: parameters.body.visibility,
       },
+      signal: options?.signal,
     });
 
-    return getWorklog(client, {
-      issueIdOrKey: parameters.issueIdOrKey,
-      id: parameters.id,
-      expand: parameters.expand,
-    });
+    return getWorklog(
+      client,
+      {
+        issueIdOrKey: parameters.issueIdOrKey,
+        id: parameters.id,
+        expand: parameters.expand,
+      },
+      options,
+    );
   }
 
   const config: SendRequestOptions<Worklog> = {
@@ -195,6 +216,7 @@ export async function updateWorklog(client: Client, parameters: UpdateWorklog): 
     },
     body: parameters.body,
     schema: WorklogSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -218,7 +240,11 @@ export async function updateWorklog(client: Client, parameters: UpdateWorklog): 
  *   _Delete own worklogs_ to delete worklogs created by the user,
  * - If the worklog has visibility restrictions, belongs to the group or has the role visibility is restricted to.
  */
-export async function deleteWorklog(client: Client, parameters: DeleteWorklog): Promise<void> {
+export async function deleteWorklog(
+  client: Client,
+  parameters: DeleteWorklog,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/worklog/${parameters.id}`,
     method: 'DELETE',
@@ -229,6 +255,7 @@ export async function deleteWorklog(client: Client, parameters: DeleteWorklog): 
       increaseBy: parameters.increaseBy,
       overrideEditableFlag: parameters.overrideEditableFlag,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -250,6 +277,7 @@ export async function deleteWorklog(client: Client, parameters: DeleteWorklog): 
 export async function getIdsOfWorklogsDeletedSince(
   client: Client,
   parameters?: GetIdsOfWorklogsDeletedSince,
+  options?: RequestOptions,
 ): Promise<ChangedWorklogs> {
   const config: SendRequestOptions<ChangedWorklogs> = {
     url: '/rest/api/3/worklog/deleted',
@@ -258,6 +286,7 @@ export async function getIdsOfWorklogsDeletedSince(
       since: parameters?.since,
     },
     schema: ChangedWorklogsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -274,7 +303,11 @@ export async function getIdsOfWorklogsDeletedSince(
  * - The worklog is set as _Viewable by All Users_.
  * - The user is a member of a project role or group with permission to view the worklog.
  */
-export async function getWorklogsForIds(client: Client, parameters: GetWorklogsForIds): Promise<Worklog[]> {
+export async function getWorklogsForIds(
+  client: Client,
+  parameters: GetWorklogsForIds,
+  options?: RequestOptions,
+): Promise<Worklog[]> {
   const config: SendRequestOptions<Worklog[]> = {
     url: '/rest/api/3/worklog/list',
     method: 'POST',
@@ -285,6 +318,7 @@ export async function getWorklogsForIds(client: Client, parameters: GetWorklogsF
       ids: parameters.ids,
     },
     schema: z.array(WorklogSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -309,6 +343,7 @@ export async function getWorklogsForIds(client: Client, parameters: GetWorklogsF
 export async function getIdsOfWorklogsModifiedSince(
   client: Client,
   parameters?: GetIdsOfWorklogsModifiedSince,
+  options?: RequestOptions,
 ): Promise<ChangedWorklogs> {
   const config: SendRequestOptions<ChangedWorklogs> = {
     url: '/rest/api/3/worklog/updated',
@@ -318,6 +353,7 @@ export async function getIdsOfWorklogsModifiedSince(
       expand: parameters?.expand,
     },
     schema: ChangedWorklogsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/issues.ts
+++ b/src/cloud/api/issues.ts
@@ -33,7 +33,7 @@ import type { GetEditIssueMeta } from '../parameters/getEditIssueMeta';
 import type { Notify } from '../parameters/notify';
 import type { GetTransitions } from '../parameters/getTransitions';
 import type { DoTransition } from '../parameters/doTransition';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Bulk fetch changelogs for multiple issues and filter by fields
@@ -51,7 +51,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issues.
  */
-export async function getBulkChangelogs(client: Client, parameters: GetBulkChangelogs): Promise<BulkChangelogResponse> {
+export async function getBulkChangelogs(
+  client: Client,
+  parameters: GetBulkChangelogs,
+  options?: RequestOptions,
+): Promise<BulkChangelogResponse> {
   const config: SendRequestOptions<BulkChangelogResponse> = {
     url: '/rest/api/3/changelog/bulkfetch',
     method: 'POST',
@@ -62,6 +66,7 @@ export async function getBulkChangelogs(client: Client, parameters: GetBulkChang
       nextPageToken: parameters.nextPageToken,
     },
     schema: BulkChangelogResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -92,7 +97,11 @@ export async function getBulkChangelogs(client: Client, parameters: GetBulkChang
  * projects_ and _Create issues_ [project permissions](https://confluence.atlassian.com/x/yodKLg) for the project in
  * which the issue or subtask is created.
  */
-export async function createIssue(client: Client, parameters: CreateIssue): Promise<CreatedIssue> {
+export async function createIssue(
+  client: Client,
+  parameters: CreateIssue,
+  options?: RequestOptions,
+): Promise<CreatedIssue> {
   if (typeof parameters.fields?.description === 'string' || typeof parameters.fields?.environment === 'string') {
     return client.sendRequest({
       url: '/rest/api/2/issue',
@@ -105,6 +114,7 @@ export async function createIssue(client: Client, parameters: CreateIssue): Prom
         transition: parameters.transition,
         update: parameters.update,
       },
+      signal: options?.signal,
     });
   }
 
@@ -122,6 +132,7 @@ export async function createIssue(client: Client, parameters: CreateIssue): Prom
       update: parameters.update,
     },
     schema: CreatedIssueSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -150,7 +161,11 @@ export async function createIssue(client: Client, parameters: CreateIssue): Prom
  * projects_ and _Create issues_ [project permissions](https://confluence.atlassian.com/x/yodKLg) for the project in
  * which each issue or subtask is created.
  */
-export async function createIssues(client: Client, parameters: CreateIssues): Promise<CreatedIssues> {
+export async function createIssues(
+  client: Client,
+  parameters: CreateIssues,
+  options?: RequestOptions,
+): Promise<CreatedIssues> {
   const config: SendRequestOptions<CreatedIssues> = {
     url: '/rest/api/3/issue/bulk',
     method: 'POST',
@@ -158,13 +173,28 @@ export async function createIssues(client: Client, parameters: CreateIssues): Pr
       issueUpdates: parameters.issueUpdates,
     },
     schema: CreatedIssuesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /**
- * Returns the details for a set of requested issues. You can request up to 100 issues.
+ * Returns the details for a set of requested issues.
+ *
+ * By default you can request up to 100 issues in a single call. You can request up to 1000 issues in a single call when
+ * the request is shaped so that it can be served efficiently, that is, when _all_ of the following are true:
+ *
+ * - The `fields` parameter explicitly names at least one field to include — a request that contains only exclusions is
+ *   **not** eligible, and neither are the `*all` and `*navigable` wildcards or the default navigable field set, because
+ *   the number of resolved fields depends on the site's configuration;
+ * - No more than 100 fields are explicitly included;
+ * - None of the included fields returns multiple values (for example `comment`, `worklog`, or `attachment`); and
+ * - The `expand` parameter does not include `changelog`, `editmeta`, `operations`, `renderedFields`, `transitions`, or
+ *   `versionedRepresentations`.
+ *
+ * Requests that do not meet all of these conditions can include at most 100 issues; larger requests are rejected with a
+ * 400 error.
  *
  * Each issue is identified by its ID or key, however, if the identifier doesn't match an issue, a case-insensitive
  * search and check for moved issues is performed. If a matching issue is found its details are returned, a 302 or other
@@ -183,7 +213,11 @@ export async function createIssues(client: Client, parameters: CreateIssues): Pr
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function bulkFetchIssues(client: Client, parameters: BulkFetchIssues): Promise<BulkIssueResults> {
+export async function bulkFetchIssues(
+  client: Client,
+  parameters: BulkFetchIssues,
+  options?: RequestOptions,
+): Promise<BulkIssueResults> {
   const config: SendRequestOptions<BulkIssueResults> = {
     url: '/rest/api/3/issue/bulkfetch',
     method: 'POST',
@@ -195,6 +229,7 @@ export async function bulkFetchIssues(client: Client, parameters: BulkFetchIssue
       properties: parameters.properties,
     },
     schema: BulkIssueResultsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -215,6 +250,7 @@ export async function bulkFetchIssues(client: Client, parameters: BulkFetchIssue
 export async function getCreateIssueMetaIssueTypes(
   client: Client,
   parameters: GetCreateIssueMetaIssueTypes,
+  options?: RequestOptions,
 ): Promise<PageOfCreateMetaIssueTypes> {
   const config: SendRequestOptions<PageOfCreateMetaIssueTypes> = {
     url: `/rest/api/3/issue/createmeta/${parameters.projectIdOrKey}/issuetypes`,
@@ -224,6 +260,7 @@ export async function getCreateIssueMetaIssueTypes(
       maxResults: parameters.maxResults,
     },
     schema: PageOfCreateMetaIssueTypesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -244,6 +281,7 @@ export async function getCreateIssueMetaIssueTypes(
 export async function getCreateIssueMetaIssueTypeId(
   client: Client,
   parameters: GetCreateIssueMetaIssueTypeId,
+  options?: RequestOptions,
 ): Promise<PageOfCreateMetaIssueTypeWithField> {
   const config: SendRequestOptions<PageOfCreateMetaIssueTypeWithField> = {
     url: `/rest/api/3/issue/createmeta/${parameters.projectIdOrKey}/issuetypes/${parameters.issueTypeId}`,
@@ -253,6 +291,7 @@ export async function getCreateIssueMetaIssueTypeId(
       maxResults: parameters.maxResults,
     },
     schema: PageOfCreateMetaIssueTypeWithFieldSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -274,7 +313,7 @@ export async function getCreateIssueMetaIssueTypeId(
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function getIssue(client: Client, parameters: GetIssue): Promise<Issue> {
+export async function getIssue(client: Client, parameters: GetIssue, options?: RequestOptions): Promise<Issue> {
   const config: SendRequestOptions<Issue> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}`,
     method: 'GET',
@@ -287,6 +326,7 @@ export async function getIssue(client: Client, parameters: GetIssue): Promise<Is
       failFast: parameters.failFast,
     },
     schema: IssueSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -324,7 +364,7 @@ export async function getIssue(client: Client, parameters: GetIssue): Promise<Is
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function editIssue(client: Client, parameters: EditIssue): Promise<void> {
+export async function editIssue(client: Client, parameters: EditIssue, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}`,
     method: 'PUT',
@@ -342,6 +382,7 @@ export async function editIssue(client: Client, parameters: EditIssue): Promise<
       transition: parameters.transition,
       update: parameters.update,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -362,13 +403,14 @@ export async function editIssue(client: Client, parameters: EditIssue): Promise<
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function deleteIssue(client: Client, parameters: DeleteIssue): Promise<void> {
+export async function deleteIssue(client: Client, parameters: DeleteIssue, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}`,
     method: 'DELETE',
     searchParams: {
       deleteSubtasks: parameters.deleteSubtasks,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -392,7 +434,7 @@ export async function deleteIssue(client: Client, parameters: DeleteIssue): Prom
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function assignIssue(client: Client, parameters: AssignIssue): Promise<void> {
+export async function assignIssue(client: Client, parameters: AssignIssue, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/assignee`,
     method: 'PUT',
@@ -412,6 +454,7 @@ export async function assignIssue(client: Client, parameters: AssignIssue): Prom
       self: parameters.self,
       timeZone: parameters.timeZone,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -430,7 +473,11 @@ export async function assignIssue(client: Client, parameters: AssignIssue): Prom
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function getChangeLogs(client: Client, parameters: GetChangeLogs): Promise<Page<Changelog>> {
+export async function getChangeLogs(
+  client: Client,
+  parameters: GetChangeLogs,
+  options?: RequestOptions,
+): Promise<Page<Changelog>> {
   const config: SendRequestOptions<Page<Changelog>> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/changelog`,
     method: 'GET',
@@ -439,6 +486,7 @@ export async function getChangeLogs(client: Client, parameters: GetChangeLogs): 
       maxResults: parameters.maxResults,
     },
     schema: PageChangelogSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -456,7 +504,11 @@ export async function getChangeLogs(client: Client, parameters: GetChangeLogs): 
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function getChangeLogsByIds(client: Client, parameters: GetChangeLogsByIds): Promise<PageOfChangelogs> {
+export async function getChangeLogsByIds(
+  client: Client,
+  parameters: GetChangeLogsByIds,
+  options?: RequestOptions,
+): Promise<PageOfChangelogs> {
   const config: SendRequestOptions<PageOfChangelogs> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/changelog/list`,
     method: 'POST',
@@ -464,6 +516,7 @@ export async function getChangeLogsByIds(client: Client, parameters: GetChangeLo
       changelogIds: parameters.changelogIds,
     },
     schema: PageOfChangelogsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -522,7 +575,11 @@ export async function getChangeLogsByIds(client: Client, parameters: GetChangeLo
  * Note: For any fields to be editable the user must have the _Edit issues_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg) for the issue.
  */
-export async function getEditIssueMeta(client: Client, parameters: GetEditIssueMeta): Promise<IssueUpdateMetadata> {
+export async function getEditIssueMeta(
+  client: Client,
+  parameters: GetEditIssueMeta,
+  options?: RequestOptions,
+): Promise<IssueUpdateMetadata> {
   const config: SendRequestOptions<IssueUpdateMetadata> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/editmeta`,
     method: 'GET',
@@ -531,6 +588,7 @@ export async function getEditIssueMeta(client: Client, parameters: GetEditIssueM
       overrideEditableFlag: parameters.overrideEditableFlag,
     },
     schema: IssueUpdateMetadataSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -546,7 +604,7 @@ export async function getEditIssueMeta(client: Client, parameters: GetEditIssueM
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function notify(client: Client, parameters: Notify): Promise<void> {
+export async function notify(client: Client, parameters: Notify, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/notify`,
     method: 'POST',
@@ -557,6 +615,7 @@ export async function notify(client: Client, parameters: Notify): Promise<void> 
       textBody: parameters.textBody,
       to: parameters.to,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -582,7 +641,11 @@ export async function notify(client: Client, parameters: Notify): Promise<void> 
  * However, if the user does not have the _Transition issues_ [ project
  * permission](https://confluence.atlassian.com/x/yodKLg) the response will not list any transitions.
  */
-export async function getTransitions(client: Client, parameters: GetTransitions): Promise<Transitions> {
+export async function getTransitions(
+  client: Client,
+  parameters: GetTransitions,
+  options?: RequestOptions,
+): Promise<Transitions> {
   const config: SendRequestOptions<Transitions> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/transitions`,
     method: 'GET',
@@ -594,6 +657,7 @@ export async function getTransitions(client: Client, parameters: GetTransitions)
       sortByOpsBarAndStatus: parameters.sortByOpsBarAndStatus,
     },
     schema: TransitionsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -616,7 +680,7 @@ export async function getTransitions(client: Client, parameters: GetTransitions)
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function doTransition(client: Client, parameters: DoTransition): Promise<void> {
+export async function doTransition(client: Client, parameters: DoTransition, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/issue/${parameters.issueIdOrKey}/transitions`,
     method: 'POST',
@@ -627,6 +691,7 @@ export async function doTransition(client: Client, parameters: DoTransition): Pr
       transition: parameters.transition,
       update: parameters.update,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/jiraExpressions.ts
+++ b/src/cloud/api/jiraExpressions.ts
@@ -5,7 +5,7 @@ import {
 } from '../models/jExpEvaluateJiraExpressionResult';
 import type { AnalyseExpression } from '../parameters/analyseExpression';
 import type { EvaluateJSISJiraExpression } from '../parameters/evaluateJSISJiraExpression';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Analyses and validates Jira expressions.
@@ -20,6 +20,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function analyseExpression(
   client: Client,
   parameters: AnalyseExpression,
+  options?: RequestOptions,
 ): Promise<JiraExpressionsAnalysis> {
   const config: SendRequestOptions<JiraExpressionsAnalysis> = {
     url: '/rest/api/3/expression/analyse',
@@ -32,6 +33,7 @@ export async function analyseExpression(
       expressions: parameters.expressions,
     },
     schema: JiraExpressionsAnalysisSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -98,6 +100,7 @@ export async function analyseExpression(
 export async function evaluateJSISJiraExpression(
   client: Client,
   parameters: EvaluateJSISJiraExpression,
+  options?: RequestOptions,
 ): Promise<JExpEvaluateJiraExpressionResult> {
   const config: SendRequestOptions<JExpEvaluateJiraExpressionResult> = {
     url: '/rest/api/3/expression/evaluate',
@@ -110,6 +113,7 @@ export async function evaluateJSISJiraExpression(
       expression: parameters.expression,
     },
     schema: JExpEvaluateJiraExpressionResultSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/jiraSettings.ts
+++ b/src/cloud/api/jiraSettings.ts
@@ -2,7 +2,7 @@ import { ApplicationPropertySchema, type ApplicationProperty } from '../models/a
 import { ConfigurationSchema, type Configuration } from '../models/configuration';
 import type { GetApplicationProperty } from '../parameters/getApplicationProperty';
 import type { SetApplicationProperty } from '../parameters/setApplicationProperty';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -19,6 +19,7 @@ import { z } from 'zod';
 export async function getApplicationProperty(
   client: Client,
   parameters?: GetApplicationProperty,
+  options?: RequestOptions,
 ): Promise<ApplicationProperty[]> {
   const config: SendRequestOptions<ApplicationProperty[]> = {
     url: '/rest/api/3/application-properties',
@@ -29,6 +30,7 @@ export async function getApplicationProperty(
       keyFilter: parameters?.keyFilter,
     },
     schema: z.array(ApplicationPropertySchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -42,11 +44,12 @@ export async function getApplicationProperty(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getAdvancedSettings(client: Client): Promise<ApplicationProperty[]> {
+export async function getAdvancedSettings(client: Client, options?: RequestOptions): Promise<ApplicationProperty[]> {
   const config: SendRequestOptions<ApplicationProperty[]> = {
     url: '/rest/api/3/application-properties/advanced-settings',
     method: 'GET',
     schema: z.array(ApplicationPropertySchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -110,12 +113,14 @@ export async function getAdvancedSettings(client: Client): Promise<ApplicationPr
 export async function setApplicationProperty(
   client: Client,
   parameters: SetApplicationProperty,
+  options?: RequestOptions,
 ): Promise<ApplicationProperty> {
   const config: SendRequestOptions<ApplicationProperty> = {
     url: `/rest/api/3/application-properties/${parameters.id}`,
     method: 'PUT',
     body: parameters.body,
     schema: ApplicationPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -129,11 +134,12 @@ export async function setApplicationProperty(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getConfiguration(client: Client): Promise<Configuration> {
+export async function getConfiguration(client: Client, options?: RequestOptions): Promise<Configuration> {
   const config: SendRequestOptions<Configuration> = {
     url: '/rest/api/3/configuration',
     method: 'GET',
     schema: ConfigurationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/jql.ts
+++ b/src/cloud/api/jql.ts
@@ -6,7 +6,7 @@ import type { GetAutoCompletePost } from '../parameters/getAutoCompletePost';
 import type { GetFieldAutoCompleteForQueryString } from '../parameters/getFieldAutoCompleteForQueryString';
 import type { ParseJqlQueries } from '../parameters/parseJqlQueries';
 import type { MigrateQueries } from '../parameters/migrateQueries';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns reference data for JQL searches. This is a downloadable version of the documentation provided in [Advanced
@@ -23,11 +23,12 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAutoComplete(client: Client): Promise<JQLReferenceData> {
+export async function getAutoComplete(client: Client, options?: RequestOptions): Promise<JQLReferenceData> {
   const config: SendRequestOptions<JQLReferenceData> = {
     url: '/rest/api/3/jql/autocompletedata',
     method: 'GET',
     schema: JQLReferenceDataSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -50,7 +51,11 @@ export async function getAutoComplete(client: Client): Promise<JQLReferenceData>
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAutoCompletePost(client: Client, parameters: GetAutoCompletePost): Promise<JQLReferenceData> {
+export async function getAutoCompletePost(
+  client: Client,
+  parameters: GetAutoCompletePost,
+  options?: RequestOptions,
+): Promise<JQLReferenceData> {
   const config: SendRequestOptions<JQLReferenceData> = {
     url: '/rest/api/3/jql/autocompletedata',
     method: 'POST',
@@ -59,6 +64,7 @@ export async function getAutoCompletePost(client: Client, parameters: GetAutoCom
       projectIds: parameters.projectIds,
     },
     schema: JQLReferenceDataSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -82,6 +88,7 @@ export async function getAutoCompletePost(client: Client, parameters: GetAutoCom
 export async function getFieldAutoCompleteForQueryString(
   client: Client,
   parameters?: GetFieldAutoCompleteForQueryString,
+  options?: RequestOptions,
 ): Promise<AutoCompleteSuggestions> {
   const config: SendRequestOptions<AutoCompleteSuggestions> = {
     url: '/rest/api/3/jql/autocompletedata/suggestions',
@@ -93,6 +100,7 @@ export async function getFieldAutoCompleteForQueryString(
       predicateValue: parameters?.predicateValue,
     },
     schema: AutoCompleteSuggestionsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -107,7 +115,11 @@ export async function getFieldAutoCompleteForQueryString(
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function parseJqlQueries(client: Client, parameters: ParseJqlQueries): Promise<ParsedJqlQueries> {
+export async function parseJqlQueries(
+  client: Client,
+  parameters: ParseJqlQueries,
+  options?: RequestOptions,
+): Promise<ParsedJqlQueries> {
   const config: SendRequestOptions<ParsedJqlQueries> = {
     url: '/rest/api/3/jql/parse',
     method: 'POST',
@@ -118,6 +130,7 @@ export async function parseJqlQueries(client: Client, parameters: ParseJqlQuerie
       queries: parameters.queries,
     },
     schema: ParsedJqlQueriesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -134,7 +147,11 @@ export async function parseJqlQueries(client: Client, parameters: ParseJqlQuerie
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function migrateQueries(client: Client, parameters: MigrateQueries): Promise<ConvertedJQLQueries> {
+export async function migrateQueries(
+  client: Client,
+  parameters: MigrateQueries,
+  options?: RequestOptions,
+): Promise<ConvertedJQLQueries> {
   const config: SendRequestOptions<ConvertedJQLQueries> = {
     url: '/rest/api/3/jql/pdcleaner',
     method: 'POST',
@@ -142,6 +159,7 @@ export async function migrateQueries(client: Client, parameters: MigrateQueries)
       queryStrings: parameters.queryStrings,
     },
     schema: ConvertedJQLQueriesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/jqlFunctionsApps.ts
+++ b/src/cloud/api/jqlFunctionsApps.ts
@@ -8,7 +8,7 @@ import {
 import type { GetPrecomputations } from '../parameters/getPrecomputations';
 import type { UpdatePrecomputations } from '../parameters/updatePrecomputations';
 import type { GetPrecomputationsByID } from '../parameters/getPrecomputationsByID';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the list of a function's precomputations along with information about when they were created, updated, and
@@ -23,6 +23,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getPrecomputations(
   client: Client,
   parameters?: GetPrecomputations,
+  options?: RequestOptions,
 ): Promise<Page<JqlFunctionPrecomputation>> {
   const config: SendRequestOptions<Page<JqlFunctionPrecomputation>> = {
     url: '/rest/api/3/jql/function/computation',
@@ -34,6 +35,7 @@ export async function getPrecomputations(
       orderBy: parameters?.orderBy,
     },
     schema: PageJqlFunctionPrecomputationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -48,7 +50,11 @@ export async function getPrecomputations(
  * The new `write:app-data:jira` OAuth scope is 100% optional now, and not using it won't break your app. However, we
  * recommend adding it to your app's scope list because we will eventually make it mandatory.
  */
-export async function updatePrecomputations(client: Client, parameters: UpdatePrecomputations): Promise<void> {
+export async function updatePrecomputations(
+  client: Client,
+  parameters: UpdatePrecomputations,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/jql/function/computation',
     method: 'POST',
@@ -58,6 +64,7 @@ export async function updatePrecomputations(client: Client, parameters: UpdatePr
     body: {
       values: parameters.values,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -76,6 +83,7 @@ export async function updatePrecomputations(client: Client, parameters: UpdatePr
 export async function getPrecomputationsByID(
   client: Client,
   parameters: GetPrecomputationsByID,
+  options?: RequestOptions,
 ): Promise<JqlFunctionPrecomputationGetByIdResponse> {
   const config: SendRequestOptions<JqlFunctionPrecomputationGetByIdResponse> = {
     url: '/rest/api/3/jql/function/computation/search',
@@ -87,6 +95,7 @@ export async function getPrecomputationsByID(
       precomputationIDs: parameters.precomputationIDs,
     },
     schema: JqlFunctionPrecomputationGetByIdResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/labels.ts
+++ b/src/cloud/api/labels.ts
@@ -1,9 +1,13 @@
 import { PageStringSchema, type PageString } from '../models/pageString';
 import type { GetAllLabels } from '../parameters/getAllLabels';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /** Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of labels. */
-export async function getAllLabels(client: Client, parameters?: GetAllLabels): Promise<PageString> {
+export async function getAllLabels(
+  client: Client,
+  parameters?: GetAllLabels,
+  options?: RequestOptions,
+): Promise<PageString> {
   const config: SendRequestOptions<PageString> = {
     url: '/rest/api/3/label',
     method: 'GET',
@@ -12,6 +16,7 @@ export async function getAllLabels(client: Client, parameters?: GetAllLabels): P
       maxResults: parameters?.maxResults,
     },
     schema: PageStringSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/migrationOfConnectModulesToForge.ts
+++ b/src/cloud/api/migrationOfConnectModulesToForge.ts
@@ -1,7 +1,7 @@
 import { TaskProgressSchema, type TaskProgress } from '../models/taskProgress';
 import type { FetchMigrationTask } from '../parameters/fetchMigrationTask';
 import type { SubmitTask } from '../parameters/submitTask';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the details of a Connect issue field's migration to Forge.
@@ -19,11 +19,16 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Only
  * Connect and Forge apps can make this request.
  */
-export async function fetchMigrationTask(client: Client, parameters: FetchMigrationTask): Promise<TaskProgress> {
+export async function fetchMigrationTask(
+  client: Client,
+  parameters: FetchMigrationTask,
+  options?: RequestOptions,
+): Promise<TaskProgress> {
   const config: SendRequestOptions<TaskProgress> = {
     url: `/rest/atlassian-connect/1/migration/${parameters.connectKey}/${parameters.jiraIssueFieldsKey}/task`,
     method: 'GET',
     schema: TaskProgressSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -44,13 +49,14 @@ export async function fetchMigrationTask(client: Client, parameters: FetchMigrat
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Only
  * Connect and Forge apps can make this request.
  */
-export async function submitTask(client: Client, parameters: SubmitTask): Promise<void> {
+export async function submitTask(client: Client, parameters: SubmitTask, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/atlassian-connect/1/migration/${parameters.connectKey}/${parameters.jiraIssueFieldsKey}/task`,
     method: 'POST',
     searchParams: {
       retriggerCompletedMigration: parameters.retriggerCompletedMigration,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/myself.ts
+++ b/src/cloud/api/myself.ts
@@ -4,7 +4,7 @@ import type { GetPreference } from '../parameters/getPreference';
 import type { SetPreference } from '../parameters/setPreference';
 import type { RemovePreference } from '../parameters/removePreference';
 import type { GetCurrentUser } from '../parameters/getCurrentUser';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -31,7 +31,11 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getPreference(client: Client, parameters: GetPreference): Promise<string> {
+export async function getPreference(
+  client: Client,
+  parameters: GetPreference,
+  options?: RequestOptions,
+): Promise<string> {
   const config: SendRequestOptions<string> = {
     url: '/rest/api/3/mypreferences',
     method: 'GET',
@@ -39,6 +43,7 @@ export async function getPreference(client: Client, parameters: GetPreference): 
       key: parameters.key,
     },
     schema: z.string(),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -77,7 +82,11 @@ export async function getPreference(client: Client, parameters: GetPreference): 
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function setPreference(client: Client, parameters: SetPreference): Promise<void> {
+export async function setPreference(
+  client: Client,
+  parameters: SetPreference,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/mypreferences',
     method: 'PUT',
@@ -85,6 +94,7 @@ export async function setPreference(client: Client, parameters: SetPreference): 
       key: parameters.key,
     },
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -105,13 +115,18 @@ export async function setPreference(client: Client, parameters: SetPreference): 
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function removePreference(client: Client, parameters: RemovePreference): Promise<void> {
+export async function removePreference(
+  client: Client,
+  parameters: RemovePreference,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/mypreferences',
     method: 'DELETE',
     searchParams: {
       key: parameters.key,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -128,11 +143,12 @@ export async function removePreference(client: Client, parameters: RemovePrefere
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getLocale(client: Client): Promise<Locale> {
+export async function getLocale(client: Client, options?: RequestOptions): Promise<Locale> {
   const config: SendRequestOptions<Locale> = {
     url: '/rest/api/3/mypreferences/locale',
     method: 'GET',
     schema: LocaleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -144,7 +160,11 @@ export async function getLocale(client: Client): Promise<Locale> {
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getCurrentUser(client: Client, parameters?: GetCurrentUser): Promise<DashboardUser> {
+export async function getCurrentUser(
+  client: Client,
+  parameters?: GetCurrentUser,
+  options?: RequestOptions,
+): Promise<DashboardUser> {
   const config: SendRequestOptions<DashboardUser> = {
     url: '/rest/api/3/myself',
     method: 'GET',
@@ -152,6 +172,7 @@ export async function getCurrentUser(client: Client, parameters?: GetCurrentUser
       expand: parameters?.expand,
     },
     schema: DashboardUserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/permissionSchemes.ts
+++ b/src/cloud/api/permissionSchemes.ts
@@ -11,7 +11,7 @@ import type { GetPermissionSchemeGrants } from '../parameters/getPermissionSchem
 import type { CreatePermissionGrant } from '../parameters/createPermissionGrant';
 import type { GetPermissionSchemeGrant } from '../parameters/getPermissionSchemeGrant';
 import type { DeletePermissionSchemeEntity } from '../parameters/deletePermissionSchemeEntity';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns all permission schemes.
@@ -128,6 +128,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getAllPermissionSchemes(
   client: Client,
   parameters?: GetAllPermissionSchemes,
+  options?: RequestOptions,
 ): Promise<PermissionSchemes> {
   const config: SendRequestOptions<PermissionSchemes> = {
     url: '/rest/api/3/permissionscheme',
@@ -136,6 +137,7 @@ export async function getAllPermissionSchemes(
       expand: parameters?.expand,
     },
     schema: PermissionSchemesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -151,6 +153,7 @@ export async function getAllPermissionSchemes(
 export async function createPermissionScheme(
   client: Client,
   parameters: CreatePermissionScheme,
+  options?: RequestOptions,
 ): Promise<PermissionScheme> {
   const config: SendRequestOptions<PermissionScheme> = {
     url: '/rest/api/3/permissionscheme',
@@ -160,6 +163,7 @@ export async function createPermissionScheme(
     },
     body: parameters.body,
     schema: PermissionSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -171,7 +175,11 @@ export async function createPermissionScheme(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getPermissionScheme(client: Client, parameters: GetPermissionScheme): Promise<PermissionScheme> {
+export async function getPermissionScheme(
+  client: Client,
+  parameters: GetPermissionScheme,
+  options?: RequestOptions,
+): Promise<PermissionScheme> {
   const config: SendRequestOptions<PermissionScheme> = {
     url: `/rest/api/3/permissionscheme/${parameters.schemeId}`,
     method: 'GET',
@@ -179,6 +187,7 @@ export async function getPermissionScheme(client: Client, parameters: GetPermiss
       expand: parameters.expand,
     },
     schema: PermissionSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -207,6 +216,7 @@ export async function getPermissionScheme(client: Client, parameters: GetPermiss
 export async function updatePermissionScheme(
   client: Client,
   parameters: UpdatePermissionScheme,
+  options?: RequestOptions,
 ): Promise<PermissionScheme> {
   const config: SendRequestOptions<PermissionScheme> = {
     url: `/rest/api/3/permissionscheme/${parameters.schemeId}`,
@@ -216,6 +226,7 @@ export async function updatePermissionScheme(
     },
     body: parameters.body,
     schema: PermissionSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -227,10 +238,15 @@ export async function updatePermissionScheme(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deletePermissionScheme(client: Client, parameters: DeletePermissionScheme): Promise<void> {
+export async function deletePermissionScheme(
+  client: Client,
+  parameters: DeletePermissionScheme,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/permissionscheme/${parameters.schemeId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -245,6 +261,7 @@ export async function deletePermissionScheme(client: Client, parameters: DeleteP
 export async function getPermissionSchemeGrants(
   client: Client,
   parameters: GetPermissionSchemeGrants,
+  options?: RequestOptions,
 ): Promise<PermissionGrants> {
   const config: SendRequestOptions<PermissionGrants> = {
     url: `/rest/api/3/permissionscheme/${parameters.schemeId}/permission`,
@@ -253,6 +270,7 @@ export async function getPermissionSchemeGrants(
       expand: parameters.expand,
     },
     schema: PermissionGrantsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -267,6 +285,7 @@ export async function getPermissionSchemeGrants(
 export async function createPermissionGrant(
   client: Client,
   parameters: CreatePermissionGrant,
+  options?: RequestOptions,
 ): Promise<PermissionGrant> {
   const config: SendRequestOptions<PermissionGrant> = {
     url: `/rest/api/3/permissionscheme/${parameters.schemeId}/permission`,
@@ -281,6 +300,7 @@ export async function createPermissionGrant(
       self: parameters.self,
     },
     schema: PermissionGrantSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -295,6 +315,7 @@ export async function createPermissionGrant(
 export async function getPermissionSchemeGrant(
   client: Client,
   parameters: GetPermissionSchemeGrant,
+  options?: RequestOptions,
 ): Promise<PermissionGrant> {
   const config: SendRequestOptions<PermissionGrant> = {
     url: `/rest/api/3/permissionscheme/${parameters.schemeId}/permission/${parameters.permissionId}`,
@@ -303,6 +324,7 @@ export async function getPermissionSchemeGrant(
       expand: parameters.expand,
     },
     schema: PermissionGrantSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -319,10 +341,12 @@ export async function getPermissionSchemeGrant(
 export async function deletePermissionSchemeEntity(
   client: Client,
   parameters: DeletePermissionSchemeEntity,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/permissionscheme/${parameters.schemeId}/permission/${parameters.permissionId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/permissions.ts
+++ b/src/cloud/api/permissions.ts
@@ -4,7 +4,7 @@ import { PermittedProjectsSchema, type PermittedProjects } from '../models/permi
 import type { GetMyPermissions } from '../parameters/getMyPermissions';
 import type { GetBulkPermissions } from '../parameters/getBulkPermissions';
 import type { GetPermittedProjects } from '../parameters/getPermittedProjects';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a list of permissions indicating which permissions the user has. Details of the user's permissions can be
@@ -39,7 +39,11 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getMyPermissions(client: Client, parameters?: GetMyPermissions): Promise<Permissions> {
+export async function getMyPermissions(
+  client: Client,
+  parameters?: GetMyPermissions,
+  options?: RequestOptions,
+): Promise<Permissions> {
   const config: SendRequestOptions<Permissions> = {
     url: '/rest/api/3/mypermissions',
     method: 'GET',
@@ -54,6 +58,7 @@ export async function getMyPermissions(client: Client, parameters?: GetMyPermiss
       commentId: parameters?.commentId,
     },
     schema: PermissionsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -70,11 +75,12 @@ export async function getMyPermissions(client: Client, parameters?: GetMyPermiss
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAllPermissions(client: Client): Promise<Permissions> {
+export async function getAllPermissions(client: Client, options?: RequestOptions): Promise<Permissions> {
   const config: SendRequestOptions<Permissions> = {
     url: '/rest/api/3/permissions',
     method: 'GET',
     schema: PermissionsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -113,6 +119,7 @@ export async function getAllPermissions(client: Client): Promise<Permissions> {
 export async function getBulkPermissions(
   client: Client,
   parameters: GetBulkPermissions,
+  options?: RequestOptions,
 ): Promise<BulkPermissionGrants> {
   const config: SendRequestOptions<BulkPermissionGrants> = {
     url: '/rest/api/3/permissions/check',
@@ -123,6 +130,7 @@ export async function getBulkPermissions(
       projectPermissions: parameters.projectPermissions,
     },
     schema: BulkPermissionGrantsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -138,6 +146,7 @@ export async function getBulkPermissions(
 export async function getPermittedProjects(
   client: Client,
   parameters: GetPermittedProjects,
+  options?: RequestOptions,
 ): Promise<PermittedProjects> {
   const config: SendRequestOptions<PermittedProjects> = {
     url: '/rest/api/3/permissions/project',
@@ -146,6 +155,7 @@ export async function getPermittedProjects(
       permissions: parameters.permissions,
     },
     schema: PermittedProjectsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectAvatars.ts
+++ b/src/cloud/api/projectAvatars.ts
@@ -4,7 +4,7 @@ import type { UpdateProjectAvatar } from '../parameters/updateProjectAvatar';
 import type { DeleteProjectAvatar } from '../parameters/deleteProjectAvatar';
 import type { CreateProjectAvatar } from '../parameters/createProjectAvatar';
 import type { GetAllProjectAvatars } from '../parameters/getAllProjectAvatars';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Sets the avatar displayed for a project.
@@ -16,7 +16,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer projects_ [project permission](https://confluence.atlassian.com/x/yodKLg).
  */
-export async function updateProjectAvatar(client: Client, parameters: UpdateProjectAvatar): Promise<void> {
+export async function updateProjectAvatar(
+  client: Client,
+  parameters: UpdateProjectAvatar,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/avatar`,
     method: 'PUT',
@@ -29,6 +33,7 @@ export async function updateProjectAvatar(client: Client, parameters: UpdateProj
       owner: parameters.owner,
       urls: parameters.urls,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -40,10 +45,15 @@ export async function updateProjectAvatar(client: Client, parameters: UpdateProj
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer projects_ [project permission](https://confluence.atlassian.com/x/yodKLg).
  */
-export async function deleteProjectAvatar(client: Client, parameters: DeleteProjectAvatar): Promise<void> {
+export async function deleteProjectAvatar(
+  client: Client,
+  parameters: DeleteProjectAvatar,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/avatar/${parameters.id}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -82,7 +92,11 @@ export async function deleteProjectAvatar(client: Client, parameters: DeleteProj
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer projects_ [project permission](https://confluence.atlassian.com/x/yodKLg).
  */
-export async function createProjectAvatar(client: Client, parameters: CreateProjectAvatar): Promise<Avatar> {
+export async function createProjectAvatar(
+  client: Client,
+  parameters: CreateProjectAvatar,
+  options?: RequestOptions,
+): Promise<Avatar> {
   const config: SendRequestOptions<Avatar> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/avatar2`,
     method: 'POST',
@@ -96,6 +110,7 @@ export async function createProjectAvatar(client: Client, parameters: CreateProj
     },
     body: parameters.body,
     schema: AvatarSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -109,11 +124,16 @@ export async function createProjectAvatar(client: Client, parameters: CreateProj
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project.
  */
-export async function getAllProjectAvatars(client: Client, parameters: GetAllProjectAvatars): Promise<ProjectAvatars> {
+export async function getAllProjectAvatars(
+  client: Client,
+  parameters: GetAllProjectAvatars,
+  options?: RequestOptions,
+): Promise<ProjectAvatars> {
   const config: SendRequestOptions<ProjectAvatars> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/avatars`,
     method: 'GET',
     schema: ProjectAvatarsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectCategories.ts
+++ b/src/cloud/api/projectCategories.ts
@@ -4,7 +4,7 @@ import type { CreateProjectCategory } from '../parameters/createProjectCategory'
 import type { GetProjectCategoryById } from '../parameters/getProjectCategoryById';
 import type { UpdateProjectCategory } from '../parameters/updateProjectCategory';
 import type { RemoveProjectCategory } from '../parameters/removeProjectCategory';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -13,11 +13,12 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getAllProjectCategories(client: Client): Promise<ProjectCategory[]> {
+export async function getAllProjectCategories(client: Client, options?: RequestOptions): Promise<ProjectCategory[]> {
   const config: SendRequestOptions<ProjectCategory[]> = {
     url: '/rest/api/3/projectCategory',
     method: 'GET',
     schema: z.array(ProjectCategorySchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -32,6 +33,7 @@ export async function getAllProjectCategories(client: Client): Promise<ProjectCa
 export async function createProjectCategory(
   client: Client,
   parameters: CreateProjectCategory,
+  options?: RequestOptions,
 ): Promise<ProjectCategory> {
   const config: SendRequestOptions<ProjectCategory> = {
     url: '/rest/api/3/projectCategory',
@@ -43,6 +45,7 @@ export async function createProjectCategory(
       self: parameters.self,
     },
     schema: ProjectCategorySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -57,11 +60,13 @@ export async function createProjectCategory(
 export async function getProjectCategoryById(
   client: Client,
   parameters: GetProjectCategoryById,
+  options?: RequestOptions,
 ): Promise<ProjectCategory> {
   const config: SendRequestOptions<ProjectCategory> = {
     url: `/rest/api/3/projectCategory/${parameters.id}`,
     method: 'GET',
     schema: ProjectCategorySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -76,12 +81,14 @@ export async function getProjectCategoryById(
 export async function updateProjectCategory(
   client: Client,
   parameters: UpdateProjectCategory,
+  options?: RequestOptions,
 ): Promise<UpdatedProjectCategory> {
   const config: SendRequestOptions<UpdatedProjectCategory> = {
     url: `/rest/api/3/projectCategory/${parameters.id}`,
     method: 'PUT',
     body: parameters.body,
     schema: UpdatedProjectCategorySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -93,10 +100,15 @@ export async function updateProjectCategory(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function removeProjectCategory(client: Client, parameters: RemoveProjectCategory): Promise<void> {
+export async function removeProjectCategory(
+  client: Client,
+  parameters: RemoveProjectCategory,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/projectCategory/${parameters.id}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectComponents.ts
+++ b/src/cloud/api/projectComponents.ts
@@ -13,7 +13,7 @@ import type { DeleteComponent } from '../parameters/deleteComponent';
 import type { GetComponentRelatedIssues } from '../parameters/getComponentRelatedIssues';
 import type { GetProjectComponentsPaginated } from '../parameters/getProjectComponentsPaginated';
 import type { GetProjectComponents } from '../parameters/getProjectComponents';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -28,6 +28,7 @@ import { z } from 'zod';
 export async function findComponentsForProjects(
   client: Client,
   parameters?: FindComponentsForProjects,
+  options?: RequestOptions,
 ): Promise<Page<Component>> {
   const config: SendRequestOptions<Page<Component>> = {
     url: '/rest/api/3/component',
@@ -40,6 +41,7 @@ export async function findComponentsForProjects(
       query: parameters?.query,
     },
     schema: PageComponentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -55,7 +57,11 @@ export async function findComponentsForProjects(
  * _Administer projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project in which the
  * component is created or _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createComponent(client: Client, parameters: CreateComponent): Promise<ProjectComponent> {
+export async function createComponent(
+  client: Client,
+  parameters: CreateComponent,
+  options?: RequestOptions,
+): Promise<ProjectComponent> {
   const config: SendRequestOptions<ProjectComponent> = {
     url: '/rest/api/3/component',
     method: 'POST',
@@ -77,6 +83,7 @@ export async function createComponent(client: Client, parameters: CreateComponen
       self: parameters.self,
     },
     schema: ProjectComponentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -90,11 +97,16 @@ export async function createComponent(client: Client, parameters: CreateComponen
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for project containing the component.
  */
-export async function getComponent(client: Client, parameters: GetComponent): Promise<ProjectComponent> {
+export async function getComponent(
+  client: Client,
+  parameters: GetComponent,
+  options?: RequestOptions,
+): Promise<ProjectComponent> {
   const config: SendRequestOptions<ProjectComponent> = {
     url: `/rest/api/3/component/${parameters.id}`,
     method: 'GET',
     schema: ProjectComponentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -110,12 +122,17 @@ export async function getComponent(client: Client, parameters: GetComponent): Pr
  * _Administer projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the
  * component or _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateComponent(client: Client, parameters: UpdateComponent): Promise<ProjectComponent> {
+export async function updateComponent(
+  client: Client,
+  parameters: UpdateComponent,
+  options?: RequestOptions,
+): Promise<ProjectComponent> {
   const config: SendRequestOptions<ProjectComponent> = {
     url: `/rest/api/3/component/${parameters.id}`,
     method: 'PUT',
     body: parameters.body,
     schema: ProjectComponentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -130,13 +147,18 @@ export async function updateComponent(client: Client, parameters: UpdateComponen
  * _Administer projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the
  * component or _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteComponent(client: Client, parameters: DeleteComponent): Promise<void> {
+export async function deleteComponent(
+  client: Client,
+  parameters: DeleteComponent,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/component/${parameters.id}`,
     method: 'DELETE',
     searchParams: {
       moveIssuesTo: parameters.moveIssuesTo,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -157,11 +179,13 @@ export async function deleteComponent(client: Client, parameters: DeleteComponen
 export async function getComponentRelatedIssues(
   client: Client,
   parameters: GetComponentRelatedIssues,
+  options?: RequestOptions,
 ): Promise<ComponentIssuesCount> {
   const config: SendRequestOptions<ComponentIssuesCount> = {
     url: `/rest/api/3/component/${parameters.id}/relatedIssueCounts`,
     method: 'GET',
     schema: ComponentIssuesCountSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -184,6 +208,7 @@ export async function getComponentRelatedIssues(
 export async function getProjectComponentsPaginated(
   client: Client,
   parameters: GetProjectComponentsPaginated,
+  options?: RequestOptions,
 ): Promise<Page<ComponentWithIssueCount>> {
   const config: SendRequestOptions<Page<ComponentWithIssueCount>> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/component`,
@@ -196,6 +221,7 @@ export async function getProjectComponentsPaginated(
       query: parameters.query,
     },
     schema: PageComponentWithIssueCountSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -217,6 +243,7 @@ export async function getProjectComponentsPaginated(
 export async function getProjectComponents(
   client: Client,
   parameters: GetProjectComponents,
+  options?: RequestOptions,
 ): Promise<ProjectComponent[]> {
   const config: SendRequestOptions<ProjectComponent[]> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/components`,
@@ -225,6 +252,7 @@ export async function getProjectComponents(
       componentSource: parameters.componentSource,
     },
     schema: z.array(ProjectComponentSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectEmail.ts
+++ b/src/cloud/api/projectEmail.ts
@@ -1,7 +1,7 @@
 import { ProjectEmailAddressSchema, type ProjectEmailAddress } from '../models/projectEmailAddress';
 import type { GetProjectEmail } from '../parameters/getProjectEmail';
 import type { UpdateProjectEmail } from '../parameters/updateProjectEmail';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the [project's sender email address](https://confluence.atlassian.com/x/dolKLg).
@@ -9,11 +9,16 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project.
  */
-export async function getProjectEmail(client: Client, parameters: GetProjectEmail): Promise<ProjectEmailAddress> {
+export async function getProjectEmail(
+  client: Client,
+  parameters: GetProjectEmail,
+  options?: RequestOptions,
+): Promise<ProjectEmailAddress> {
   const config: SendRequestOptions<ProjectEmailAddress> = {
     url: `/rest/api/3/project/${parameters.projectId}/email`,
     method: 'GET',
     schema: ProjectEmailAddressSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -28,7 +33,11 @@ export async function getProjectEmail(client: Client, parameters: GetProjectEmai
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) or _Administer Projects_ [project
  * permission.](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function updateProjectEmail(client: Client, parameters: UpdateProjectEmail): Promise<void> {
+export async function updateProjectEmail(
+  client: Client,
+  parameters: UpdateProjectEmail,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/project/${parameters.projectId}/email`,
     method: 'PUT',
@@ -36,6 +45,7 @@ export async function updateProjectEmail(client: Client, parameters: UpdateProje
       emailAddress: parameters.emailAddress,
       emailAddressStatus: parameters.emailAddressStatus,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectFeatures.ts
+++ b/src/cloud/api/projectFeatures.ts
@@ -4,17 +4,19 @@ import {
 } from '../models/containerForProjectFeatures';
 import type { GetFeaturesForProject } from '../parameters/getFeaturesForProject';
 import type { ToggleFeatureForProject } from '../parameters/toggleFeatureForProject';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /** Returns the list of features for a project. */
 export async function getFeaturesForProject(
   client: Client,
   parameters: GetFeaturesForProject,
+  options?: RequestOptions,
 ): Promise<ContainerForProjectFeatures> {
   const config: SendRequestOptions<ContainerForProjectFeatures> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/features`,
     method: 'GET',
     schema: ContainerForProjectFeaturesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -24,6 +26,7 @@ export async function getFeaturesForProject(
 export async function toggleFeatureForProject(
   client: Client,
   parameters: ToggleFeatureForProject,
+  options?: RequestOptions,
 ): Promise<ContainerForProjectFeatures> {
   const config: SendRequestOptions<ContainerForProjectFeatures> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/features/${parameters.featureKey}`,
@@ -32,6 +35,7 @@ export async function toggleFeatureForProject(
       state: parameters.state,
     },
     schema: ContainerForProjectFeaturesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectKeyAndNameValidation.ts
+++ b/src/cloud/api/projectKeyAndNameValidation.ts
@@ -2,7 +2,7 @@ import { ErrorCollectionSchema, type ErrorCollection } from '../models/errorColl
 import type { ValidateProjectKey } from '../parameters/validateProjectKey';
 import type { GetValidProjectKey } from '../parameters/getValidProjectKey';
 import type { GetValidProjectName } from '../parameters/getValidProjectName';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -10,7 +10,11 @@ import { z } from 'zod';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function validateProjectKey(client: Client, parameters?: ValidateProjectKey): Promise<ErrorCollection> {
+export async function validateProjectKey(
+  client: Client,
+  parameters?: ValidateProjectKey,
+  options?: RequestOptions,
+): Promise<ErrorCollection> {
   const config: SendRequestOptions<ErrorCollection> = {
     url: '/rest/api/3/projectvalidate/key',
     method: 'GET',
@@ -18,6 +22,7 @@ export async function validateProjectKey(client: Client, parameters?: ValidatePr
       key: parameters?.key,
     },
     schema: ErrorCollectionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -28,7 +33,11 @@ export async function validateProjectKey(client: Client, parameters?: ValidatePr
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getValidProjectKey(client: Client, parameters?: GetValidProjectKey): Promise<string> {
+export async function getValidProjectKey(
+  client: Client,
+  parameters?: GetValidProjectKey,
+  options?: RequestOptions,
+): Promise<string> {
   const config: SendRequestOptions<string> = {
     url: '/rest/api/3/projectvalidate/validProjectKey',
     method: 'GET',
@@ -36,6 +45,7 @@ export async function getValidProjectKey(client: Client, parameters?: GetValidPr
       key: parameters?.key,
     },
     schema: z.string(),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -48,7 +58,11 @@ export async function getValidProjectKey(client: Client, parameters?: GetValidPr
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getValidProjectName(client: Client, parameters: GetValidProjectName): Promise<string> {
+export async function getValidProjectName(
+  client: Client,
+  parameters: GetValidProjectName,
+  options?: RequestOptions,
+): Promise<string> {
   const config: SendRequestOptions<string> = {
     url: '/rest/api/3/projectvalidate/validProjectName',
     method: 'GET',
@@ -56,6 +70,7 @@ export async function getValidProjectName(client: Client, parameters: GetValidPr
       name: parameters.name,
     },
     schema: z.string(),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectPermissionSchemes.ts
+++ b/src/cloud/api/projectPermissionSchemes.ts
@@ -8,7 +8,7 @@ import type { GetProjectIssueSecurityScheme } from '../parameters/getProjectIssu
 import type { GetAssignedPermissionScheme } from '../parameters/getAssignedPermissionScheme';
 import type { AssignPermissionScheme } from '../parameters/assignPermissionScheme';
 import type { GetSecurityLevelsForProject } from '../parameters/getSecurityLevelsForProject';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the [issue security scheme](https://confluence.atlassian.com/x/J4lKLg) associated with the project.
@@ -20,11 +20,13 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getProjectIssueSecurityScheme(
   client: Client,
   parameters: GetProjectIssueSecurityScheme,
+  options?: RequestOptions,
 ): Promise<SecurityScheme> {
   const config: SendRequestOptions<SecurityScheme> = {
     url: `/rest/api/3/project/${parameters.projectKeyOrId}/issuesecuritylevelscheme`,
     method: 'GET',
     schema: SecuritySchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -40,6 +42,7 @@ export async function getProjectIssueSecurityScheme(
 export async function getAssignedPermissionScheme(
   client: Client,
   parameters: GetAssignedPermissionScheme,
+  options?: RequestOptions,
 ): Promise<PermissionScheme> {
   const config: SendRequestOptions<PermissionScheme> = {
     url: `/rest/api/3/project/${parameters.projectKeyOrId}/permissionscheme`,
@@ -48,6 +51,7 @@ export async function getAssignedPermissionScheme(
       expand: parameters.expand,
     },
     schema: PermissionSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -63,6 +67,7 @@ export async function getAssignedPermissionScheme(
 export async function assignPermissionScheme(
   client: Client,
   parameters: AssignPermissionScheme,
+  options?: RequestOptions,
 ): Promise<PermissionScheme> {
   const config: SendRequestOptions<PermissionScheme> = {
     url: `/rest/api/3/project/${parameters.projectKeyOrId}/permissionscheme`,
@@ -74,6 +79,7 @@ export async function assignPermissionScheme(
       id: parameters.id,
     },
     schema: PermissionSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -93,11 +99,13 @@ export async function assignPermissionScheme(
 export async function getSecurityLevelsForProject(
   client: Client,
   parameters: GetSecurityLevelsForProject,
+  options?: RequestOptions,
 ): Promise<ProjectIssueSecurityLevels> {
   const config: SendRequestOptions<ProjectIssueSecurityLevels> = {
     url: `/rest/api/3/project/${parameters.projectKeyOrId}/securitylevel`,
     method: 'GET',
     schema: ProjectIssueSecurityLevelsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectProperties.ts
+++ b/src/cloud/api/projectProperties.ts
@@ -4,7 +4,7 @@ import type { GetProjectPropertyKeys } from '../parameters/getProjectPropertyKey
 import type { GetProjectProperty } from '../parameters/getProjectProperty';
 import type { SetProjectProperty } from '../parameters/setProjectProperty';
 import type { DeleteProjectProperty } from '../parameters/deleteProjectProperty';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns all [project
@@ -19,11 +19,13 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getProjectPropertyKeys(
   client: Client,
   parameters: GetProjectPropertyKeys,
+  options?: RequestOptions,
 ): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/properties`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -38,11 +40,16 @@ export async function getProjectPropertyKeys(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the property.
  */
-export async function getProjectProperty(client: Client, parameters: GetProjectProperty): Promise<EntityProperty> {
+export async function getProjectProperty(
+  client: Client,
+  parameters: GetProjectProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/properties/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -62,11 +69,16 @@ export async function getProjectProperty(client: Client, parameters: GetProjectP
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) or _Administer Projects_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg) for the project in which the property is created.
  */
-export async function setProjectProperty(client: Client, parameters: SetProjectProperty): Promise<void> {
+export async function setProjectProperty(
+  client: Client,
+  parameters: SetProjectProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/properties/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -83,10 +95,15 @@ export async function setProjectProperty(client: Client, parameters: SetProjectP
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) or _Administer Projects_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the property.
  */
-export async function deleteProjectProperty(client: Client, parameters: DeleteProjectProperty): Promise<void> {
+export async function deleteProjectProperty(
+  client: Client,
+  parameters: DeleteProjectProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/properties/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectRoleActors.ts
+++ b/src/cloud/api/projectRoleActors.ts
@@ -5,7 +5,7 @@ import type { DeleteActor } from '../parameters/deleteActor';
 import type { GetProjectRoleActorsForRole } from '../parameters/getProjectRoleActorsForRole';
 import type { AddProjectRoleActorsToRole } from '../parameters/addProjectRoleActorsToRole';
 import type { DeleteProjectRoleActorsFromRole } from '../parameters/deleteProjectRoleActorsFromRole';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Adds actors to a project role for the project.
@@ -19,7 +19,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * _Administer Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project or _Administer
  * Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function addActorUsers(client: Client, parameters: AddActorUsers): Promise<ProjectRole> {
+export async function addActorUsers(
+  client: Client,
+  parameters: AddActorUsers,
+  options?: RequestOptions,
+): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/role/${parameters.id}`,
     method: 'POST',
@@ -29,6 +33,7 @@ export async function addActorUsers(client: Client, parameters: AddActorUsers): 
       user: parameters.user,
     },
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -44,12 +49,13 @@ export async function addActorUsers(client: Client, parameters: AddActorUsers): 
  * _Administer Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project or _Administer
  * Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function setActors(client: Client, parameters: SetActors): Promise<ProjectRole> {
+export async function setActors(client: Client, parameters: SetActors, options?: RequestOptions): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/role/${parameters.id}`,
     method: 'PUT',
     body: parameters.body,
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -67,7 +73,7 @@ export async function setActors(client: Client, parameters: SetActors): Promise<
  * _Administer Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project or _Administer
  * Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteActor(client: Client, parameters: DeleteActor): Promise<void> {
+export async function deleteActor(client: Client, parameters: DeleteActor, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/role/${parameters.id}`,
     method: 'DELETE',
@@ -76,6 +82,7 @@ export async function deleteActor(client: Client, parameters: DeleteActor): Prom
       group: parameters.group,
       groupId: parameters.groupId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -92,11 +99,13 @@ export async function deleteActor(client: Client, parameters: DeleteActor): Prom
 export async function getProjectRoleActorsForRole(
   client: Client,
   parameters: GetProjectRoleActorsForRole,
+  options?: RequestOptions,
 ): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/role/${parameters.id}/actors`,
     method: 'GET',
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -115,6 +124,7 @@ export async function getProjectRoleActorsForRole(
 export async function addProjectRoleActorsToRole(
   client: Client,
   parameters: AddProjectRoleActorsToRole,
+  options?: RequestOptions,
 ): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/role/${parameters.id}/actors`,
@@ -125,6 +135,7 @@ export async function addProjectRoleActorsToRole(
       user: parameters.user,
     },
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -143,6 +154,7 @@ export async function addProjectRoleActorsToRole(
 export async function deleteProjectRoleActorsFromRole(
   client: Client,
   parameters: DeleteProjectRoleActorsFromRole,
+  options?: RequestOptions,
 ): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/role/${parameters.id}/actors`,
@@ -153,6 +165,7 @@ export async function deleteProjectRoleActorsFromRole(
       group: parameters.group,
     },
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectRoles.ts
+++ b/src/cloud/api/projectRoles.ts
@@ -9,7 +9,7 @@ import type { GetProjectRoleById } from '../parameters/getProjectRoleById';
 import type { PartialUpdateProjectRole } from '../parameters/partialUpdateProjectRole';
 import type { FullyUpdateProjectRole } from '../parameters/fullyUpdateProjectRole';
 import type { DeleteProjectRole } from '../parameters/deleteProjectRole';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -26,11 +26,16 @@ import { z } from 'zod';
  * _Administer Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for any project on the site or
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getProjectRoles(client: Client, parameters: GetProjectRolesParameters): Promise<GetProjectRoles> {
+export async function getProjectRoles(
+  client: Client,
+  parameters: GetProjectRolesParameters,
+  options?: RequestOptions,
+): Promise<GetProjectRoles> {
   const config: SendRequestOptions<GetProjectRoles> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/role`,
     method: 'GET',
     schema: GetProjectRolesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -51,7 +56,11 @@ export async function getProjectRoles(client: Client, parameters: GetProjectRole
  * _Administer Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project or _Administer
  * Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getProjectRole(client: Client, parameters: GetProjectRole): Promise<ProjectRole> {
+export async function getProjectRole(
+  client: Client,
+  parameters: GetProjectRole,
+  options?: RequestOptions,
+): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/role/${parameters.id}`,
     method: 'GET',
@@ -59,6 +68,7 @@ export async function getProjectRole(client: Client, parameters: GetProjectRole)
       excludeInactiveUsers: parameters.excludeInactiveUsers,
     },
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -77,6 +87,7 @@ export async function getProjectRole(client: Client, parameters: GetProjectRole)
 export async function getProjectRoleDetails(
   client: Client,
   parameters: GetProjectRoleDetails,
+  options?: RequestOptions,
 ): Promise<ProjectRoleDetails[]> {
   const config: SendRequestOptions<ProjectRoleDetails[]> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/roledetails`,
@@ -87,6 +98,7 @@ export async function getProjectRoleDetails(
       excludeOtherServiceRoles: parameters.excludeOtherServiceRoles,
     },
     schema: z.array(ProjectRoleDetailsSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -129,11 +141,12 @@ export async function getProjectRoleDetails(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getAllProjectRoles(client: Client): Promise<ProjectRole[]> {
+export async function getAllProjectRoles(client: Client, options?: RequestOptions): Promise<ProjectRole[]> {
   const config: SendRequestOptions<ProjectRole[]> = {
     url: '/rest/api/3/role',
     method: 'GET',
     schema: z.array(ProjectRoleSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -152,7 +165,11 @@ export async function getAllProjectRoles(client: Client): Promise<ProjectRole[]>
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createProjectRole(client: Client, parameters: CreateProjectRole): Promise<ProjectRole> {
+export async function createProjectRole(
+  client: Client,
+  parameters: CreateProjectRole,
+  options?: RequestOptions,
+): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: '/rest/api/3/role',
     method: 'POST',
@@ -161,6 +178,7 @@ export async function createProjectRole(client: Client, parameters: CreateProjec
       name: parameters.name,
     },
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -173,11 +191,16 @@ export async function createProjectRole(client: Client, parameters: CreateProjec
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getProjectRoleById(client: Client, parameters: GetProjectRoleById): Promise<ProjectRole> {
+export async function getProjectRoleById(
+  client: Client,
+  parameters: GetProjectRoleById,
+  options?: RequestOptions,
+): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/role/${parameters.id}`,
     method: 'GET',
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -195,6 +218,7 @@ export async function getProjectRoleById(client: Client, parameters: GetProjectR
 export async function partialUpdateProjectRole(
   client: Client,
   parameters: PartialUpdateProjectRole,
+  options?: RequestOptions,
 ): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/role/${parameters.id}`,
@@ -204,6 +228,7 @@ export async function partialUpdateProjectRole(
       name: parameters.name,
     },
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -215,7 +240,11 @@ export async function partialUpdateProjectRole(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function fullyUpdateProjectRole(client: Client, parameters: FullyUpdateProjectRole): Promise<ProjectRole> {
+export async function fullyUpdateProjectRole(
+  client: Client,
+  parameters: FullyUpdateProjectRole,
+  options?: RequestOptions,
+): Promise<ProjectRole> {
   const config: SendRequestOptions<ProjectRole> = {
     url: `/rest/api/3/role/${parameters.id}`,
     method: 'PUT',
@@ -224,6 +253,7 @@ export async function fullyUpdateProjectRole(client: Client, parameters: FullyUp
       name: parameters.name,
     },
     schema: ProjectRoleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -236,13 +266,18 @@ export async function fullyUpdateProjectRole(client: Client, parameters: FullyUp
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteProjectRole(client: Client, parameters: DeleteProjectRole): Promise<void> {
+export async function deleteProjectRole(
+  client: Client,
+  parameters: DeleteProjectRole,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/role/${parameters.id}`,
     method: 'DELETE',
     searchParams: {
       swap: parameters.swap,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectTemplates.ts
+++ b/src/cloud/api/projectTemplates.ts
@@ -1,5 +1,5 @@
 import type { CreateProjectWithCustomTemplate } from '../parameters/createProjectWithCustomTemplate';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Creates a project based on a custom template provided in the request.
@@ -26,6 +26,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function createProjectWithCustomTemplate(
   client: Client,
   parameters: CreateProjectWithCustomTemplate,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/project-template',
@@ -34,6 +35,7 @@ export async function createProjectWithCustomTemplate(
       details: parameters.details,
       template: parameters.template,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectTypes.ts
+++ b/src/cloud/api/projectTypes.ts
@@ -1,7 +1,7 @@
 import { ProjectTypeSchema, type ProjectType } from '../models/projectType';
 import type { GetProjectTypeByKey } from '../parameters/getProjectTypeByKey';
 import type { GetAccessibleProjectTypeByKey } from '../parameters/getAccessibleProjectTypeByKey';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -12,22 +12,24 @@ import { z } from 'zod';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getAllProjectTypes(client: Client): Promise<ProjectType[]> {
+export async function getAllProjectTypes(client: Client, options?: RequestOptions): Promise<ProjectType[]> {
   const config: SendRequestOptions<ProjectType[]> = {
     url: '/rest/api/3/project/type',
     method: 'GET',
     schema: z.array(ProjectTypeSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /** Returns all [project types](https://confluence.atlassian.com/x/Var1Nw) with a valid license. */
-export async function getAllAccessibleProjectTypes(client: Client): Promise<ProjectType[]> {
+export async function getAllAccessibleProjectTypes(client: Client, options?: RequestOptions): Promise<ProjectType[]> {
   const config: SendRequestOptions<ProjectType[]> = {
     url: '/rest/api/3/project/type/accessible',
     method: 'GET',
     schema: z.array(ProjectTypeSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -40,11 +42,16 @@ export async function getAllAccessibleProjectTypes(client: Client): Promise<Proj
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getProjectTypeByKey(client: Client, parameters: GetProjectTypeByKey): Promise<ProjectType> {
+export async function getProjectTypeByKey(
+  client: Client,
+  parameters: GetProjectTypeByKey,
+  options?: RequestOptions,
+): Promise<ProjectType> {
   const config: SendRequestOptions<ProjectType> = {
     url: `/rest/api/3/project/type/${parameters.projectTypeKey}`,
     method: 'GET',
     schema: ProjectTypeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -59,11 +66,13 @@ export async function getProjectTypeByKey(client: Client, parameters: GetProject
 export async function getAccessibleProjectTypeByKey(
   client: Client,
   parameters: GetAccessibleProjectTypeByKey,
+  options?: RequestOptions,
 ): Promise<ProjectType> {
   const config: SendRequestOptions<ProjectType> = {
     url: `/rest/api/3/project/type/${parameters.projectTypeKey}/accessible`,
     method: 'GET',
     schema: ProjectTypeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projectVersions.ts
+++ b/src/cloud/api/projectVersions.ts
@@ -21,7 +21,7 @@ import type { UpdateRelatedWork } from '../parameters/updateRelatedWork';
 import type { DeleteAndReplaceVersion } from '../parameters/deleteAndReplaceVersion';
 import type { GetVersionUnresolvedIssues } from '../parameters/getVersionUnresolvedIssues';
 import type { DeleteRelatedWork } from '../parameters/deleteRelatedWork';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -38,6 +38,7 @@ import { z } from 'zod';
 export async function getProjectVersionsPaginated(
   client: Client,
   parameters: GetProjectVersionsPaginated,
+  options?: RequestOptions,
 ): Promise<Page<Version>> {
   const config: SendRequestOptions<Page<Version>> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/version`,
@@ -51,6 +52,7 @@ export async function getProjectVersionsPaginated(
       expand: parameters.expand,
     },
     schema: PageVersionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -66,7 +68,11 @@ export async function getProjectVersionsPaginated(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project.
  */
-export async function getProjectVersions(client: Client, parameters: GetProjectVersions): Promise<Version[]> {
+export async function getProjectVersions(
+  client: Client,
+  parameters: GetProjectVersions,
+  options?: RequestOptions,
+): Promise<Version[]> {
   const config: SendRequestOptions<Version[]> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/versions`,
     method: 'GET',
@@ -74,6 +80,7 @@ export async function getProjectVersions(client: Client, parameters: GetProjectV
       expand: parameters.expand,
     },
     schema: z.array(VersionSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -88,7 +95,11 @@ export async function getProjectVersions(client: Client, parameters: GetProjectV
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) or _Administer Projects_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg) for the project the version is added to.
  */
-export async function createVersion(client: Client, parameters: CreateVersion): Promise<Version> {
+export async function createVersion(
+  client: Client,
+  parameters: CreateVersion,
+  options?: RequestOptions,
+): Promise<Version> {
   const config: SendRequestOptions<Version> = {
     url: '/rest/api/3/version',
     method: 'POST',
@@ -113,6 +124,7 @@ export async function createVersion(client: Client, parameters: CreateVersion): 
       userStartDate: parameters.userStartDate,
     },
     schema: VersionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -126,7 +138,7 @@ export async function createVersion(client: Client, parameters: CreateVersion): 
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the version.
  */
-export async function getVersion(client: Client, parameters: GetVersion): Promise<Version> {
+export async function getVersion(client: Client, parameters: GetVersion, options?: RequestOptions): Promise<Version> {
   const config: SendRequestOptions<Version> = {
     url: `/rest/api/3/version/${parameters.id}`,
     method: 'GET',
@@ -134,6 +146,7 @@ export async function getVersion(client: Client, parameters: GetVersion): Promis
       expand: parameters.expand,
     },
     schema: VersionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -148,12 +161,17 @@ export async function getVersion(client: Client, parameters: GetVersion): Promis
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) or _Administer Projects_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg) for the project that contains the version.
  */
-export async function updateVersion(client: Client, parameters: UpdateVersion): Promise<Version> {
+export async function updateVersion(
+  client: Client,
+  parameters: UpdateVersion,
+  options?: RequestOptions,
+): Promise<Version> {
   const config: SendRequestOptions<Version> = {
     url: `/rest/api/3/version/${parameters.id}`,
     method: 'PUT',
     body: parameters.body,
     schema: VersionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -173,10 +191,15 @@ export async function updateVersion(client: Client, parameters: UpdateVersion): 
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) or _Administer Projects_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg) for the project that contains the version.
  */
-export async function mergeVersions(client: Client, parameters: MergeVersions): Promise<void> {
+export async function mergeVersions(
+  client: Client,
+  parameters: MergeVersions,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/version/${parameters.id}/mergeto/${parameters.moveIssuesTo}`,
     method: 'PUT',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -190,7 +213,7 @@ export async function mergeVersions(client: Client, parameters: MergeVersions): 
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ project permission for the project that contains the version.
  */
-export async function moveVersion(client: Client, parameters: MoveVersion): Promise<Version> {
+export async function moveVersion(client: Client, parameters: MoveVersion, options?: RequestOptions): Promise<Version> {
   const config: SendRequestOptions<Version> = {
     url: `/rest/api/3/version/${parameters.id}/move`,
     method: 'POST',
@@ -199,6 +222,7 @@ export async function moveVersion(client: Client, parameters: MoveVersion): Prom
       position: parameters.position,
     },
     schema: VersionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -219,11 +243,13 @@ export async function moveVersion(client: Client, parameters: MoveVersion): Prom
 export async function getVersionRelatedIssues(
   client: Client,
   parameters: GetVersionRelatedIssues,
+  options?: RequestOptions,
 ): Promise<VersionIssueCounts> {
   const config: SendRequestOptions<VersionIssueCounts> = {
     url: `/rest/api/3/version/${parameters.id}/relatedIssueCounts`,
     method: 'GET',
     schema: VersionIssueCountsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -237,11 +263,16 @@ export async function getVersionRelatedIssues(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project containing the version.
  */
-export async function getRelatedWork(client: Client, parameters: GetRelatedWork): Promise<VersionRelatedWork[]> {
+export async function getRelatedWork(
+  client: Client,
+  parameters: GetRelatedWork,
+  options?: RequestOptions,
+): Promise<VersionRelatedWork[]> {
   const config: SendRequestOptions<VersionRelatedWork[]> = {
     url: `/rest/api/3/version/${parameters.id}/relatedwork`,
     method: 'GET',
     schema: z.array(VersionRelatedWorkSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -258,7 +289,11 @@ export async function getRelatedWork(client: Client, parameters: GetRelatedWork)
  * permissions](https://confluence.atlassian.com/adminjiraserver/managing-project-permissions-938847145.html) for the
  * project that contains the version.
  */
-export async function createRelatedWork(client: Client, parameters: CreateRelatedWork): Promise<VersionRelatedWork> {
+export async function createRelatedWork(
+  client: Client,
+  parameters: CreateRelatedWork,
+  options?: RequestOptions,
+): Promise<VersionRelatedWork> {
   const config: SendRequestOptions<VersionRelatedWork> = {
     url: `/rest/api/3/version/${parameters.id}/relatedwork`,
     method: 'POST',
@@ -270,6 +305,7 @@ export async function createRelatedWork(client: Client, parameters: CreateRelate
       url: parameters.url,
     },
     schema: VersionRelatedWorkSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -286,7 +322,11 @@ export async function createRelatedWork(client: Client, parameters: CreateRelate
  * permissions](https://confluence.atlassian.com/adminjiraserver/managing-project-permissions-938847145.html) for the
  * project that contains the version.
  */
-export async function updateRelatedWork(client: Client, parameters: UpdateRelatedWork): Promise<VersionRelatedWork> {
+export async function updateRelatedWork(
+  client: Client,
+  parameters: UpdateRelatedWork,
+  options?: RequestOptions,
+): Promise<VersionRelatedWork> {
   const config: SendRequestOptions<VersionRelatedWork> = {
     url: `/rest/api/3/version/${parameters.id}/relatedwork`,
     method: 'PUT',
@@ -298,6 +338,7 @@ export async function updateRelatedWork(client: Client, parameters: UpdateRelate
       url: parameters.url,
     },
     schema: VersionRelatedWorkSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -318,7 +359,11 @@ export async function updateRelatedWork(client: Client, parameters: UpdateRelate
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg) or _Administer Projects_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg) for the project that contains the version.
  */
-export async function deleteAndReplaceVersion(client: Client, parameters: DeleteAndReplaceVersion): Promise<void> {
+export async function deleteAndReplaceVersion(
+  client: Client,
+  parameters: DeleteAndReplaceVersion,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/version/${parameters.id}/removeAndSwap`,
     method: 'POST',
@@ -327,6 +372,7 @@ export async function deleteAndReplaceVersion(client: Client, parameters: Delete
       moveAffectedIssuesTo: parameters.moveAffectedIssuesTo,
       moveFixIssuesTo: parameters.moveFixIssuesTo,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -343,11 +389,13 @@ export async function deleteAndReplaceVersion(client: Client, parameters: Delete
 export async function getVersionUnresolvedIssues(
   client: Client,
   parameters: GetVersionUnresolvedIssues,
+  options?: RequestOptions,
 ): Promise<VersionUnresolvedIssuesCount> {
   const config: SendRequestOptions<VersionUnresolvedIssuesCount> = {
     url: `/rest/api/3/version/${parameters.id}/unresolvedIssueCount`,
     method: 'GET',
     schema: VersionUnresolvedIssuesCountSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -363,10 +411,15 @@ export async function getVersionUnresolvedIssues(
  * permissions](https://confluence.atlassian.com/adminjiraserver/managing-project-permissions-938847145.html) for the
  * project that contains the version.
  */
-export async function deleteRelatedWork(client: Client, parameters: DeleteRelatedWork): Promise<void> {
+export async function deleteRelatedWork(
+  client: Client,
+  parameters: DeleteRelatedWork,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/version/${parameters.versionId}/relatedwork/${parameters.relatedWorkId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/projects.ts
+++ b/src/cloud/api/projects.ts
@@ -14,7 +14,7 @@ import type { ArchiveProject } from '../parameters/archiveProject';
 import type { GetAllStatuses } from '../parameters/getAllStatuses';
 import type { GetHierarchy } from '../parameters/getHierarchy';
 import type { GetNotificationSchemeForProject } from '../parameters/getNotificationSchemeForProject';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -40,7 +40,11 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createProject(client: Client, parameters: CreateProject): Promise<ProjectIdentifiers> {
+export async function createProject(
+  client: Client,
+  parameters: CreateProject,
+  options?: RequestOptions,
+): Promise<ProjectIdentifiers> {
   const config: SendRequestOptions<ProjectIdentifiers> = {
     url: '/rest/api/3/project',
     method: 'POST',
@@ -64,6 +68,7 @@ export async function createProject(client: Client, parameters: CreateProject): 
       workflowScheme: parameters.workflowScheme,
     },
     schema: ProjectIdentifiersSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -82,7 +87,11 @@ export async function createProject(client: Client, parameters: CreateProject): 
  * - _Administer Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project.
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function searchProjects(client: Client, parameters?: SearchProjects): Promise<Page<Project>> {
+export async function searchProjects(
+  client: Client,
+  parameters?: SearchProjects,
+  options?: RequestOptions,
+): Promise<Page<Project>> {
   const config: SendRequestOptions<Page<Project>> = {
     url: '/rest/api/3/project/search',
     method: 'GET',
@@ -102,6 +111,7 @@ export async function searchProjects(client: Client, parameters?: SearchProjects
       propertyQuery: parameters?.propertyQuery,
     },
     schema: PageProjectSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -115,7 +125,7 @@ export async function searchProjects(client: Client, parameters?: SearchProjects
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project.
  */
-export async function getProject(client: Client, parameters: GetProject): Promise<Project> {
+export async function getProject(client: Client, parameters: GetProject, options?: RequestOptions): Promise<Project> {
   const config: SendRequestOptions<Project> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}`,
     method: 'GET',
@@ -124,6 +134,7 @@ export async function getProject(client: Client, parameters: GetProject): Promis
       properties: parameters.properties,
     },
     schema: ProjectSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -140,7 +151,11 @@ export async function getProject(client: Client, parameters: GetProject): Promis
  * schemes or project key. Otherwise you will only need _Administer Projects_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function updateProject(client: Client, parameters: UpdateProject): Promise<Project> {
+export async function updateProject(
+  client: Client,
+  parameters: UpdateProject,
+  options?: RequestOptions,
+): Promise<Project> {
   const config: SendRequestOptions<Project> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}`,
     method: 'PUT',
@@ -162,6 +177,7 @@ export async function updateProject(client: Client, parameters: UpdateProject): 
       url: parameters.url,
     },
     schema: ProjectSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -176,13 +192,18 @@ export async function updateProject(client: Client, parameters: UpdateProject): 
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteProject(client: Client, parameters: DeleteProject): Promise<void> {
+export async function deleteProject(
+  client: Client,
+  parameters: DeleteProject,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}`,
     method: 'DELETE',
     searchParams: {
       enableUndo: parameters.enableUndo,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -195,10 +216,15 @@ export async function deleteProject(client: Client, parameters: DeleteProject): 
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function archiveProject(client: Client, parameters: ArchiveProject): Promise<void> {
+export async function archiveProject(
+  client: Client,
+  parameters: ArchiveProject,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/archive`,
     method: 'POST',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -213,11 +239,16 @@ export async function archiveProject(client: Client, parameters: ArchiveProject)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * Projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project.
  */
-export async function getAllStatuses(client: Client, parameters: GetAllStatuses): Promise<IssueTypeWithStatus[]> {
+export async function getAllStatuses(
+  client: Client,
+  parameters: GetAllStatuses,
+  options?: RequestOptions,
+): Promise<IssueTypeWithStatus[]> {
   const config: SendRequestOptions<IssueTypeWithStatus[]> = {
     url: `/rest/api/3/project/${parameters.projectIdOrKey}/statuses`,
     method: 'GET',
     schema: z.array(IssueTypeWithStatusSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -237,11 +268,16 @@ export async function getAllStatuses(client: Client, parameters: GetAllStatuses)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * projects_ [project permission](https://confluence.atlassian.com/x/yodKLg) for the project.
  */
-export async function getHierarchy(client: Client, parameters: GetHierarchy): Promise<ProjectIssueTypeHierarchy> {
+export async function getHierarchy(
+  client: Client,
+  parameters: GetHierarchy,
+  options?: RequestOptions,
+): Promise<ProjectIssueTypeHierarchy> {
   const config: SendRequestOptions<ProjectIssueTypeHierarchy> = {
     url: `/rest/api/3/project/${parameters.projectId}/hierarchy`,
     method: 'GET',
     schema: ProjectIssueTypeHierarchySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -257,6 +293,7 @@ export async function getHierarchy(client: Client, parameters: GetHierarchy): Pr
 export async function getNotificationSchemeForProject(
   client: Client,
   parameters: GetNotificationSchemeForProject,
+  options?: RequestOptions,
 ): Promise<NotificationScheme> {
   const config: SendRequestOptions<NotificationScheme> = {
     url: `/rest/api/3/project/${parameters.projectKeyOrId}/notificationscheme`,
@@ -265,6 +302,7 @@ export async function getNotificationSchemeForProject(
       expand: parameters.expand,
     },
     schema: NotificationSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/screenSchemes.ts
+++ b/src/cloud/api/screenSchemes.ts
@@ -6,7 +6,7 @@ import type { GetScreenSchemes } from '../parameters/getScreenSchemes';
 import type { CreateScreenScheme } from '../parameters/createScreenScheme';
 import type { UpdateScreenScheme } from '../parameters/updateScreenScheme';
 import type { DeleteScreenScheme } from '../parameters/deleteScreenScheme';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of screen
@@ -17,7 +17,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getScreenSchemes(client: Client, parameters?: GetScreenSchemes): Promise<Page<ScreenScheme>> {
+export async function getScreenSchemes(
+  client: Client,
+  parameters?: GetScreenSchemes,
+  options?: RequestOptions,
+): Promise<Page<ScreenScheme>> {
   const config: SendRequestOptions<Page<ScreenScheme>> = {
     url: '/rest/api/3/screenscheme',
     method: 'GET',
@@ -30,6 +34,7 @@ export async function getScreenSchemes(client: Client, parameters?: GetScreenSch
       orderBy: parameters?.orderBy,
     },
     schema: PageScreenSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -41,7 +46,11 @@ export async function getScreenSchemes(client: Client, parameters?: GetScreenSch
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createScreenScheme(client: Client, parameters: CreateScreenScheme): Promise<ScreenSchemeId> {
+export async function createScreenScheme(
+  client: Client,
+  parameters: CreateScreenScheme,
+  options?: RequestOptions,
+): Promise<ScreenSchemeId> {
   const config: SendRequestOptions<ScreenSchemeId> = {
     url: '/rest/api/3/screenscheme',
     method: 'POST',
@@ -51,6 +60,7 @@ export async function createScreenScheme(client: Client, parameters: CreateScree
       screens: parameters.screens,
     },
     schema: ScreenSchemeIdSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -62,7 +72,11 @@ export async function createScreenScheme(client: Client, parameters: CreateScree
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateScreenScheme(client: Client, parameters: UpdateScreenScheme): Promise<void> {
+export async function updateScreenScheme(
+  client: Client,
+  parameters: UpdateScreenScheme,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/screenscheme/${parameters.screenSchemeId}`,
     method: 'PUT',
@@ -71,6 +85,7 @@ export async function updateScreenScheme(client: Client, parameters: UpdateScree
       name: parameters.name,
       screens: parameters.screens,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -84,10 +99,15 @@ export async function updateScreenScheme(client: Client, parameters: UpdateScree
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteScreenScheme(client: Client, parameters: DeleteScreenScheme): Promise<void> {
+export async function deleteScreenScheme(
+  client: Client,
+  parameters: DeleteScreenScheme,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/screenscheme/${parameters.screenSchemeId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/screenTabFields.ts
+++ b/src/cloud/api/screenTabFields.ts
@@ -3,7 +3,7 @@ import type { GetAllScreenTabFields } from '../parameters/getAllScreenTabFields'
 import type { AddScreenTabField } from '../parameters/addScreenTabField';
 import type { RemoveScreenTabField } from '../parameters/removeScreenTabField';
 import type { MoveScreenTabField } from '../parameters/moveScreenTabField';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -19,6 +19,7 @@ import { z } from 'zod';
 export async function getAllScreenTabFields(
   client: Client,
   parameters: GetAllScreenTabFields,
+  options?: RequestOptions,
 ): Promise<ScreenableField[]> {
   const config: SendRequestOptions<ScreenableField[]> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs/${parameters.tabId}/fields`,
@@ -27,6 +28,7 @@ export async function getAllScreenTabFields(
       projectKey: parameters.projectKey,
     },
     schema: z.array(ScreenableFieldSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -38,7 +40,11 @@ export async function getAllScreenTabFields(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function addScreenTabField(client: Client, parameters: AddScreenTabField): Promise<ScreenableField> {
+export async function addScreenTabField(
+  client: Client,
+  parameters: AddScreenTabField,
+  options?: RequestOptions,
+): Promise<ScreenableField> {
   const config: SendRequestOptions<ScreenableField> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs/${parameters.tabId}/fields`,
     method: 'POST',
@@ -49,6 +55,7 @@ export async function addScreenTabField(client: Client, parameters: AddScreenTab
       fieldId: parameters.fieldId,
     },
     schema: ScreenableFieldSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -60,10 +67,15 @@ export async function addScreenTabField(client: Client, parameters: AddScreenTab
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function removeScreenTabField(client: Client, parameters: RemoveScreenTabField): Promise<void> {
+export async function removeScreenTabField(
+  client: Client,
+  parameters: RemoveScreenTabField,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs/${parameters.tabId}/fields/${parameters.id}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -77,7 +89,11 @@ export async function removeScreenTabField(client: Client, parameters: RemoveScr
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function moveScreenTabField(client: Client, parameters: MoveScreenTabField): Promise<void> {
+export async function moveScreenTabField(
+  client: Client,
+  parameters: MoveScreenTabField,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs/${parameters.tabId}/fields/${parameters.id}/move`,
     method: 'POST',
@@ -85,6 +101,7 @@ export async function moveScreenTabField(client: Client, parameters: MoveScreenT
       after: parameters.after,
       position: parameters.position,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/screenTabs.ts
+++ b/src/cloud/api/screenTabs.ts
@@ -4,7 +4,7 @@ import type { AddScreenTab } from '../parameters/addScreenTab';
 import type { RenameScreenTab } from '../parameters/renameScreenTab';
 import type { DeleteScreenTab } from '../parameters/deleteScreenTab';
 import type { MoveScreenTab } from '../parameters/moveScreenTab';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -17,7 +17,11 @@ import { z } from 'zod';
  *   specified, providing that the screen is associated with the project through a Screen Scheme and Issue Type Screen
  *   Scheme.
  */
-export async function getAllScreenTabs(client: Client, parameters: GetAllScreenTabs): Promise<ScreenableTab[]> {
+export async function getAllScreenTabs(
+  client: Client,
+  parameters: GetAllScreenTabs,
+  options?: RequestOptions,
+): Promise<ScreenableTab[]> {
   const config: SendRequestOptions<ScreenableTab[]> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs`,
     method: 'GET',
@@ -25,6 +29,7 @@ export async function getAllScreenTabs(client: Client, parameters: GetAllScreenT
       projectKey: parameters.projectKey,
     },
     schema: z.array(ScreenableTabSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -36,7 +41,11 @@ export async function getAllScreenTabs(client: Client, parameters: GetAllScreenT
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function addScreenTab(client: Client, parameters: AddScreenTab): Promise<ScreenableTab> {
+export async function addScreenTab(
+  client: Client,
+  parameters: AddScreenTab,
+  options?: RequestOptions,
+): Promise<ScreenableTab> {
   const config: SendRequestOptions<ScreenableTab> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs`,
     method: 'POST',
@@ -45,6 +54,7 @@ export async function addScreenTab(client: Client, parameters: AddScreenTab): Pr
       name: parameters.name,
     },
     schema: ScreenableTabSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -56,7 +66,11 @@ export async function addScreenTab(client: Client, parameters: AddScreenTab): Pr
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function renameScreenTab(client: Client, parameters: RenameScreenTab): Promise<ScreenableTab> {
+export async function renameScreenTab(
+  client: Client,
+  parameters: RenameScreenTab,
+  options?: RequestOptions,
+): Promise<ScreenableTab> {
   const config: SendRequestOptions<ScreenableTab> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs/${parameters.tabId}`,
     method: 'PUT',
@@ -65,6 +79,7 @@ export async function renameScreenTab(client: Client, parameters: RenameScreenTa
       name: parameters.name,
     },
     schema: ScreenableTabSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -76,10 +91,15 @@ export async function renameScreenTab(client: Client, parameters: RenameScreenTa
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteScreenTab(client: Client, parameters: DeleteScreenTab): Promise<void> {
+export async function deleteScreenTab(
+  client: Client,
+  parameters: DeleteScreenTab,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs/${parameters.tabId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -91,10 +111,15 @@ export async function deleteScreenTab(client: Client, parameters: DeleteScreenTa
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function moveScreenTab(client: Client, parameters: MoveScreenTab): Promise<void> {
+export async function moveScreenTab(
+  client: Client,
+  parameters: MoveScreenTab,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/screens/${parameters.screenId}/tabs/${parameters.tabId}/move/${parameters.pos}`,
     method: 'POST',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/screens.ts
+++ b/src/cloud/api/screens.ts
@@ -8,7 +8,7 @@ import type { GetScreensForField } from '../parameters/getScreensForField';
 import type { GetScreens } from '../parameters/getScreens';
 import type { AddFieldToDefaultScreen } from '../parameters/addFieldToDefaultScreen';
 import type { GetAvailableScreenFields } from '../parameters/getAvailableScreenFields';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -18,7 +18,11 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getScreensForField(client: Client, parameters: GetScreensForField): Promise<Page<ScreenWithTab>> {
+export async function getScreensForField(
+  client: Client,
+  parameters: GetScreensForField,
+  options?: RequestOptions,
+): Promise<Page<ScreenWithTab>> {
   const config: SendRequestOptions<Page<ScreenWithTab>> = {
     url: `/rest/api/3/field/${parameters.fieldId}/screens`,
     method: 'GET',
@@ -28,6 +32,7 @@ export async function getScreensForField(client: Client, parameters: GetScreensF
       expand: parameters.expand,
     },
     schema: PageScreenWithTabSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -40,7 +45,11 @@ export async function getScreensForField(client: Client, parameters: GetScreensF
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getScreens(client: Client, parameters?: GetScreens): Promise<Page<Screen>> {
+export async function getScreens(
+  client: Client,
+  parameters?: GetScreens,
+  options?: RequestOptions,
+): Promise<Page<Screen>> {
   const config: SendRequestOptions<Page<Screen>> = {
     url: '/rest/api/3/screens',
     method: 'GET',
@@ -53,6 +62,7 @@ export async function getScreens(client: Client, parameters?: GetScreens): Promi
       orderBy: parameters?.orderBy,
     },
     schema: PageScreenSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -64,10 +74,15 @@ export async function getScreens(client: Client, parameters?: GetScreens): Promi
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function addFieldToDefaultScreen(client: Client, parameters: AddFieldToDefaultScreen): Promise<void> {
+export async function addFieldToDefaultScreen(
+  client: Client,
+  parameters: AddFieldToDefaultScreen,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/screens/addToDefault/${parameters.fieldId}`,
     method: 'POST',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -82,11 +97,13 @@ export async function addFieldToDefaultScreen(client: Client, parameters: AddFie
 export async function getAvailableScreenFields(
   client: Client,
   parameters: GetAvailableScreenFields,
+  options?: RequestOptions,
 ): Promise<ScreenableField[]> {
   const config: SendRequestOptions<ScreenableField[]> = {
     url: `/rest/api/3/screens/${parameters.screenId}/availableFields`,
     method: 'GET',
     schema: z.array(ScreenableFieldSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/serverInfo.ts
+++ b/src/cloud/api/serverInfo.ts
@@ -1,5 +1,5 @@
 import { ServerInformationSchema, type ServerInformation } from '../models/serverInformation';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns information about the Jira instance.
@@ -8,11 +8,12 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** None.
  */
-export async function getServerInfo(client: Client): Promise<ServerInformation> {
+export async function getServerInfo(client: Client, options?: RequestOptions): Promise<ServerInformation> {
   const config: SendRequestOptions<ServerInformation> = {
     url: '/rest/api/3/serverInfo',
     method: 'GET',
     schema: ServerInformationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/status.ts
+++ b/src/cloud/api/status.ts
@@ -15,7 +15,7 @@ import type { Search } from '../parameters/search';
 import type { GetProjectIssueTypeUsagesForStatus } from '../parameters/getProjectIssueTypeUsagesForStatus';
 import type { GetProjectUsagesForStatus } from '../parameters/getProjectUsagesForStatus';
 import type { GetWorkflowUsagesForStatus } from '../parameters/getWorkflowUsagesForStatus';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -26,7 +26,11 @@ import { z } from 'zod';
  * - _Administer projects_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  * - _Administer Jira_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function getStatusesById(client: Client, parameters: GetStatusesById): Promise<JiraStatus[]> {
+export async function getStatusesById(
+  client: Client,
+  parameters: GetStatusesById,
+  options?: RequestOptions,
+): Promise<JiraStatus[]> {
   const config: SendRequestOptions<JiraStatus[]> = {
     url: '/rest/api/3/statuses',
     method: 'GET',
@@ -34,6 +38,7 @@ export async function getStatusesById(client: Client, parameters: GetStatusesByI
       id: parameters.id,
     },
     schema: z.array(JiraStatusSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -47,7 +52,11 @@ export async function getStatusesById(client: Client, parameters: GetStatusesByI
  * - _Administer projects_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  * - _Administer Jira_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function createStatuses(client: Client, parameters: CreateStatuses): Promise<JiraStatus[]> {
+export async function createStatuses(
+  client: Client,
+  parameters: CreateStatuses,
+  options?: RequestOptions,
+): Promise<JiraStatus[]> {
   const config: SendRequestOptions<JiraStatus[]> = {
     url: '/rest/api/3/statuses',
     method: 'POST',
@@ -56,6 +65,7 @@ export async function createStatuses(client: Client, parameters: CreateStatuses)
       statuses: parameters.statuses,
     },
     schema: z.array(JiraStatusSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -69,13 +79,18 @@ export async function createStatuses(client: Client, parameters: CreateStatuses)
  * - _Administer projects_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  * - _Administer Jira_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function updateStatuses(client: Client, parameters: UpdateStatuses): Promise<void> {
+export async function updateStatuses(
+  client: Client,
+  parameters: UpdateStatuses,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/statuses',
     method: 'PUT',
     body: {
       statuses: parameters.statuses,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -89,13 +104,18 @@ export async function updateStatuses(client: Client, parameters: UpdateStatuses)
  * - _Administer projects_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  * - _Administer Jira_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function deleteStatusesById(client: Client, parameters: DeleteStatusesById): Promise<void> {
+export async function deleteStatusesById(
+  client: Client,
+  parameters: DeleteStatusesById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/statuses',
     method: 'DELETE',
     searchParams: {
       id: parameters.id,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -110,7 +130,11 @@ export async function deleteStatusesById(client: Client, parameters: DeleteStatu
  * - _Administer Jira_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  * - _Browse projects_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function getStatusesByName(client: Client, parameters: GetStatusesByName): Promise<JiraStatus[]> {
+export async function getStatusesByName(
+  client: Client,
+  parameters: GetStatusesByName,
+  options?: RequestOptions,
+): Promise<JiraStatus[]> {
   const config: SendRequestOptions<JiraStatus[]> = {
     url: '/rest/api/3/statuses/byNames',
     method: 'GET',
@@ -119,6 +143,7 @@ export async function getStatusesByName(client: Client, parameters: GetStatusesB
       projectId: parameters.projectId,
     },
     schema: z.array(JiraStatusSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -133,7 +158,7 @@ export async function getStatusesByName(client: Client, parameters: GetStatusesB
  * - _Administer projects_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  * - _Administer Jira_ [project permission.](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function search(client: Client, parameters?: Search): Promise<PageOfStatuses> {
+export async function search(client: Client, parameters?: Search, options?: RequestOptions): Promise<PageOfStatuses> {
   const config: SendRequestOptions<PageOfStatuses> = {
     url: '/rest/api/3/statuses/search',
     method: 'GET',
@@ -146,6 +171,7 @@ export async function search(client: Client, parameters?: Search): Promise<PageO
       includeGlobalStatuses: parameters?.includeGlobalStatuses,
     },
     schema: PageOfStatusesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -155,6 +181,7 @@ export async function search(client: Client, parameters?: Search): Promise<PageO
 export async function getProjectIssueTypeUsagesForStatus(
   client: Client,
   parameters: GetProjectIssueTypeUsagesForStatus,
+  options?: RequestOptions,
 ): Promise<StatusProjectIssueTypeUsageDTO> {
   const config: SendRequestOptions<StatusProjectIssueTypeUsageDTO> = {
     url: `/rest/api/3/statuses/${parameters.statusId}/project/${parameters.projectId}/issueTypeUsages`,
@@ -164,6 +191,7 @@ export async function getProjectIssueTypeUsagesForStatus(
       maxResults: parameters.maxResults,
     },
     schema: StatusProjectIssueTypeUsageDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -173,6 +201,7 @@ export async function getProjectIssueTypeUsagesForStatus(
 export async function getProjectUsagesForStatus(
   client: Client,
   parameters: GetProjectUsagesForStatus,
+  options?: RequestOptions,
 ): Promise<StatusProjectUsageDTO> {
   const config: SendRequestOptions<StatusProjectUsageDTO> = {
     url: `/rest/api/3/statuses/${parameters.statusId}/projectUsages`,
@@ -182,6 +211,7 @@ export async function getProjectUsagesForStatus(
       maxResults: parameters.maxResults,
     },
     schema: StatusProjectUsageDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -191,6 +221,7 @@ export async function getProjectUsagesForStatus(
 export async function getWorkflowUsagesForStatus(
   client: Client,
   parameters: GetWorkflowUsagesForStatus,
+  options?: RequestOptions,
 ): Promise<StatusWorkflowUsageDTO> {
   const config: SendRequestOptions<StatusWorkflowUsageDTO> = {
     url: `/rest/api/3/statuses/${parameters.statusId}/workflowUsages`,
@@ -200,6 +231,7 @@ export async function getWorkflowUsagesForStatus(
       maxResults: parameters.maxResults,
     },
     schema: StatusWorkflowUsageDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/tasks.ts
+++ b/src/cloud/api/tasks.ts
@@ -1,6 +1,6 @@
 import { TaskProgressObjectSchema, type TaskProgressObject } from '../models/taskProgressObject';
 import type { GetTask } from '../parameters/getTask';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the status of a [long-running asynchronous
@@ -19,11 +19,16 @@ import type { Client, SendRequestOptions } from '#/core';
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  * - Creator of the task.
  */
-export async function getTask(client: Client, parameters: GetTask): Promise<TaskProgressObject> {
+export async function getTask(
+  client: Client,
+  parameters: GetTask,
+  options?: RequestOptions,
+): Promise<TaskProgressObject> {
   const config: SendRequestOptions<TaskProgressObject> = {
     url: `/rest/api/3/task/${parameters.taskId}`,
     method: 'GET',
     schema: TaskProgressObjectSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/timeTracking.ts
+++ b/src/cloud/api/timeTracking.ts
@@ -2,7 +2,7 @@ import { TimeTrackingProviderSchema, type TimeTrackingProvider } from '../models
 import { TimeTrackingConfigurationSchema, type TimeTrackingConfiguration } from '../models/timeTrackingConfiguration';
 import type { SelectTimeTrackingImplementation } from '../parameters/selectTimeTrackingImplementation';
 import type { SetSharedTimeTrackingConfiguration } from '../parameters/setSharedTimeTrackingConfiguration';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -12,10 +12,11 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getSelectedTimeTrackingImplementation(client: Client): Promise<void> {
+export async function getSelectedTimeTrackingImplementation(client: Client, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/configuration/timetracking',
     method: 'GET',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -30,6 +31,7 @@ export async function getSelectedTimeTrackingImplementation(client: Client): Pro
 export async function selectTimeTrackingImplementation(
   client: Client,
   parameters: SelectTimeTrackingImplementation,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/configuration/timetracking',
@@ -39,6 +41,7 @@ export async function selectTimeTrackingImplementation(
       name: parameters.name,
       url: parameters.url,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -53,11 +56,15 @@ export async function selectTimeTrackingImplementation(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getAvailableTimeTrackingImplementations(client: Client): Promise<TimeTrackingProvider[]> {
+export async function getAvailableTimeTrackingImplementations(
+  client: Client,
+  options?: RequestOptions,
+): Promise<TimeTrackingProvider[]> {
   const config: SendRequestOptions<TimeTrackingProvider[]> = {
     url: '/rest/api/3/configuration/timetracking/list',
     method: 'GET',
     schema: z.array(TimeTrackingProviderSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -70,11 +77,15 @@ export async function getAvailableTimeTrackingImplementations(client: Client): P
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getSharedTimeTrackingConfiguration(client: Client): Promise<TimeTrackingConfiguration> {
+export async function getSharedTimeTrackingConfiguration(
+  client: Client,
+  options?: RequestOptions,
+): Promise<TimeTrackingConfiguration> {
   const config: SendRequestOptions<TimeTrackingConfiguration> = {
     url: '/rest/api/3/configuration/timetracking/options',
     method: 'GET',
     schema: TimeTrackingConfigurationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -89,6 +100,7 @@ export async function getSharedTimeTrackingConfiguration(client: Client): Promis
 export async function setSharedTimeTrackingConfiguration(
   client: Client,
   parameters: SetSharedTimeTrackingConfiguration,
+  options?: RequestOptions,
 ): Promise<TimeTrackingConfiguration> {
   const config: SendRequestOptions<TimeTrackingConfiguration> = {
     url: '/rest/api/3/configuration/timetracking/options',
@@ -100,6 +112,7 @@ export async function setSharedTimeTrackingConfiguration(
       workingHoursPerDay: parameters.workingHoursPerDay,
     },
     schema: TimeTrackingConfigurationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/uiModificationsApps.ts
+++ b/src/cloud/api/uiModificationsApps.ts
@@ -6,7 +6,7 @@ import type { GetUiModifications } from '../parameters/getUiModifications';
 import type { CreateUiModification } from '../parameters/createUiModification';
 import type { UpdateUiModification } from '../parameters/updateUiModification';
 import type { DeleteUiModification } from '../parameters/deleteUiModification';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Gets UI modifications. UI modifications can only be retrieved by Forge apps.
@@ -19,6 +19,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getUiModifications(
   client: Client,
   parameters?: GetUiModifications,
+  options?: RequestOptions,
 ): Promise<Page<UiModificationDetails>> {
   const config: SendRequestOptions<Page<UiModificationDetails>> = {
     url: '/rest/api/3/uiModifications',
@@ -29,6 +30,7 @@ export async function getUiModifications(
       expand: parameters?.expand,
     },
     schema: PageUiModificationDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -52,6 +54,13 @@ export async function getUiModifications(
  *   Wildcards are not supported. Supported JSM views:
  *
  *   - `JSMRequestCreate` - Jira Service Management request create portal view
+ * - **Agent view contexts:** For Agent view types, use `projectId` and `issueTypeId` like Jira contexts, and optionally
+ *   set `requestTypeId`. `portalId` must not be set. One of `projectId`, `issueTypeId`, or `viewType` can act as a
+ *   wildcard. Supported Agent views:
+ *
+ *   - `GICAgentView` - Agent view variant of Jira global issue create
+ *   - `IssueViewAgentView` - Agent view variant of Jira issue view
+ *   - `IssueTransitionAgentView` - Agent view variant of Jira issue transition
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  *
@@ -65,6 +74,7 @@ export async function getUiModifications(
 export async function createUiModification(
   client: Client,
   parameters: CreateUiModification,
+  options?: RequestOptions,
 ): Promise<UiModificationIdentifiers> {
   const config: SendRequestOptions<UiModificationIdentifiers> = {
     url: '/rest/api/3/uiModifications',
@@ -76,6 +86,7 @@ export async function createUiModification(
       name: parameters.name,
     },
     schema: UiModificationIdentifiersSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -99,6 +110,13 @@ export async function createUiModification(
  *   Wildcards are not supported. Supported JSM views:
  *
  *   - `JSMRequestCreate` - Jira Service Management request create portal view
+ * - **Agent view contexts:** For Agent view types, use `projectId` and `issueTypeId` like Jira contexts, and optionally
+ *   set `requestTypeId`. `portalId` must not be set. One of `projectId`, `issueTypeId`, or `viewType` can act as a
+ *   wildcard. Supported Agent views:
+ *
+ *   - `GICAgentView` - Agent view variant of Jira global issue create
+ *   - `IssueViewAgentView` - Agent view variant of Jira issue view
+ *   - `IssueTransitionAgentView` - Agent view variant of Jira issue transition
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  *
@@ -109,7 +127,11 @@ export async function createUiModification(
  * The new `write:app-data:jira` OAuth scope is 100% optional now, and not using it won't break your app. However, we
  * recommend adding it to your app's scope list because we will eventually make it mandatory.
  */
-export async function updateUiModification(client: Client, parameters: UpdateUiModification): Promise<void> {
+export async function updateUiModification(
+  client: Client,
+  parameters: UpdateUiModification,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/uiModifications/${parameters.uiModificationId}`,
     method: 'PUT',
@@ -119,6 +141,7 @@ export async function updateUiModification(client: Client, parameters: UpdateUiM
       description: parameters.description,
       name: parameters.name,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -133,10 +156,15 @@ export async function updateUiModification(client: Client, parameters: UpdateUiM
  * The new `write:app-data:jira` OAuth scope is 100% optional now, and not using it won't break your app. However, we
  * recommend adding it to your app's scope list because we will eventually make it mandatory.
  */
-export async function deleteUiModification(client: Client, parameters: DeleteUiModification): Promise<void> {
+export async function deleteUiModification(
+  client: Client,
+  parameters: DeleteUiModification,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/uiModifications/${parameters.uiModificationId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/userProperties.ts
+++ b/src/cloud/api/userProperties.ts
@@ -4,7 +4,7 @@ import type { GetUserPropertyKeys } from '../parameters/getUserPropertyKeys';
 import type { GetUserProperty } from '../parameters/getUserProperty';
 import type { SetUserProperty } from '../parameters/setUserProperty';
 import type { DeleteUserProperty } from '../parameters/deleteUserProperty';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns the keys of all properties for a user.
@@ -18,7 +18,11 @@ import type { Client, SendRequestOptions } from '#/core';
  *   user.
  * - Access to Jira, to access the calling user's property keys.
  */
-export async function getUserPropertyKeys(client: Client, parameters?: GetUserPropertyKeys): Promise<PropertyKeys> {
+export async function getUserPropertyKeys(
+  client: Client,
+  parameters?: GetUserPropertyKeys,
+  options?: RequestOptions,
+): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: '/rest/api/3/user/properties',
     method: 'GET',
@@ -26,6 +30,7 @@ export async function getUserPropertyKeys(client: Client, parameters?: GetUserPr
       accountId: parameters?.accountId,
     },
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -44,7 +49,11 @@ export async function getUserPropertyKeys(client: Client, parameters?: GetUserPr
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg), to get a property from any user.
  * - Access to Jira, to get a property from the calling user's record.
  */
-export async function getUserProperty(client: Client, parameters: GetUserProperty): Promise<EntityProperty> {
+export async function getUserProperty(
+  client: Client,
+  parameters: GetUserProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/api/3/user/properties/${parameters.propertyKey}`,
     method: 'GET',
@@ -52,6 +61,7 @@ export async function getUserProperty(client: Client, parameters: GetUserPropert
       accountId: parameters.accountId,
     },
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -68,7 +78,11 @@ export async function getUserProperty(client: Client, parameters: GetUserPropert
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg), to set a property on any user.
  * - Access to Jira, to set a property on the calling user's record.
  */
-export async function setUserProperty(client: Client, parameters: SetUserProperty): Promise<void> {
+export async function setUserProperty(
+  client: Client,
+  parameters: SetUserProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/user/properties/${parameters.propertyKey}`,
     method: 'PUT',
@@ -76,6 +90,7 @@ export async function setUserProperty(client: Client, parameters: SetUserPropert
       accountId: parameters.accountId,
     },
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -92,13 +107,18 @@ export async function setUserProperty(client: Client, parameters: SetUserPropert
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg), to delete a property from any user.
  * - Access to Jira, to delete a property from the calling user's record.
  */
-export async function deleteUserProperty(client: Client, parameters: DeleteUserProperty): Promise<void> {
+export async function deleteUserProperty(
+  client: Client,
+  parameters: DeleteUserProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/user/properties/${parameters.propertyKey}`,
     method: 'DELETE',
     searchParams: {
       accountId: parameters.accountId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/userSearch.ts
+++ b/src/cloud/api/userSearch.ts
@@ -12,7 +12,7 @@ import type { FindUsers } from '../parameters/findUsers';
 import type { FindUsersByQuery } from '../parameters/findUsersByQuery';
 import type { FindUserKeysByQuery } from '../parameters/findUserKeysByQuery';
 import type { FindUsersWithBrowsePermission } from '../parameters/findUsersWithBrowsePermission';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -39,6 +39,7 @@ import { z } from 'zod';
 export async function findBulkAssignableUsers(
   client: Client,
   parameters: FindBulkAssignableUsers,
+  options?: RequestOptions,
 ): Promise<DashboardUser[]> {
   const config: SendRequestOptions<DashboardUser[]> = {
     url: '/rest/api/3/user/assignable/multiProjectSearch',
@@ -51,6 +52,7 @@ export async function findBulkAssignableUsers(
       maxResults: parameters.maxResults,
     },
     schema: z.array(DashboardUserSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -84,7 +86,11 @@ export async function findBulkAssignableUsers(
  * users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg) or _Assign issues_ [project
  * permission](https://confluence.atlassian.com/x/yodKLg)
  */
-export async function findAssignableUsers(client: Client, parameters?: FindAssignableUsers): Promise<DashboardUser[]> {
+export async function findAssignableUsers(
+  client: Client,
+  parameters?: FindAssignableUsers,
+  options?: RequestOptions,
+): Promise<DashboardUser[]> {
   const config: SendRequestOptions<DashboardUser[]> = {
     url: '/rest/api/3/user/assignable/search',
     method: 'GET',
@@ -103,6 +109,7 @@ export async function findAssignableUsers(client: Client, parameters?: FindAssig
       appType: parameters?.appType,
     },
     schema: z.array(DashboardUserSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -138,6 +145,7 @@ export async function findAssignableUsers(client: Client, parameters?: FindAssig
 export async function findUsersWithAllPermissions(
   client: Client,
   parameters: FindUsersWithAllPermissions,
+  options?: RequestOptions,
 ): Promise<DashboardUser[]> {
   const config: SendRequestOptions<DashboardUser[]> = {
     url: '/rest/api/3/user/permission/search',
@@ -152,6 +160,7 @@ export async function findUsersWithAllPermissions(
       maxResults: parameters.maxResults,
     },
     schema: z.array(DashboardUserSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -178,7 +187,11 @@ export async function findUsersWithAllPermissions(
  * users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg). Anonymous calls and calls by users
  * without the required permission return search results for an exact name match only.
  */
-export async function findUsersForPicker(client: Client, parameters: FindUsersForPicker): Promise<FoundUsers> {
+export async function findUsersForPicker(
+  client: Client,
+  parameters: FindUsersForPicker,
+  options?: RequestOptions,
+): Promise<FoundUsers> {
   const config: SendRequestOptions<FoundUsers> = {
     url: '/rest/api/3/user/picker',
     method: 'GET',
@@ -191,6 +204,7 @@ export async function findUsersForPicker(client: Client, parameters: FindUsersFo
       excludeConnectUsers: parameters.excludeConnectUsers,
     },
     schema: FoundUsersSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -215,7 +229,11 @@ export async function findUsersForPicker(client: Client, parameters: FindUsersFo
  * users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg). Anonymous calls or calls by users
  * without the required permission return empty search results.
  */
-export async function findUsers(client: Client, parameters?: FindUsers): Promise<DashboardUser[]> {
+export async function findUsers(
+  client: Client,
+  parameters?: FindUsers,
+  options?: RequestOptions,
+): Promise<DashboardUser[]> {
   const config: SendRequestOptions<DashboardUser[]> = {
     url: '/rest/api/3/user/search',
     method: 'GET',
@@ -228,6 +246,7 @@ export async function findUsers(client: Client, parameters?: FindUsers): Promise
       property: parameters?.property,
     },
     schema: z.array(DashboardUserSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -264,7 +283,11 @@ export async function findUsers(client: Client, parameters?: FindUsers): Promise
  *
  * `is assignee of PROJ AND [propertyKey].entity.property.path is "property value"`
  */
-export async function findUsersByQuery(client: Client, parameters: FindUsersByQuery): Promise<Page<DashboardUser>> {
+export async function findUsersByQuery(
+  client: Client,
+  parameters: FindUsersByQuery,
+  options?: RequestOptions,
+): Promise<Page<DashboardUser>> {
   const config: SendRequestOptions<Page<DashboardUser>> = {
     url: '/rest/api/3/user/search/query',
     method: 'GET',
@@ -274,6 +297,7 @@ export async function findUsersByQuery(client: Client, parameters: FindUsersByQu
       maxResults: parameters.maxResults,
     },
     schema: PageUserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -310,7 +334,11 @@ export async function findUsersByQuery(client: Client, parameters: FindUsersByQu
  *
  * `is assignee of PROJ AND [propertyKey].entity.property.path is "property value"`
  */
-export async function findUserKeysByQuery(client: Client, parameters: FindUserKeysByQuery): Promise<Page<UserKey>> {
+export async function findUserKeysByQuery(
+  client: Client,
+  parameters: FindUserKeysByQuery,
+  options?: RequestOptions,
+): Promise<Page<UserKey>> {
   const config: SendRequestOptions<Page<UserKey>> = {
     url: '/rest/api/3/user/search/query/key',
     method: 'GET',
@@ -320,6 +348,7 @@ export async function findUserKeysByQuery(client: Client, parameters: FindUserKe
       maxResult: parameters.maxResult,
     },
     schema: PageUserKeySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -356,6 +385,7 @@ export async function findUserKeysByQuery(client: Client, parameters: FindUserKe
 export async function findUsersWithBrowsePermission(
   client: Client,
   parameters?: FindUsersWithBrowsePermission,
+  options?: RequestOptions,
 ): Promise<DashboardUser[]> {
   const config: SendRequestOptions<DashboardUser[]> = {
     url: '/rest/api/3/user/viewissue/search',
@@ -369,6 +399,7 @@ export async function findUsersWithBrowsePermission(
       maxResults: parameters?.maxResults,
     },
     schema: z.array(DashboardUserSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/users.ts
+++ b/src/cloud/api/users.ts
@@ -13,7 +13,7 @@ import type { GetUserEmailBulk } from '../parameters/getUserEmailBulk';
 import type { GetUserGroups } from '../parameters/getUserGroups';
 import type { GetAllUsersDefault } from '../parameters/getAllUsersDefault';
 import type { GetAllUsers } from '../parameters/getAllUsers';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -26,7 +26,7 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getUser(client: Client, parameters?: GetUser): Promise<DashboardUser> {
+export async function getUser(client: Client, parameters?: GetUser, options?: RequestOptions): Promise<DashboardUser> {
   const config: SendRequestOptions<DashboardUser> = {
     url: '/rest/api/3/user',
     method: 'GET',
@@ -35,6 +35,7 @@ export async function getUser(client: Client, parameters?: GetUser): Promise<Das
       expand: parameters?.expand,
     },
     schema: DashboardUserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -47,13 +48,17 @@ export async function getUser(client: Client, parameters?: GetUser): Promise<Das
  * **Note:** This API does not support Forge apps.
  *
  * If the user exists and has access to Jira, the operation returns a 201 status. If the user exists but does not have
- * access to Jira, the operation returns a 400 status.
+ * access to Jira & no new jira-products are requested, the operation returns a 400 status.
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg). The caller has to be an
  * **organization admin**.
  */
-export async function createUser(client: Client, parameters: CreateUser): Promise<DashboardUser> {
+export async function createUser(
+  client: Client,
+  parameters: CreateUser,
+  options?: RequestOptions,
+): Promise<DashboardUser> {
   const config: SendRequestOptions<DashboardUser> = {
     url: '/rest/api/3/user',
     method: 'POST',
@@ -63,6 +68,7 @@ export async function createUser(client: Client, parameters: CreateUser): Promis
       self: parameters.self,
     },
     schema: DashboardUserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -75,13 +81,14 @@ export async function createUser(client: Client, parameters: CreateUser): Promis
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Site
  * administration (that is, membership of the _site-admin_ [group](https://confluence.atlassian.com/x/24xjL)).
  */
-export async function removeUser(client: Client, parameters: RemoveUser): Promise<void> {
+export async function removeUser(client: Client, parameters: RemoveUser, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/user',
     method: 'DELETE',
     searchParams: {
       accountId: parameters.accountId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -97,7 +104,11 @@ export async function removeUser(client: Client, parameters: RemoveUser): Promis
  *   user.
  * - Permission to access Jira, to get the calling user's column details.
  */
-export async function getUserDefaultColumns(client: Client, parameters?: GetUserDefaultColumns): Promise<ColumnItem[]> {
+export async function getUserDefaultColumns(
+  client: Client,
+  parameters?: GetUserDefaultColumns,
+  options?: RequestOptions,
+): Promise<ColumnItem[]> {
   const config: SendRequestOptions<ColumnItem[]> = {
     url: '/rest/api/3/user/columns',
     method: 'GET',
@@ -105,6 +116,7 @@ export async function getUserDefaultColumns(client: Client, parameters?: GetUser
       accountId: parameters?.accountId,
     },
     schema: z.array(ColumnItemSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -125,7 +137,11 @@ export async function getUserDefaultColumns(client: Client, parameters?: GetUser
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg), to set the columns on any user.
  * - Permission to access Jira, to set the calling user's columns.
  */
-export async function setUserColumns(client: Client, parameters: SetUserColumns): Promise<void> {
+export async function setUserColumns(
+  client: Client,
+  parameters: SetUserColumns,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/user/columns',
     method: 'PUT',
@@ -135,6 +151,7 @@ export async function setUserColumns(client: Client, parameters: SetUserColumns)
     body: {
       columns: parameters.columns,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -149,13 +166,18 @@ export async function setUserColumns(client: Client, parameters: SetUserColumns)
  * - _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg), to set the columns on any user.
  * - Permission to access Jira, to set the calling user's columns.
  */
-export async function resetUserColumns(client: Client, parameters: ResetUserColumns): Promise<void> {
+export async function resetUserColumns(
+  client: Client,
+  parameters: ResetUserColumns,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/user/columns',
     method: 'DELETE',
     searchParams: {
       accountId: parameters.accountId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -167,7 +189,11 @@ export async function resetUserColumns(client: Client, parameters: ResetUserColu
  * [guidelines](https://community.developer.atlassian.com/t/guidelines-for-requesting-access-to-email-address/27603).
  * For Forge apps, this API only supports access via asApp() requests.
  */
-export async function getUserEmail(client: Client, parameters: GetUserEmail): Promise<UnrestrictedUserEmail> {
+export async function getUserEmail(
+  client: Client,
+  parameters: GetUserEmail,
+  options?: RequestOptions,
+): Promise<UnrestrictedUserEmail> {
   const config: SendRequestOptions<UnrestrictedUserEmail> = {
     url: '/rest/api/3/user/email',
     method: 'GET',
@@ -175,6 +201,7 @@ export async function getUserEmail(client: Client, parameters: GetUserEmail): Pr
       accountId: parameters.accountId,
     },
     schema: UnrestrictedUserEmailSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -186,7 +213,11 @@ export async function getUserEmail(client: Client, parameters: GetUserEmail): Pr
  * [guidelines](https://community.developer.atlassian.com/t/guidelines-for-requesting-access-to-email-address/27603).
  * For Forge apps, this API only supports access via asApp() requests.
  */
-export async function getUserEmailBulk(client: Client, parameters: GetUserEmailBulk): Promise<UnrestrictedUserEmail> {
+export async function getUserEmailBulk(
+  client: Client,
+  parameters: GetUserEmailBulk,
+  options?: RequestOptions,
+): Promise<UnrestrictedUserEmail> {
   const config: SendRequestOptions<UnrestrictedUserEmail> = {
     url: '/rest/api/3/user/email/bulk',
     method: 'GET',
@@ -194,6 +225,7 @@ export async function getUserEmailBulk(client: Client, parameters: GetUserEmailB
       accountId: parameters.accountId,
     },
     schema: UnrestrictedUserEmailSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -205,7 +237,11 @@ export async function getUserEmailBulk(client: Client, parameters: GetUserEmailB
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getUserGroups(client: Client, parameters: GetUserGroups): Promise<GroupName[]> {
+export async function getUserGroups(
+  client: Client,
+  parameters: GetUserGroups,
+  options?: RequestOptions,
+): Promise<GroupName[]> {
   const config: SendRequestOptions<GroupName[]> = {
     url: '/rest/api/3/user/groups',
     method: 'GET',
@@ -213,6 +249,7 @@ export async function getUserGroups(client: Client, parameters: GetUserGroups): 
       accountId: parameters.accountId,
     },
     schema: z.array(GroupNameSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -229,7 +266,11 @@ export async function getUserGroups(client: Client, parameters: GetUserGroups): 
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getAllUsersDefault(client: Client, parameters?: GetAllUsersDefault): Promise<DashboardUser[]> {
+export async function getAllUsersDefault(
+  client: Client,
+  parameters?: GetAllUsersDefault,
+  options?: RequestOptions,
+): Promise<DashboardUser[]> {
   const config: SendRequestOptions<DashboardUser[]> = {
     url: '/rest/api/3/users',
     method: 'GET',
@@ -239,6 +280,7 @@ export async function getAllUsersDefault(client: Client, parameters?: GetAllUser
       expand: parameters?.expand,
     },
     schema: z.array(DashboardUserSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -255,7 +297,11 @@ export async function getAllUsersDefault(client: Client, parameters?: GetAllUser
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** _Browse
  * users and groups_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getAllUsers(client: Client, parameters?: GetAllUsers): Promise<DashboardUser[]> {
+export async function getAllUsers(
+  client: Client,
+  parameters?: GetAllUsers,
+  options?: RequestOptions,
+): Promise<DashboardUser[]> {
   const config: SendRequestOptions<DashboardUser[]> = {
     url: '/rest/api/3/users/search',
     method: 'GET',
@@ -265,6 +311,7 @@ export async function getAllUsers(client: Client, parameters?: GetAllUsers): Pro
       expand: parameters?.expand,
     },
     schema: z.array(DashboardUserSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/webhooks.ts
+++ b/src/cloud/api/webhooks.ts
@@ -10,7 +10,7 @@ import type { GetDynamicWebhooksForApp } from '../parameters/getDynamicWebhooksF
 import type { RegisterDynamicWebhooks } from '../parameters/registerDynamicWebhooks';
 import type { DeleteWebhookById } from '../parameters/deleteWebhookById';
 import type { RefreshWebhooks } from '../parameters/refreshWebhooks';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of the
@@ -23,6 +23,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getDynamicWebhooksForApp(
   client: Client,
   parameters?: GetDynamicWebhooksForApp,
+  options?: RequestOptions,
 ): Promise<Page<Webhook>> {
   const config: SendRequestOptions<Page<Webhook>> = {
     url: '/rest/api/3/webhook',
@@ -32,6 +33,7 @@ export async function getDynamicWebhooksForApp(
       maxResults: parameters?.maxResults,
     },
     schema: PageWebhookSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -50,6 +52,7 @@ export async function getDynamicWebhooksForApp(
 export async function registerDynamicWebhooks(
   client: Client,
   parameters: RegisterDynamicWebhooks,
+  options?: RequestOptions,
 ): Promise<ContainerForRegisteredWebhooks> {
   const config: SendRequestOptions<ContainerForRegisteredWebhooks> = {
     url: '/rest/api/3/webhook',
@@ -59,6 +62,7 @@ export async function registerDynamicWebhooks(
       webhooks: parameters.webhooks,
     },
     schema: ContainerForRegisteredWebhooksSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -72,13 +76,18 @@ export async function registerDynamicWebhooks(
  * [Connect](https://developer.atlassian.com/cloud/jira/platform/#connect-apps) and [OAuth
  * 2.0](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps) apps can use this operation.
  */
-export async function deleteWebhookById(client: Client, parameters: DeleteWebhookById): Promise<void> {
+export async function deleteWebhookById(
+  client: Client,
+  parameters: DeleteWebhookById,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/webhook',
     method: 'DELETE',
     body: {
       webhookIds: parameters.webhookIds,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -94,7 +103,11 @@ export async function deleteWebhookById(client: Client, parameters: DeleteWebhoo
  * [Connect](https://developer.atlassian.com/cloud/jira/platform/#connect-apps) and [OAuth
  * 2.0](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps) apps can use this operation.
  */
-export async function refreshWebhooks(client: Client, parameters: RefreshWebhooks): Promise<WebhooksExpirationDate> {
+export async function refreshWebhooks(
+  client: Client,
+  parameters: RefreshWebhooks,
+  options?: RequestOptions,
+): Promise<WebhooksExpirationDate> {
   const config: SendRequestOptions<WebhooksExpirationDate> = {
     url: '/rest/api/3/webhook/refresh',
     method: 'PUT',
@@ -102,6 +115,7 @@ export async function refreshWebhooks(client: Client, parameters: RefreshWebhook
       webhookIds: parameters.webhookIds,
     },
     schema: WebhooksExpirationDateSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/workflowSchemeDrafts.ts
+++ b/src/cloud/api/workflowSchemeDrafts.ts
@@ -16,7 +16,7 @@ import type { PublishDraftWorkflowScheme } from '../parameters/publishDraftWorkf
 import type { GetDraftWorkflow } from '../parameters/getDraftWorkflow';
 import type { UpdateDraftWorkflowMapping } from '../parameters/updateDraftWorkflowMapping';
 import type { DeleteDraftWorkflowMapping } from '../parameters/deleteDraftWorkflowMapping';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Create a draft workflow scheme from an active workflow scheme, by copying the active workflow scheme. Note that an
@@ -28,11 +28,13 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function createWorkflowSchemeDraftFromParent(
   client: Client,
   parameters: CreateWorkflowSchemeDraftFromParent,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/createdraft`,
     method: 'POST',
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -53,11 +55,13 @@ export async function createWorkflowSchemeDraftFromParent(
 export async function getWorkflowSchemeDraft(
   client: Client,
   parameters: GetWorkflowSchemeDraft,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft`,
     method: 'GET',
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -73,12 +77,14 @@ export async function getWorkflowSchemeDraft(
 export async function updateWorkflowSchemeDraft(
   client: Client,
   parameters: UpdateWorkflowSchemeDraft,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft`,
     method: 'PUT',
     body: parameters.body,
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -90,10 +96,15 @@ export async function updateWorkflowSchemeDraft(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteWorkflowSchemeDraft(client: Client, parameters: DeleteWorkflowSchemeDraft): Promise<void> {
+export async function deleteWorkflowSchemeDraft(
+  client: Client,
+  parameters: DeleteWorkflowSchemeDraft,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -110,11 +121,13 @@ export async function deleteWorkflowSchemeDraft(client: Client, parameters: Dele
 export async function getDraftDefaultWorkflow(
   client: Client,
   parameters: GetDraftDefaultWorkflow,
+  options?: RequestOptions,
 ): Promise<DefaultWorkflow> {
   const config: SendRequestOptions<DefaultWorkflow> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/default`,
     method: 'GET',
     schema: DefaultWorkflowSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -129,6 +142,7 @@ export async function getDraftDefaultWorkflow(
 export async function updateDraftDefaultWorkflow(
   client: Client,
   parameters: UpdateDraftDefaultWorkflow,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/default`,
@@ -138,6 +152,7 @@ export async function updateDraftDefaultWorkflow(
       workflow: parameters.workflow,
     },
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -153,11 +168,13 @@ export async function updateDraftDefaultWorkflow(
 export async function deleteDraftDefaultWorkflow(
   client: Client,
   parameters: DeleteDraftDefaultWorkflow,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/default`,
     method: 'DELETE',
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -172,11 +189,13 @@ export async function deleteDraftDefaultWorkflow(
 export async function getWorkflowSchemeDraftIssueType(
   client: Client,
   parameters: GetWorkflowSchemeDraftIssueType,
+  options?: RequestOptions,
 ): Promise<IssueTypeWorkflowMapping> {
   const config: SendRequestOptions<IssueTypeWorkflowMapping> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/issuetype/${parameters.issueType}`,
     method: 'GET',
     schema: IssueTypeWorkflowMappingSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -191,12 +210,14 @@ export async function getWorkflowSchemeDraftIssueType(
 export async function setWorkflowSchemeDraftIssueType(
   client: Client,
   parameters: SetWorkflowSchemeDraftIssueType,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/issuetype/${parameters.issueType}`,
     method: 'PUT',
     body: parameters.body,
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -211,11 +232,13 @@ export async function setWorkflowSchemeDraftIssueType(
 export async function deleteWorkflowSchemeDraftIssueType(
   client: Client,
   parameters: DeleteWorkflowSchemeDraftIssueType,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/issuetype/${parameters.issueType}`,
     method: 'DELETE',
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -238,6 +261,7 @@ export async function deleteWorkflowSchemeDraftIssueType(
 export async function publishDraftWorkflowScheme(
   client: Client,
   parameters: PublishDraftWorkflowScheme,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/publish`,
@@ -248,6 +272,7 @@ export async function publishDraftWorkflowScheme(
     body: {
       statusMappings: parameters.statusMappings,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -262,6 +287,7 @@ export async function publishDraftWorkflowScheme(
 export async function getDraftWorkflow(
   client: Client,
   parameters: GetDraftWorkflow,
+  options?: RequestOptions,
 ): Promise<IssueTypesWorkflowMapping> {
   const config: SendRequestOptions<IssueTypesWorkflowMapping> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/workflow`,
@@ -270,6 +296,7 @@ export async function getDraftWorkflow(
       workflowName: parameters.workflowName,
     },
     schema: IssueTypesWorkflowMappingSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -285,6 +312,7 @@ export async function getDraftWorkflow(
 export async function updateDraftWorkflowMapping(
   client: Client,
   parameters: UpdateDraftWorkflowMapping,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/workflow`,
@@ -299,6 +327,7 @@ export async function updateDraftWorkflowMapping(
       workflow: parameters.workflow,
     },
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -313,6 +342,7 @@ export async function updateDraftWorkflowMapping(
 export async function deleteDraftWorkflowMapping(
   client: Client,
   parameters: DeleteDraftWorkflowMapping,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/draft/workflow`,
@@ -320,6 +350,7 @@ export async function deleteDraftWorkflowMapping(
     searchParams: {
       workflowName: parameters.workflowName,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/workflowSchemeProjectAssociations.ts
+++ b/src/cloud/api/workflowSchemeProjectAssociations.ts
@@ -4,7 +4,7 @@ import {
 } from '../models/containerOfWorkflowSchemeAssociations';
 import type { GetWorkflowSchemeProjectAssociations } from '../parameters/getWorkflowSchemeProjectAssociations';
 import type { AssignSchemeToProject } from '../parameters/assignSchemeToProject';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a list of the workflow schemes associated with a list of projects. Each returned workflow scheme includes a
@@ -20,6 +20,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getWorkflowSchemeProjectAssociations(
   client: Client,
   parameters: GetWorkflowSchemeProjectAssociations,
+  options?: RequestOptions,
 ): Promise<ContainerOfWorkflowSchemeAssociations> {
   const config: SendRequestOptions<ContainerOfWorkflowSchemeAssociations> = {
     url: '/rest/api/3/workflowscheme/project',
@@ -28,6 +29,7 @@ export async function getWorkflowSchemeProjectAssociations(
       projectId: parameters.projectId,
     },
     schema: ContainerOfWorkflowSchemeAssociationsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -41,7 +43,11 @@ export async function getWorkflowSchemeProjectAssociations(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function assignSchemeToProject(client: Client, parameters: AssignSchemeToProject): Promise<void> {
+export async function assignSchemeToProject(
+  client: Client,
+  parameters: AssignSchemeToProject,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: '/rest/api/3/workflowscheme/project',
     method: 'PUT',
@@ -49,6 +55,7 @@ export async function assignSchemeToProject(client: Client, parameters: AssignSc
       projectId: parameters.projectId,
       workflowSchemeId: parameters.workflowSchemeId,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/workflowSchemes.ts
+++ b/src/cloud/api/workflowSchemes.ts
@@ -35,7 +35,7 @@ import type { GetWorkflow } from '../parameters/getWorkflow';
 import type { UpdateWorkflowMapping } from '../parameters/updateWorkflowMapping';
 import type { DeleteWorkflowMapping } from '../parameters/deleteWorkflowMapping';
 import type { GetProjectUsagesForWorkflowScheme } from '../parameters/getProjectUsagesForWorkflowScheme';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -48,6 +48,7 @@ import { z } from 'zod';
 export async function getAllWorkflowSchemes(
   client: Client,
   parameters?: GetAllWorkflowSchemes,
+  options?: RequestOptions,
 ): Promise<Page<WorkflowScheme>> {
   const config: SendRequestOptions<Page<WorkflowScheme>> = {
     url: '/rest/api/3/workflowscheme',
@@ -57,6 +58,7 @@ export async function getAllWorkflowSchemes(
       maxResults: parameters?.maxResults,
     },
     schema: PageWorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -68,7 +70,11 @@ export async function getAllWorkflowSchemes(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function createWorkflowScheme(client: Client, parameters: CreateWorkflowScheme): Promise<WorkflowScheme> {
+export async function createWorkflowScheme(
+  client: Client,
+  parameters: CreateWorkflowScheme,
+  options?: RequestOptions,
+): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: '/rest/api/3/workflowscheme',
     method: 'POST',
@@ -88,6 +94,7 @@ export async function createWorkflowScheme(client: Client, parameters: CreateWor
       updateDraftIfNeeded: parameters.updateDraftIfNeeded,
     },
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -104,6 +111,7 @@ export async function createWorkflowScheme(client: Client, parameters: CreateWor
 export async function readWorkflowSchemes(
   client: Client,
   parameters: ReadWorkflowSchemes,
+  options?: RequestOptions,
 ): Promise<WorkflowSchemeReadResponse[]> {
   const config: SendRequestOptions<WorkflowSchemeReadResponse[]> = {
     url: '/rest/api/3/workflowscheme/read',
@@ -113,6 +121,7 @@ export async function readWorkflowSchemes(
       workflowSchemeIds: parameters.workflowSchemeIds,
     },
     schema: z.array(WorkflowSchemeReadResponseSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -129,7 +138,11 @@ export async function readWorkflowSchemes(
  * - _Administer Jira_ project permission to update all, including global-scoped, workflow schemes.
  * - _Administer projects_ project permission to update project-scoped workflow schemes.
  */
-export async function updateSchemes(client: Client, parameters: UpdateSchemes): Promise<TaskProgressObject> {
+export async function updateSchemes(
+  client: Client,
+  parameters: UpdateSchemes,
+  options?: RequestOptions,
+): Promise<TaskProgressObject> {
   const config: SendRequestOptions<TaskProgressObject> = {
     url: '/rest/api/3/workflowscheme/update',
     method: 'POST',
@@ -144,6 +157,7 @@ export async function updateSchemes(client: Client, parameters: UpdateSchemes): 
       workflowsForIssueTypes: parameters.workflowsForIssueTypes,
     },
     schema: TaskProgressObjectSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -162,6 +176,7 @@ export async function updateSchemes(client: Client, parameters: UpdateSchemes): 
 export async function getRequiredWorkflowSchemeMappings(
   client: Client,
   parameters: GetRequiredWorkflowSchemeMappings,
+  options?: RequestOptions,
 ): Promise<WorkflowSchemeUpdateRequiredMappingsResponse> {
   const config: SendRequestOptions<WorkflowSchemeUpdateRequiredMappingsResponse> = {
     url: '/rest/api/3/workflowscheme/update/mappings',
@@ -172,6 +187,7 @@ export async function getRequiredWorkflowSchemeMappings(
       workflowsForIssueTypes: parameters.workflowsForIssueTypes,
     },
     schema: WorkflowSchemeUpdateRequiredMappingsResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -183,7 +199,11 @@ export async function getRequiredWorkflowSchemeMappings(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getWorkflowScheme(client: Client, parameters: GetWorkflowScheme): Promise<WorkflowScheme> {
+export async function getWorkflowScheme(
+  client: Client,
+  parameters: GetWorkflowScheme,
+  options?: RequestOptions,
+): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}`,
     method: 'GET',
@@ -191,6 +211,7 @@ export async function getWorkflowScheme(client: Client, parameters: GetWorkflowS
       returnDraftIfExists: parameters.returnDraftIfExists,
     },
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -204,12 +225,17 @@ export async function getWorkflowScheme(client: Client, parameters: GetWorkflowS
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function updateWorkflowScheme(client: Client, parameters: UpdateWorkflowScheme): Promise<WorkflowScheme> {
+export async function updateWorkflowScheme(
+  client: Client,
+  parameters: UpdateWorkflowScheme,
+  options?: RequestOptions,
+): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}`,
     method: 'PUT',
     body: parameters.body,
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -222,10 +248,15 @@ export async function updateWorkflowScheme(client: Client, parameters: UpdateWor
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteWorkflowScheme(client: Client, parameters: DeleteWorkflowScheme): Promise<void> {
+export async function deleteWorkflowScheme(
+  client: Client,
+  parameters: DeleteWorkflowScheme,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -239,7 +270,11 @@ export async function deleteWorkflowScheme(client: Client, parameters: DeleteWor
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getDefaultWorkflow(client: Client, parameters: GetDefaultWorkflow): Promise<DefaultWorkflow> {
+export async function getDefaultWorkflow(
+  client: Client,
+  parameters: GetDefaultWorkflow,
+  options?: RequestOptions,
+): Promise<DefaultWorkflow> {
   const config: SendRequestOptions<DefaultWorkflow> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/default`,
     method: 'GET',
@@ -247,6 +282,7 @@ export async function getDefaultWorkflow(client: Client, parameters: GetDefaultW
       returnDraftIfExists: parameters.returnDraftIfExists,
     },
     schema: DefaultWorkflowSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -265,6 +301,7 @@ export async function getDefaultWorkflow(client: Client, parameters: GetDefaultW
 export async function updateDefaultWorkflow(
   client: Client,
   parameters: UpdateDefaultWorkflow,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/default`,
@@ -274,6 +311,7 @@ export async function updateDefaultWorkflow(
       workflow: parameters.workflow,
     },
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -293,6 +331,7 @@ export async function updateDefaultWorkflow(
 export async function deleteDefaultWorkflow(
   client: Client,
   parameters: DeleteDefaultWorkflow,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/default`,
@@ -301,6 +340,7 @@ export async function deleteDefaultWorkflow(
       updateDraftIfNeeded: parameters.updateDraftIfNeeded,
     },
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -315,6 +355,7 @@ export async function deleteDefaultWorkflow(
 export async function getWorkflowSchemeIssueType(
   client: Client,
   parameters: GetWorkflowSchemeIssueType,
+  options?: RequestOptions,
 ): Promise<IssueTypeWorkflowMapping> {
   const config: SendRequestOptions<IssueTypeWorkflowMapping> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/issuetype/${parameters.issueType}`,
@@ -323,6 +364,7 @@ export async function getWorkflowSchemeIssueType(
       returnDraftIfExists: parameters.returnDraftIfExists,
     },
     schema: IssueTypeWorkflowMappingSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -341,12 +383,14 @@ export async function getWorkflowSchemeIssueType(
 export async function setWorkflowSchemeIssueType(
   client: Client,
   parameters: SetWorkflowSchemeIssueType,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/issuetype/${parameters.issueType}`,
     method: 'PUT',
     body: parameters.body,
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -365,6 +409,7 @@ export async function setWorkflowSchemeIssueType(
 export async function deleteWorkflowSchemeIssueType(
   client: Client,
   parameters: DeleteWorkflowSchemeIssueType,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/issuetype/${parameters.issueType}`,
@@ -373,6 +418,7 @@ export async function deleteWorkflowSchemeIssueType(
       updateDraftIfNeeded: parameters.updateDraftIfNeeded,
     },
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -384,7 +430,11 @@ export async function deleteWorkflowSchemeIssueType(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function getWorkflow(client: Client, parameters: GetWorkflow): Promise<IssueTypesWorkflowMapping> {
+export async function getWorkflow(
+  client: Client,
+  parameters: GetWorkflow,
+  options?: RequestOptions,
+): Promise<IssueTypesWorkflowMapping> {
   const config: SendRequestOptions<IssueTypesWorkflowMapping> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/workflow`,
     method: 'GET',
@@ -393,6 +443,7 @@ export async function getWorkflow(client: Client, parameters: GetWorkflow): Prom
       returnDraftIfExists: parameters.returnDraftIfExists,
     },
     schema: IssueTypesWorkflowMappingSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -412,6 +463,7 @@ export async function getWorkflow(client: Client, parameters: GetWorkflow): Prom
 export async function updateWorkflowMapping(
   client: Client,
   parameters: UpdateWorkflowMapping,
+  options?: RequestOptions,
 ): Promise<WorkflowScheme> {
   const config: SendRequestOptions<WorkflowScheme> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/workflow`,
@@ -426,6 +478,7 @@ export async function updateWorkflowMapping(
       workflow: parameters.workflow,
     },
     schema: WorkflowSchemeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -441,7 +494,11 @@ export async function updateWorkflowMapping(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteWorkflowMapping(client: Client, parameters: DeleteWorkflowMapping): Promise<void> {
+export async function deleteWorkflowMapping(
+  client: Client,
+  parameters: DeleteWorkflowMapping,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/workflowscheme/${parameters.id}/workflow`,
     method: 'DELETE',
@@ -449,6 +506,7 @@ export async function deleteWorkflowMapping(client: Client, parameters: DeleteWo
       workflowName: parameters.workflowName,
       updateDraftIfNeeded: parameters.updateDraftIfNeeded,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -458,6 +516,7 @@ export async function deleteWorkflowMapping(client: Client, parameters: DeleteWo
 export async function getProjectUsagesForWorkflowScheme(
   client: Client,
   parameters: GetProjectUsagesForWorkflowScheme,
+  options?: RequestOptions,
 ): Promise<WorkflowSchemeProjectUsageDTO> {
   const config: SendRequestOptions<WorkflowSchemeProjectUsageDTO> = {
     url: `/rest/api/3/workflowscheme/${parameters.workflowSchemeId}/projectUsages`,
@@ -467,6 +526,7 @@ export async function getProjectUsagesForWorkflowScheme(
       maxResults: parameters.maxResults,
     },
     schema: WorkflowSchemeProjectUsageDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/workflowStatusCategories.ts
+++ b/src/cloud/api/workflowStatusCategories.ts
@@ -1,6 +1,6 @@
 import { StatusCategorySchema, type StatusCategory } from '../models/statusCategory';
 import type { GetStatusCategory } from '../parameters/getStatusCategory';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -9,11 +9,12 @@ import { z } from 'zod';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getStatusCategories(client: Client): Promise<StatusCategory[]> {
+export async function getStatusCategories(client: Client, options?: RequestOptions): Promise<StatusCategory[]> {
   const config: SendRequestOptions<StatusCategory[]> = {
     url: '/rest/api/3/statuscategory',
     method: 'GET',
     schema: z.array(StatusCategorySchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -26,11 +27,16 @@ export async function getStatusCategories(client: Client): Promise<StatusCategor
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:** Permission
  * to access Jira.
  */
-export async function getStatusCategory(client: Client, parameters: GetStatusCategory): Promise<StatusCategory> {
+export async function getStatusCategory(
+  client: Client,
+  parameters: GetStatusCategory,
+  options?: RequestOptions,
+): Promise<StatusCategory> {
   const config: SendRequestOptions<StatusCategory> = {
     url: `/rest/api/3/statuscategory/${parameters.idOrKey}`,
     method: 'GET',
     schema: StatusCategorySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/workflowStatuses.ts
+++ b/src/cloud/api/workflowStatuses.ts
@@ -1,6 +1,6 @@
 import { StatusDetailsSchema, type StatusDetails } from '../models/statusDetails';
 import type { GetStatus } from '../parameters/getStatus';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -13,11 +13,12 @@ import { z } from 'zod';
  * permission](https://support.atlassian.com/jira-cloud-administration/docs/manage-project-permissions/) for the
  * project.
  */
-export async function getStatuses(client: Client): Promise<StatusDetails[]> {
+export async function getStatuses(client: Client, options?: RequestOptions): Promise<StatusDetails[]> {
   const config: SendRequestOptions<StatusDetails[]> = {
     url: '/rest/api/3/status',
     method: 'GET',
     schema: z.array(StatusDetailsSchema),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -36,11 +37,16 @@ export async function getStatuses(client: Client): Promise<StatusDetails[]> {
  * permission](https://support.atlassian.com/jira-cloud-administration/docs/manage-project-permissions/) for the
  * project.
  */
-export async function getStatus(client: Client, parameters: GetStatus): Promise<StatusDetails> {
+export async function getStatus(
+  client: Client,
+  parameters: GetStatus,
+  options?: RequestOptions,
+): Promise<StatusDetails> {
   const config: SendRequestOptions<StatusDetails> = {
     url: `/rest/api/3/status/${parameters.idOrName}`,
     method: 'GET',
     schema: StatusDetailsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/workflowTransitionRules.ts
+++ b/src/cloud/api/workflowTransitionRules.ts
@@ -8,7 +8,7 @@ import {
 import type { GetWorkflowTransitionRuleConfigurations } from '../parameters/getWorkflowTransitionRuleConfigurations';
 import type { UpdateWorkflowTransitionRuleConfigurations } from '../parameters/updateWorkflowTransitionRuleConfigurations';
 import type { DeleteWorkflowTransitionRuleConfigurations } from '../parameters/deleteWorkflowTransitionRuleConfigurations';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a [paginated](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#pagination) list of workflows
@@ -32,6 +32,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getWorkflowTransitionRuleConfigurations(
   client: Client,
   parameters: GetWorkflowTransitionRuleConfigurations,
+  options?: RequestOptions,
 ): Promise<Page<WorkflowTransitionRules>> {
   const config: SendRequestOptions<Page<WorkflowTransitionRules>> = {
     url: '/rest/api/3/workflow/rule/config',
@@ -47,6 +48,7 @@ export async function getWorkflowTransitionRuleConfigurations(
       expand: parameters.expand,
     },
     schema: PageWorkflowTransitionRulesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -80,6 +82,7 @@ export async function getWorkflowTransitionRuleConfigurations(
 export async function updateWorkflowTransitionRuleConfigurations(
   client: Client,
   parameters: UpdateWorkflowTransitionRuleConfigurations,
+  options?: RequestOptions,
 ): Promise<WorkflowTransitionRulesUpdateErrors> {
   const config: SendRequestOptions<WorkflowTransitionRulesUpdateErrors> = {
     url: '/rest/api/3/workflow/rule/config',
@@ -88,6 +91,7 @@ export async function updateWorkflowTransitionRuleConfigurations(
       workflows: parameters.workflows,
     },
     schema: WorkflowTransitionRulesUpdateErrorsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -111,6 +115,7 @@ export async function updateWorkflowTransitionRuleConfigurations(
 export async function deleteWorkflowTransitionRuleConfigurations(
   client: Client,
   parameters: DeleteWorkflowTransitionRuleConfigurations,
+  options?: RequestOptions,
 ): Promise<WorkflowTransitionRulesUpdateErrors> {
   const config: SendRequestOptions<WorkflowTransitionRulesUpdateErrors> = {
     url: '/rest/api/3/workflow/rule/config/delete',
@@ -119,6 +124,7 @@ export async function deleteWorkflowTransitionRuleConfigurations(
       workflows: parameters.workflows,
     },
     schema: WorkflowTransitionRulesUpdateErrorsSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/api/workflows.ts
+++ b/src/cloud/api/workflows.ts
@@ -40,7 +40,7 @@ import type { ReadWorkflowPreviews } from '../parameters/readWorkflowPreviews';
 import type { SearchWorkflows } from '../parameters/searchWorkflows';
 import type { UpdateWorkflows } from '../parameters/updateWorkflows';
 import type { ValidateUpdateWorkflows } from '../parameters/validateUpdateWorkflows';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a workflow and related statuses for a specified workflow id and version number.
@@ -57,6 +57,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function readWorkflowFromHistory(
   client: Client,
   parameters: ReadWorkflowFromHistory,
+  options?: RequestOptions,
 ): Promise<WorkflowHistoryReadResponseDTO> {
   const config: SendRequestOptions<WorkflowHistoryReadResponseDTO> = {
     url: '/rest/api/3/workflow/history',
@@ -66,6 +67,7 @@ export async function readWorkflowFromHistory(
       workflowId: parameters.workflowId,
     },
     schema: WorkflowHistoryReadResponseDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -86,6 +88,7 @@ export async function readWorkflowFromHistory(
 export async function listWorkflowHistory(
   client: Client,
   parameters: ListWorkflowHistory,
+  options?: RequestOptions,
 ): Promise<WorkflowHistoryListResponseDTO> {
   const config: SendRequestOptions<WorkflowHistoryListResponseDTO> = {
     url: '/rest/api/3/workflow/history/list',
@@ -97,6 +100,7 @@ export async function listWorkflowHistory(
       workflowId: parameters.workflowId,
     },
     schema: WorkflowHistoryListResponseDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -115,10 +119,15 @@ export async function listWorkflowHistory(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro#permissions) required:**
  * _Administer Jira_ [global permission](https://confluence.atlassian.com/x/x4dKLg).
  */
-export async function deleteInactiveWorkflow(client: Client, parameters: DeleteInactiveWorkflow): Promise<void> {
+export async function deleteInactiveWorkflow(
+  client: Client,
+  parameters: DeleteInactiveWorkflow,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/api/3/workflow/${parameters.entityId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -128,6 +137,7 @@ export async function deleteInactiveWorkflow(client: Client, parameters: DeleteI
 export async function getWorkflowProjectIssueTypeUsages(
   client: Client,
   parameters: GetWorkflowProjectIssueTypeUsages,
+  options?: RequestOptions,
 ): Promise<WorkflowProjectIssueTypeUsageDTO> {
   const config: SendRequestOptions<WorkflowProjectIssueTypeUsageDTO> = {
     url: `/rest/api/3/workflow/${parameters.workflowId}/project/${parameters.projectId}/issueTypeUsages`,
@@ -137,6 +147,7 @@ export async function getWorkflowProjectIssueTypeUsages(
       maxResults: parameters.maxResults,
     },
     schema: WorkflowProjectIssueTypeUsageDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -146,6 +157,7 @@ export async function getWorkflowProjectIssueTypeUsages(
 export async function getProjectUsagesForWorkflow(
   client: Client,
   parameters: GetProjectUsagesForWorkflow,
+  options?: RequestOptions,
 ): Promise<WorkflowProjectUsageDTO> {
   const config: SendRequestOptions<WorkflowProjectUsageDTO> = {
     url: `/rest/api/3/workflow/${parameters.workflowId}/projectUsages`,
@@ -155,6 +167,7 @@ export async function getProjectUsagesForWorkflow(
       maxResults: parameters.maxResults,
     },
     schema: WorkflowProjectUsageDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -164,6 +177,7 @@ export async function getProjectUsagesForWorkflow(
 export async function getWorkflowSchemeUsagesForWorkflow(
   client: Client,
   parameters: GetWorkflowSchemeUsagesForWorkflow,
+  options?: RequestOptions,
 ): Promise<WorkflowSchemeUsageDTO> {
   const config: SendRequestOptions<WorkflowSchemeUsageDTO> = {
     url: `/rest/api/3/workflow/${parameters.workflowId}/workflowSchemes`,
@@ -173,6 +187,7 @@ export async function getWorkflowSchemeUsagesForWorkflow(
       maxResults: parameters.maxResults,
     },
     schema: WorkflowSchemeUsageDTOSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -188,7 +203,11 @@ export async function getWorkflowSchemeUsagesForWorkflow(
  * - At least one of the _Administer projects_ and _View (read-only) workflow_ project permissions to access
  *   project-scoped workflows
  */
-export async function readWorkflows(client: Client, parameters: ReadWorkflows): Promise<WorkflowReadResponse> {
+export async function readWorkflows(
+  client: Client,
+  parameters: ReadWorkflows,
+  options?: RequestOptions,
+): Promise<WorkflowReadResponse> {
   const config: SendRequestOptions<WorkflowReadResponse> = {
     url: '/rest/api/3/workflows',
     method: 'POST',
@@ -198,6 +217,7 @@ export async function readWorkflows(client: Client, parameters: ReadWorkflows): 
       workflowNames: parameters.workflowNames,
     },
     schema: WorkflowReadResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -796,6 +816,7 @@ export async function readWorkflows(client: Client, parameters: ReadWorkflows): 
 export async function workflowCapabilities(
   client: Client,
   parameters?: WorkflowCapabilitiesParameters,
+  options?: RequestOptions,
 ): Promise<WorkflowCapabilities> {
   const config: SendRequestOptions<WorkflowCapabilities> = {
     url: '/rest/api/3/workflows/capabilities',
@@ -806,6 +827,7 @@ export async function workflowCapabilities(
       issueTypeId: parameters?.issueTypeId,
     },
     schema: WorkflowCapabilitiesSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -819,7 +841,11 @@ export async function workflowCapabilities(
  * - _Administer Jira_ project permission to create all, including global-scoped, workflows
  * - _Administer projects_ project permissions to create project-scoped workflows
  */
-export async function createWorkflows(client: Client, parameters: CreateWorkflows): Promise<WorkflowCreateResponse> {
+export async function createWorkflows(
+  client: Client,
+  parameters: CreateWorkflows,
+  options?: RequestOptions,
+): Promise<WorkflowCreateResponse> {
   const config: SendRequestOptions<WorkflowCreateResponse> = {
     url: '/rest/api/3/workflows/create',
     method: 'POST',
@@ -829,6 +855,7 @@ export async function createWorkflows(client: Client, parameters: CreateWorkflow
       workflows: parameters.workflows,
     },
     schema: WorkflowCreateResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -845,6 +872,7 @@ export async function createWorkflows(client: Client, parameters: CreateWorkflow
 export async function validateCreateWorkflows(
   client: Client,
   parameters: ValidateCreateWorkflows,
+  options?: RequestOptions,
 ): Promise<WorkflowValidationErrorList> {
   const config: SendRequestOptions<WorkflowValidationErrorList> = {
     url: '/rest/api/3/workflows/create/validation',
@@ -854,17 +882,22 @@ export async function validateCreateWorkflows(
       validationOptions: parameters.validationOptions,
     },
     schema: WorkflowValidationErrorListSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
 /** Get the user's default workflow editor. This can be either the new editor or the legacy editor. */
-export async function getDefaultEditor(client: Client): Promise<DefaultWorkflowEditorResponse> {
+export async function getDefaultEditor(
+  client: Client,
+  options?: RequestOptions,
+): Promise<DefaultWorkflowEditorResponse> {
   const config: SendRequestOptions<DefaultWorkflowEditorResponse> = {
     url: '/rest/api/3/workflows/defaultEditor',
     method: 'GET',
     schema: DefaultWorkflowEditorResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -881,6 +914,7 @@ export async function getDefaultEditor(client: Client): Promise<DefaultWorkflowE
 export async function readWorkflowPreviews(
   client: Client,
   parameters: ReadWorkflowPreviews,
+  options?: RequestOptions,
 ): Promise<WorkflowPreviewResponse> {
   const config: SendRequestOptions<WorkflowPreviewResponse> = {
     url: '/rest/api/3/workflows/preview',
@@ -892,6 +926,7 @@ export async function readWorkflowPreviews(
       workflowNames: parameters.workflowNames,
     },
     schema: WorkflowPreviewResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -908,7 +943,11 @@ export async function readWorkflowPreviews(
  * - At least one of the _Administer projects_ and _View (read-only) workflow_ project permissions to access
  *   project-scoped workflows
  */
-export async function searchWorkflows(client: Client, parameters?: SearchWorkflows): Promise<WorkflowSearchResponse> {
+export async function searchWorkflows(
+  client: Client,
+  parameters?: SearchWorkflows,
+  options?: RequestOptions,
+): Promise<WorkflowSearchResponse> {
   const config: SendRequestOptions<WorkflowSearchResponse> = {
     url: '/rest/api/3/workflows/search',
     method: 'GET',
@@ -923,6 +962,7 @@ export async function searchWorkflows(client: Client, parameters?: SearchWorkflo
       projectId: parameters?.projectId,
     },
     schema: WorkflowSearchResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -936,7 +976,11 @@ export async function searchWorkflows(client: Client, parameters?: SearchWorkflo
  * - _Administer Jira_ project permission to create all, including global-scoped, workflows
  * - _Administer projects_ project permissions to create project-scoped workflows
  */
-export async function updateWorkflows(client: Client, parameters: UpdateWorkflows): Promise<WorkflowUpdateResponse> {
+export async function updateWorkflows(
+  client: Client,
+  parameters: UpdateWorkflows,
+  options?: RequestOptions,
+): Promise<WorkflowUpdateResponse> {
   const config: SendRequestOptions<WorkflowUpdateResponse> = {
     url: '/rest/api/3/workflows/update',
     method: 'POST',
@@ -945,6 +989,7 @@ export async function updateWorkflows(client: Client, parameters: UpdateWorkflow
       workflows: parameters.workflows,
     },
     schema: WorkflowUpdateResponseSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -961,6 +1006,7 @@ export async function updateWorkflows(client: Client, parameters: UpdateWorkflow
 export async function validateUpdateWorkflows(
   client: Client,
   parameters: ValidateUpdateWorkflows,
+  options?: RequestOptions,
 ): Promise<WorkflowValidationErrorList> {
   const config: SendRequestOptions<WorkflowValidationErrorList> = {
     url: '/rest/api/3/workflows/update/validation',
@@ -970,6 +1016,7 @@ export async function validateUpdateWorkflows(
       validationOptions: parameters.validationOptions,
     },
     schema: WorkflowValidationErrorListSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/cloud/createCloudClient.ts
+++ b/src/cloud/createCloudClient.ts
@@ -1,4 +1,4 @@
-import { type ClientConfig, type Client, createClient, type Buffer } from '#/core';
+import { type ClientConfig, type Client, type RequestOptions, createClient, type Buffer } from '#/core';
 import * as announcementBanner from './api/announcementBanner';
 import * as issueCustomFieldValuesApps from './api/issueCustomFieldValuesApps';
 import * as issueCustomFieldConfigurationApps from './api/issueCustomFieldConfigurationApps';
@@ -737,1065 +737,1469 @@ export function createCloudClient(clientConfig: ClientConfig | Client) {
 
   return {
     announcementBanner: {
-      getBanner: (): Promise<AnnouncementBannerConfiguration> => announcementBanner.getBanner(client),
-      setBanner: (parameters: SetBanner): Promise<void> => announcementBanner.setBanner(client, parameters),
+      getBanner: (options?: RequestOptions): Promise<AnnouncementBannerConfiguration> =>
+        announcementBanner.getBanner(client, options),
+      setBanner: (parameters: SetBanner, options?: RequestOptions): Promise<void> =>
+        announcementBanner.setBanner(client, parameters, options),
     },
     issueCustomFieldValuesApps: {
-      updateMultipleCustomFieldValues: (parameters: UpdateMultipleCustomFieldValues): Promise<void> =>
-        issueCustomFieldValuesApps.updateMultipleCustomFieldValues(client, parameters),
-      updateCustomFieldValue: (parameters: UpdateCustomFieldValue): Promise<void> =>
-        issueCustomFieldValuesApps.updateCustomFieldValue(client, parameters),
+      updateMultipleCustomFieldValues: (
+        parameters: UpdateMultipleCustomFieldValues,
+        options?: RequestOptions,
+      ): Promise<void> => issueCustomFieldValuesApps.updateMultipleCustomFieldValues(client, parameters, options),
+      updateCustomFieldValue: (parameters: UpdateCustomFieldValue, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldValuesApps.updateCustomFieldValue(client, parameters, options),
     },
     issueCustomFieldConfigurationApps: {
-      getCustomFieldConfiguration: (parameters: GetCustomFieldConfiguration): Promise<Page<ContextualConfiguration>> =>
-        issueCustomFieldConfigurationApps.getCustomFieldConfiguration(client, parameters),
-      updateCustomFieldConfiguration: (parameters: UpdateCustomFieldConfiguration): Promise<void> =>
-        issueCustomFieldConfigurationApps.updateCustomFieldConfiguration(client, parameters),
+      getCustomFieldConfiguration: (
+        parameters: GetCustomFieldConfiguration,
+        options?: RequestOptions,
+      ): Promise<Page<ContextualConfiguration>> =>
+        issueCustomFieldConfigurationApps.getCustomFieldConfiguration(client, parameters, options),
+      updateCustomFieldConfiguration: (
+        parameters: UpdateCustomFieldConfiguration,
+        options?: RequestOptions,
+      ): Promise<void> => issueCustomFieldConfigurationApps.updateCustomFieldConfiguration(client, parameters, options),
     },
     jiraSettings: {
-      getApplicationProperty: (parameters?: GetApplicationProperty): Promise<ApplicationProperty[]> =>
-        jiraSettings.getApplicationProperty(client, parameters),
-      getAdvancedSettings: (): Promise<ApplicationProperty[]> => jiraSettings.getAdvancedSettings(client),
-      setApplicationProperty: (parameters: SetApplicationProperty): Promise<ApplicationProperty> =>
-        jiraSettings.setApplicationProperty(client, parameters),
-      getConfiguration: (): Promise<Configuration> => jiraSettings.getConfiguration(client),
+      getApplicationProperty: (
+        parameters?: GetApplicationProperty,
+        options?: RequestOptions,
+      ): Promise<ApplicationProperty[]> => jiraSettings.getApplicationProperty(client, parameters, options),
+      getAdvancedSettings: (options?: RequestOptions): Promise<ApplicationProperty[]> =>
+        jiraSettings.getAdvancedSettings(client, options),
+      setApplicationProperty: (
+        parameters: SetApplicationProperty,
+        options?: RequestOptions,
+      ): Promise<ApplicationProperty> => jiraSettings.setApplicationProperty(client, parameters, options),
+      getConfiguration: (options?: RequestOptions): Promise<Configuration> =>
+        jiraSettings.getConfiguration(client, options),
     },
     applicationRoles: {
-      getAllApplicationRoles: (): Promise<ApplicationRole[]> => applicationRoles.getAllApplicationRoles(client),
-      getApplicationRole: (parameters: GetApplicationRole): Promise<ApplicationRole> =>
-        applicationRoles.getApplicationRole(client, parameters),
+      getAllApplicationRoles: (options?: RequestOptions): Promise<ApplicationRole[]> =>
+        applicationRoles.getAllApplicationRoles(client, options),
+      getApplicationRole: (parameters: GetApplicationRole, options?: RequestOptions): Promise<ApplicationRole> =>
+        applicationRoles.getApplicationRole(client, parameters, options),
     },
     issueAttachments: {
-      getAttachmentContent: (parameters: GetAttachmentContent): Promise<Buffer> =>
-        issueAttachments.getAttachmentContent(client, parameters),
-      getAttachmentMeta: (): Promise<AttachmentSettings> => issueAttachments.getAttachmentMeta(client),
-      getAttachmentThumbnail: (parameters: GetAttachmentThumbnail): Promise<Buffer> =>
-        issueAttachments.getAttachmentThumbnail(client, parameters),
-      getAttachment: (parameters: GetAttachment): Promise<AttachmentMetadata> =>
-        issueAttachments.getAttachment(client, parameters),
-      removeAttachment: (parameters: RemoveAttachment): Promise<void> =>
-        issueAttachments.removeAttachment(client, parameters),
-      addAttachment: (parameters: AddAttachment): Promise<Attachment[]> =>
-        issueAttachments.addAttachment(client, parameters),
+      getAttachmentContent: (parameters: GetAttachmentContent, options?: RequestOptions): Promise<Buffer> =>
+        issueAttachments.getAttachmentContent(client, parameters, options),
+      getAttachmentMeta: (options?: RequestOptions): Promise<AttachmentSettings> =>
+        issueAttachments.getAttachmentMeta(client, options),
+      getAttachmentThumbnail: (parameters: GetAttachmentThumbnail, options?: RequestOptions): Promise<Buffer> =>
+        issueAttachments.getAttachmentThumbnail(client, parameters, options),
+      getAttachment: (parameters: GetAttachment, options?: RequestOptions): Promise<AttachmentMetadata> =>
+        issueAttachments.getAttachment(client, parameters, options),
+      removeAttachment: (parameters: RemoveAttachment, options?: RequestOptions): Promise<void> =>
+        issueAttachments.removeAttachment(client, parameters, options),
+      addAttachment: (parameters: AddAttachment, options?: RequestOptions): Promise<Attachment[]> =>
+        issueAttachments.addAttachment(client, parameters, options),
     },
     auditRecords: {
-      getAuditRecords: (parameters?: GetAuditRecords): Promise<AuditRecords> =>
-        auditRecords.getAuditRecords(client, parameters),
+      getAuditRecords: (parameters?: GetAuditRecords, options?: RequestOptions): Promise<AuditRecords> =>
+        auditRecords.getAuditRecords(client, parameters, options),
     },
     avatars: {
-      getAllSystemAvatars: (parameters: GetAllSystemAvatars): Promise<SystemAvatars> =>
-        avatars.getAllSystemAvatars(client, parameters),
-      getAvatars: (parameters: GetAvatars): Promise<Avatars> => avatars.getAvatars(client, parameters),
-      storeAvatar: (parameters: StoreAvatar): Promise<Avatar> => avatars.storeAvatar(client, parameters),
-      deleteAvatar: (parameters: DeleteAvatar): Promise<void> => avatars.deleteAvatar(client, parameters),
-      getAvatarImageByType: (parameters: GetAvatarImageByType): Promise<Blob> =>
-        avatars.getAvatarImageByType(client, parameters),
-      getAvatarImageByID: (parameters: GetAvatarImageByID): Promise<Blob> =>
-        avatars.getAvatarImageByID(client, parameters),
-      getAvatarImageByOwner: (parameters: GetAvatarImageByOwner): Promise<Blob> =>
-        avatars.getAvatarImageByOwner(client, parameters),
+      getAllSystemAvatars: (parameters: GetAllSystemAvatars, options?: RequestOptions): Promise<SystemAvatars> =>
+        avatars.getAllSystemAvatars(client, parameters, options),
+      getAvatars: (parameters: GetAvatars, options?: RequestOptions): Promise<Avatars> =>
+        avatars.getAvatars(client, parameters, options),
+      storeAvatar: (parameters: StoreAvatar, options?: RequestOptions): Promise<Avatar> =>
+        avatars.storeAvatar(client, parameters, options),
+      deleteAvatar: (parameters: DeleteAvatar, options?: RequestOptions): Promise<void> =>
+        avatars.deleteAvatar(client, parameters, options),
+      getAvatarImageByType: (parameters: GetAvatarImageByType, options?: RequestOptions): Promise<Blob> =>
+        avatars.getAvatarImageByType(client, parameters, options),
+      getAvatarImageByID: (parameters: GetAvatarImageByID, options?: RequestOptions): Promise<Blob> =>
+        avatars.getAvatarImageByID(client, parameters, options),
+      getAvatarImageByOwner: (parameters: GetAvatarImageByOwner, options?: RequestOptions): Promise<Blob> =>
+        avatars.getAvatarImageByOwner(client, parameters, options),
     },
     issueBulkOperations: {
-      submitBulkDelete: (parameters: SubmitBulkDelete): Promise<SubmittedBulkOperation> =>
-        issueBulkOperations.submitBulkDelete(client, parameters),
-      getBulkEditableFields: (parameters: GetBulkEditableFields): Promise<BulkEditGetFields> =>
-        issueBulkOperations.getBulkEditableFields(client, parameters),
-      submitBulkEdit: (parameters: SubmitBulkEdit): Promise<SubmittedBulkOperation> =>
-        issueBulkOperations.submitBulkEdit(client, parameters),
-      submitBulkMove: (parameters: SubmitBulkMove): Promise<SubmittedBulkOperation> =>
-        issueBulkOperations.submitBulkMove(client, parameters),
-      getAvailableTransitions: (parameters: GetAvailableTransitions): Promise<BulkTransitionGetAvailableTransitions> =>
-        issueBulkOperations.getAvailableTransitions(client, parameters),
-      submitBulkTransition: (parameters: SubmitBulkTransition): Promise<SubmittedBulkOperation> =>
-        issueBulkOperations.submitBulkTransition(client, parameters),
-      submitBulkUnwatch: (parameters: SubmitBulkUnwatch): Promise<SubmittedBulkOperation> =>
-        issueBulkOperations.submitBulkUnwatch(client, parameters),
-      submitBulkWatch: (parameters: SubmitBulkWatch): Promise<SubmittedBulkOperation> =>
-        issueBulkOperations.submitBulkWatch(client, parameters),
-      getBulkOperationProgress: (parameters: GetBulkOperationProgress): Promise<BulkOperationProgress> =>
-        issueBulkOperations.getBulkOperationProgress(client, parameters),
+      submitBulkDelete: (parameters: SubmitBulkDelete, options?: RequestOptions): Promise<SubmittedBulkOperation> =>
+        issueBulkOperations.submitBulkDelete(client, parameters, options),
+      getBulkEditableFields: (
+        parameters: GetBulkEditableFields,
+        options?: RequestOptions,
+      ): Promise<BulkEditGetFields> => issueBulkOperations.getBulkEditableFields(client, parameters, options),
+      submitBulkEdit: (parameters: SubmitBulkEdit, options?: RequestOptions): Promise<SubmittedBulkOperation> =>
+        issueBulkOperations.submitBulkEdit(client, parameters, options),
+      submitBulkMove: (parameters: SubmitBulkMove, options?: RequestOptions): Promise<SubmittedBulkOperation> =>
+        issueBulkOperations.submitBulkMove(client, parameters, options),
+      getAvailableTransitions: (
+        parameters: GetAvailableTransitions,
+        options?: RequestOptions,
+      ): Promise<BulkTransitionGetAvailableTransitions> =>
+        issueBulkOperations.getAvailableTransitions(client, parameters, options),
+      submitBulkTransition: (
+        parameters: SubmitBulkTransition,
+        options?: RequestOptions,
+      ): Promise<SubmittedBulkOperation> => issueBulkOperations.submitBulkTransition(client, parameters, options),
+      submitBulkUnwatch: (parameters: SubmitBulkUnwatch, options?: RequestOptions): Promise<SubmittedBulkOperation> =>
+        issueBulkOperations.submitBulkUnwatch(client, parameters, options),
+      submitBulkWatch: (parameters: SubmitBulkWatch, options?: RequestOptions): Promise<SubmittedBulkOperation> =>
+        issueBulkOperations.submitBulkWatch(client, parameters, options),
+      getBulkOperationProgress: (
+        parameters: GetBulkOperationProgress,
+        options?: RequestOptions,
+      ): Promise<BulkOperationProgress> => issueBulkOperations.getBulkOperationProgress(client, parameters, options),
     },
     issues: {
-      getBulkChangelogs: (parameters: GetBulkChangelogs): Promise<BulkChangelogResponse> =>
-        issues.getBulkChangelogs(client, parameters),
-      createIssue: (parameters: CreateIssue): Promise<CreatedIssue> => issues.createIssue(client, parameters),
-      createIssues: (parameters: CreateIssues): Promise<CreatedIssues> => issues.createIssues(client, parameters),
-      bulkFetchIssues: (parameters: BulkFetchIssues): Promise<BulkIssueResults> =>
-        issues.bulkFetchIssues(client, parameters),
-      getCreateIssueMetaIssueTypes: (parameters: GetCreateIssueMetaIssueTypes): Promise<PageOfCreateMetaIssueTypes> =>
-        issues.getCreateIssueMetaIssueTypes(client, parameters),
+      getBulkChangelogs: (parameters: GetBulkChangelogs, options?: RequestOptions): Promise<BulkChangelogResponse> =>
+        issues.getBulkChangelogs(client, parameters, options),
+      createIssue: (parameters: CreateIssue, options?: RequestOptions): Promise<CreatedIssue> =>
+        issues.createIssue(client, parameters, options),
+      createIssues: (parameters: CreateIssues, options?: RequestOptions): Promise<CreatedIssues> =>
+        issues.createIssues(client, parameters, options),
+      bulkFetchIssues: (parameters: BulkFetchIssues, options?: RequestOptions): Promise<BulkIssueResults> =>
+        issues.bulkFetchIssues(client, parameters, options),
+      getCreateIssueMetaIssueTypes: (
+        parameters: GetCreateIssueMetaIssueTypes,
+        options?: RequestOptions,
+      ): Promise<PageOfCreateMetaIssueTypes> => issues.getCreateIssueMetaIssueTypes(client, parameters, options),
       getCreateIssueMetaIssueTypeId: (
         parameters: GetCreateIssueMetaIssueTypeId,
-      ): Promise<PageOfCreateMetaIssueTypeWithField> => issues.getCreateIssueMetaIssueTypeId(client, parameters),
-      getIssue: (parameters: GetIssue): Promise<Issue> => issues.getIssue(client, parameters),
-      editIssue: (parameters: EditIssue): Promise<void> => issues.editIssue(client, parameters),
-      deleteIssue: (parameters: DeleteIssue): Promise<void> => issues.deleteIssue(client, parameters),
-      assignIssue: (parameters: AssignIssue): Promise<void> => issues.assignIssue(client, parameters),
-      getChangeLogs: (parameters: GetChangeLogs): Promise<Page<Changelog>> => issues.getChangeLogs(client, parameters),
-      getChangeLogsByIds: (parameters: GetChangeLogsByIds): Promise<PageOfChangelogs> =>
-        issues.getChangeLogsByIds(client, parameters),
-      getEditIssueMeta: (parameters: GetEditIssueMeta): Promise<IssueUpdateMetadata> =>
-        issues.getEditIssueMeta(client, parameters),
-      notify: (parameters: Notify): Promise<void> => issues.notify(client, parameters),
-      getTransitions: (parameters: GetTransitions): Promise<Transitions> => issues.getTransitions(client, parameters),
-      doTransition: (parameters: DoTransition): Promise<void> => issues.doTransition(client, parameters),
+        options?: RequestOptions,
+      ): Promise<PageOfCreateMetaIssueTypeWithField> =>
+        issues.getCreateIssueMetaIssueTypeId(client, parameters, options),
+      getIssue: (parameters: GetIssue, options?: RequestOptions): Promise<Issue> =>
+        issues.getIssue(client, parameters, options),
+      editIssue: (parameters: EditIssue, options?: RequestOptions): Promise<void> =>
+        issues.editIssue(client, parameters, options),
+      deleteIssue: (parameters: DeleteIssue, options?: RequestOptions): Promise<void> =>
+        issues.deleteIssue(client, parameters, options),
+      assignIssue: (parameters: AssignIssue, options?: RequestOptions): Promise<void> =>
+        issues.assignIssue(client, parameters, options),
+      getChangeLogs: (parameters: GetChangeLogs, options?: RequestOptions): Promise<Page<Changelog>> =>
+        issues.getChangeLogs(client, parameters, options),
+      getChangeLogsByIds: (parameters: GetChangeLogsByIds, options?: RequestOptions): Promise<PageOfChangelogs> =>
+        issues.getChangeLogsByIds(client, parameters, options),
+      getEditIssueMeta: (parameters: GetEditIssueMeta, options?: RequestOptions): Promise<IssueUpdateMetadata> =>
+        issues.getEditIssueMeta(client, parameters, options),
+      notify: (parameters: Notify, options?: RequestOptions): Promise<void> =>
+        issues.notify(client, parameters, options),
+      getTransitions: (parameters: GetTransitions, options?: RequestOptions): Promise<Transitions> =>
+        issues.getTransitions(client, parameters, options),
+      doTransition: (parameters: DoTransition, options?: RequestOptions): Promise<void> =>
+        issues.doTransition(client, parameters, options),
     },
     issueComments: {
-      getCommentsByIds: (parameters: GetCommentsByIds): Promise<Page<Comment>> =>
-        issueComments.getCommentsByIds(client, parameters),
-      getComments: (parameters: GetComments): Promise<PageOfComments> => issueComments.getComments(client, parameters),
-      addComment: (parameters: AddComment): Promise<Comment> => issueComments.addComment(client, parameters),
-      getComment: (parameters: GetComment): Promise<Comment> => issueComments.getComment(client, parameters),
-      updateComment: (parameters: UpdateComment): Promise<Comment> => issueComments.updateComment(client, parameters),
-      deleteComment: (parameters: DeleteComment): Promise<void> => issueComments.deleteComment(client, parameters),
+      getCommentsByIds: (parameters: GetCommentsByIds, options?: RequestOptions): Promise<Page<Comment>> =>
+        issueComments.getCommentsByIds(client, parameters, options),
+      getComments: (parameters: GetComments, options?: RequestOptions): Promise<PageOfComments> =>
+        issueComments.getComments(client, parameters, options),
+      addComment: (parameters: AddComment, options?: RequestOptions): Promise<Comment> =>
+        issueComments.addComment(client, parameters, options),
+      getComment: (parameters: GetComment, options?: RequestOptions): Promise<Comment> =>
+        issueComments.getComment(client, parameters, options),
+      updateComment: (parameters: UpdateComment, options?: RequestOptions): Promise<Comment> =>
+        issueComments.updateComment(client, parameters, options),
+      deleteComment: (parameters: DeleteComment, options?: RequestOptions): Promise<void> =>
+        issueComments.deleteComment(client, parameters, options),
     },
     issueCommentProperties: {
-      getCommentPropertyKeys: (parameters: GetCommentPropertyKeys): Promise<PropertyKeys> =>
-        issueCommentProperties.getCommentPropertyKeys(client, parameters),
-      getCommentProperty: (parameters: GetCommentProperty): Promise<EntityProperty> =>
-        issueCommentProperties.getCommentProperty(client, parameters),
-      setCommentProperty: (parameters: SetCommentProperty): Promise<void> =>
-        issueCommentProperties.setCommentProperty(client, parameters),
-      deleteCommentProperty: (parameters: DeleteCommentProperty): Promise<void> =>
-        issueCommentProperties.deleteCommentProperty(client, parameters),
+      getCommentPropertyKeys: (parameters: GetCommentPropertyKeys, options?: RequestOptions): Promise<PropertyKeys> =>
+        issueCommentProperties.getCommentPropertyKeys(client, parameters, options),
+      getCommentProperty: (parameters: GetCommentProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        issueCommentProperties.getCommentProperty(client, parameters, options),
+      setCommentProperty: (parameters: SetCommentProperty, options?: RequestOptions): Promise<void> =>
+        issueCommentProperties.setCommentProperty(client, parameters, options),
+      deleteCommentProperty: (parameters: DeleteCommentProperty, options?: RequestOptions): Promise<void> =>
+        issueCommentProperties.deleteCommentProperty(client, parameters, options),
     },
     projectComponents: {
-      findComponentsForProjects: (parameters?: FindComponentsForProjects): Promise<Page<Component>> =>
-        projectComponents.findComponentsForProjects(client, parameters),
-      createComponent: (parameters: CreateComponent): Promise<ProjectComponent> =>
-        projectComponents.createComponent(client, parameters),
-      getComponent: (parameters: GetComponent): Promise<ProjectComponent> =>
-        projectComponents.getComponent(client, parameters),
-      updateComponent: (parameters: UpdateComponent): Promise<ProjectComponent> =>
-        projectComponents.updateComponent(client, parameters),
-      deleteComponent: (parameters: DeleteComponent): Promise<void> =>
-        projectComponents.deleteComponent(client, parameters),
-      getComponentRelatedIssues: (parameters: GetComponentRelatedIssues): Promise<ComponentIssuesCount> =>
-        projectComponents.getComponentRelatedIssues(client, parameters),
+      findComponentsForProjects: (
+        parameters?: FindComponentsForProjects,
+        options?: RequestOptions,
+      ): Promise<Page<Component>> => projectComponents.findComponentsForProjects(client, parameters, options),
+      createComponent: (parameters: CreateComponent, options?: RequestOptions): Promise<ProjectComponent> =>
+        projectComponents.createComponent(client, parameters, options),
+      getComponent: (parameters: GetComponent, options?: RequestOptions): Promise<ProjectComponent> =>
+        projectComponents.getComponent(client, parameters, options),
+      updateComponent: (parameters: UpdateComponent, options?: RequestOptions): Promise<ProjectComponent> =>
+        projectComponents.updateComponent(client, parameters, options),
+      deleteComponent: (parameters: DeleteComponent, options?: RequestOptions): Promise<void> =>
+        projectComponents.deleteComponent(client, parameters, options),
+      getComponentRelatedIssues: (
+        parameters: GetComponentRelatedIssues,
+        options?: RequestOptions,
+      ): Promise<ComponentIssuesCount> => projectComponents.getComponentRelatedIssues(client, parameters, options),
       getProjectComponentsPaginated: (
         parameters: GetProjectComponentsPaginated,
-      ): Promise<Page<ComponentWithIssueCount>> => projectComponents.getProjectComponentsPaginated(client, parameters),
-      getProjectComponents: (parameters: GetProjectComponents): Promise<ProjectComponent[]> =>
-        projectComponents.getProjectComponents(client, parameters),
+        options?: RequestOptions,
+      ): Promise<Page<ComponentWithIssueCount>> =>
+        projectComponents.getProjectComponentsPaginated(client, parameters, options),
+      getProjectComponents: (parameters: GetProjectComponents, options?: RequestOptions): Promise<ProjectComponent[]> =>
+        projectComponents.getProjectComponents(client, parameters, options),
     },
     timeTracking: {
-      getSelectedTimeTrackingImplementation: (): Promise<void> =>
-        timeTracking.getSelectedTimeTrackingImplementation(client),
-      selectTimeTrackingImplementation: (parameters: SelectTimeTrackingImplementation): Promise<void> =>
-        timeTracking.selectTimeTrackingImplementation(client, parameters),
-      getAvailableTimeTrackingImplementations: (): Promise<TimeTrackingProvider[]> =>
-        timeTracking.getAvailableTimeTrackingImplementations(client),
-      getSharedTimeTrackingConfiguration: (): Promise<TimeTrackingConfiguration> =>
-        timeTracking.getSharedTimeTrackingConfiguration(client),
+      getSelectedTimeTrackingImplementation: (options?: RequestOptions): Promise<void> =>
+        timeTracking.getSelectedTimeTrackingImplementation(client, options),
+      selectTimeTrackingImplementation: (
+        parameters: SelectTimeTrackingImplementation,
+        options?: RequestOptions,
+      ): Promise<void> => timeTracking.selectTimeTrackingImplementation(client, parameters, options),
+      getAvailableTimeTrackingImplementations: (options?: RequestOptions): Promise<TimeTrackingProvider[]> =>
+        timeTracking.getAvailableTimeTrackingImplementations(client, options),
+      getSharedTimeTrackingConfiguration: (options?: RequestOptions): Promise<TimeTrackingConfiguration> =>
+        timeTracking.getSharedTimeTrackingConfiguration(client, options),
       setSharedTimeTrackingConfiguration: (
         parameters: SetSharedTimeTrackingConfiguration,
-      ): Promise<TimeTrackingConfiguration> => timeTracking.setSharedTimeTrackingConfiguration(client, parameters),
+        options?: RequestOptions,
+      ): Promise<TimeTrackingConfiguration> =>
+        timeTracking.setSharedTimeTrackingConfiguration(client, parameters, options),
     },
     issueCustomFieldOptions: {
-      getCustomFieldOption: (parameters: GetCustomFieldOption): Promise<CustomFieldOption> =>
-        issueCustomFieldOptions.getCustomFieldOption(client, parameters),
-      getOptionsForContext: (parameters: GetOptionsForContext): Promise<Page<CustomFieldContextOption>> =>
-        issueCustomFieldOptions.getOptionsForContext(client, parameters),
-      createCustomFieldOption: (parameters: CreateCustomFieldOption): Promise<CustomFieldCreatedContextOptionsList> =>
-        issueCustomFieldOptions.createCustomFieldOption(client, parameters),
-      updateCustomFieldOption: (parameters: UpdateCustomFieldOption): Promise<CustomFieldUpdatedContextOptionsList> =>
-        issueCustomFieldOptions.updateCustomFieldOption(client, parameters),
-      reorderCustomFieldOptions: (parameters: ReorderCustomFieldOptions): Promise<void> =>
-        issueCustomFieldOptions.reorderCustomFieldOptions(client, parameters),
-      deleteCustomFieldOption: (parameters: DeleteCustomFieldOption): Promise<void> =>
-        issueCustomFieldOptions.deleteCustomFieldOption(client, parameters),
+      getCustomFieldOption: (parameters: GetCustomFieldOption, options?: RequestOptions): Promise<CustomFieldOption> =>
+        issueCustomFieldOptions.getCustomFieldOption(client, parameters, options),
+      getOptionsForContext: (
+        parameters: GetOptionsForContext,
+        options?: RequestOptions,
+      ): Promise<Page<CustomFieldContextOption>> =>
+        issueCustomFieldOptions.getOptionsForContext(client, parameters, options),
+      createCustomFieldOption: (
+        parameters: CreateCustomFieldOption,
+        options?: RequestOptions,
+      ): Promise<CustomFieldCreatedContextOptionsList> =>
+        issueCustomFieldOptions.createCustomFieldOption(client, parameters, options),
+      updateCustomFieldOption: (
+        parameters: UpdateCustomFieldOption,
+        options?: RequestOptions,
+      ): Promise<CustomFieldUpdatedContextOptionsList> =>
+        issueCustomFieldOptions.updateCustomFieldOption(client, parameters, options),
+      reorderCustomFieldOptions: (parameters: ReorderCustomFieldOptions, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldOptions.reorderCustomFieldOptions(client, parameters, options),
+      deleteCustomFieldOption: (parameters: DeleteCustomFieldOption, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldOptions.deleteCustomFieldOption(client, parameters, options),
       replaceCustomFieldOption: (
         parameters: ReplaceCustomFieldOption,
+        options?: RequestOptions,
       ): Promise<TaskProgressRemoveOptionFromIssuesResult> =>
-        issueCustomFieldOptions.replaceCustomFieldOption(client, parameters),
+        issueCustomFieldOptions.replaceCustomFieldOption(client, parameters, options),
     },
     dashboards: {
-      getAllDashboards: (parameters?: GetAllDashboards): Promise<PageOfDashboards> =>
-        dashboards.getAllDashboards(client, parameters),
-      getDashboardsPaginated: (parameters?: GetDashboardsPaginated): Promise<Page<Dashboard>> =>
-        dashboards.getDashboardsPaginated(client, parameters),
-      getDashboardItemPropertyKeys: (parameters: GetDashboardItemPropertyKeys): Promise<PropertyKeys> =>
-        dashboards.getDashboardItemPropertyKeys(client, parameters),
-      getDashboardItemProperty: (parameters: GetDashboardItemProperty): Promise<EntityProperty> =>
-        dashboards.getDashboardItemProperty(client, parameters),
-      setDashboardItemProperty: (parameters: SetDashboardItemProperty): Promise<void> =>
-        dashboards.setDashboardItemProperty(client, parameters),
-      deleteDashboardItemProperty: (parameters: DeleteDashboardItemProperty): Promise<void> =>
-        dashboards.deleteDashboardItemProperty(client, parameters),
-      getDashboard: (parameters: GetDashboard): Promise<Dashboard> => dashboards.getDashboard(client, parameters),
+      getAllDashboards: (parameters?: GetAllDashboards, options?: RequestOptions): Promise<PageOfDashboards> =>
+        dashboards.getAllDashboards(client, parameters, options),
+      getDashboardsPaginated: (
+        parameters?: GetDashboardsPaginated,
+        options?: RequestOptions,
+      ): Promise<Page<Dashboard>> => dashboards.getDashboardsPaginated(client, parameters, options),
+      getDashboardItemPropertyKeys: (
+        parameters: GetDashboardItemPropertyKeys,
+        options?: RequestOptions,
+      ): Promise<PropertyKeys> => dashboards.getDashboardItemPropertyKeys(client, parameters, options),
+      getDashboardItemProperty: (
+        parameters: GetDashboardItemProperty,
+        options?: RequestOptions,
+      ): Promise<EntityProperty> => dashboards.getDashboardItemProperty(client, parameters, options),
+      setDashboardItemProperty: (parameters: SetDashboardItemProperty, options?: RequestOptions): Promise<void> =>
+        dashboards.setDashboardItemProperty(client, parameters, options),
+      deleteDashboardItemProperty: (parameters: DeleteDashboardItemProperty, options?: RequestOptions): Promise<void> =>
+        dashboards.deleteDashboardItemProperty(client, parameters, options),
+      getDashboard: (parameters: GetDashboard, options?: RequestOptions): Promise<Dashboard> =>
+        dashboards.getDashboard(client, parameters, options),
     },
     appDataPolicies: {
-      getPolicy: (): Promise<WorkspaceDataPolicy> => appDataPolicies.getPolicy(client),
-      getPolicies: (parameters?: GetPolicies): Promise<ProjectDataPolicies> =>
-        appDataPolicies.getPolicies(client, parameters),
+      getPolicy: (options?: RequestOptions): Promise<WorkspaceDataPolicy> => appDataPolicies.getPolicy(client, options),
+      getPolicies: (parameters?: GetPolicies, options?: RequestOptions): Promise<ProjectDataPolicies> =>
+        appDataPolicies.getPolicies(client, parameters, options),
     },
     jiraExpressions: {
-      analyseExpression: (parameters: AnalyseExpression): Promise<JiraExpressionsAnalysis> =>
-        jiraExpressions.analyseExpression(client, parameters),
-      evaluateJSISJiraExpression: (parameters: EvaluateJSISJiraExpression): Promise<JExpEvaluateJiraExpressionResult> =>
-        jiraExpressions.evaluateJSISJiraExpression(client, parameters),
+      analyseExpression: (parameters: AnalyseExpression, options?: RequestOptions): Promise<JiraExpressionsAnalysis> =>
+        jiraExpressions.analyseExpression(client, parameters, options),
+      evaluateJSISJiraExpression: (
+        parameters: EvaluateJSISJiraExpression,
+        options?: RequestOptions,
+      ): Promise<JExpEvaluateJiraExpressionResult> =>
+        jiraExpressions.evaluateJSISJiraExpression(client, parameters, options),
     },
     issueFields: {
-      getFields: (): Promise<FieldDetails[]> => issueFields.getFields(client),
-      createCustomField: (parameters: CreateCustomField): Promise<FieldDetails> =>
-        issueFields.createCustomField(client, parameters),
-      getFieldsPaginated: (parameters?: GetFieldsPaginated): Promise<Page<Field>> =>
-        issueFields.getFieldsPaginated(client, parameters),
-      getTrashedFieldsPaginated: (parameters?: GetTrashedFieldsPaginated): Promise<Page<Field>> =>
-        issueFields.getTrashedFieldsPaginated(client, parameters),
-      updateCustomField: (parameters: UpdateCustomField): Promise<void> =>
-        issueFields.updateCustomField(client, parameters),
-      deleteCustomField: (parameters: DeleteCustomField): Promise<TaskProgressObject> =>
-        issueFields.deleteCustomField(client, parameters),
-      restoreCustomField: (parameters: RestoreCustomField): Promise<void> =>
-        issueFields.restoreCustomField(client, parameters),
-      trashCustomField: (parameters: TrashCustomField): Promise<void> =>
-        issueFields.trashCustomField(client, parameters),
+      getFields: (options?: RequestOptions): Promise<FieldDetails[]> => issueFields.getFields(client, options),
+      createCustomField: (parameters: CreateCustomField, options?: RequestOptions): Promise<FieldDetails> =>
+        issueFields.createCustomField(client, parameters, options),
+      getFieldsPaginated: (parameters?: GetFieldsPaginated, options?: RequestOptions): Promise<Page<Field>> =>
+        issueFields.getFieldsPaginated(client, parameters, options),
+      getTrashedFieldsPaginated: (
+        parameters?: GetTrashedFieldsPaginated,
+        options?: RequestOptions,
+      ): Promise<Page<Field>> => issueFields.getTrashedFieldsPaginated(client, parameters, options),
+      updateCustomField: (parameters: UpdateCustomField, options?: RequestOptions): Promise<void> =>
+        issueFields.updateCustomField(client, parameters, options),
+      deleteCustomField: (parameters: DeleteCustomField, options?: RequestOptions): Promise<TaskProgressObject> =>
+        issueFields.deleteCustomField(client, parameters, options),
+      restoreCustomField: (parameters: RestoreCustomField, options?: RequestOptions): Promise<void> =>
+        issueFields.restoreCustomField(client, parameters, options),
+      trashCustomField: (parameters: TrashCustomField, options?: RequestOptions): Promise<void> =>
+        issueFields.trashCustomField(client, parameters, options),
     },
     issueCustomFieldAssociations: {
-      createAssociations: (parameters: CreateAssociations): Promise<void> =>
-        issueCustomFieldAssociations.createAssociations(client, parameters),
-      removeAssociations: (parameters: RemoveAssociations): Promise<void> =>
-        issueCustomFieldAssociations.removeAssociations(client, parameters),
+      createAssociations: (parameters: CreateAssociations, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldAssociations.createAssociations(client, parameters, options),
+      removeAssociations: (parameters: RemoveAssociations, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldAssociations.removeAssociations(client, parameters, options),
     },
     issueCustomFieldContexts: {
-      getContextsForField: (parameters: GetContextsForField): Promise<Page<CustomFieldContext>> =>
-        issueCustomFieldContexts.getContextsForField(client, parameters),
-      createCustomFieldContext: (parameters: CreateCustomFieldContext): Promise<CreateCustomFieldContextModel> =>
-        issueCustomFieldContexts.createCustomFieldContext(client, parameters),
-      getContextDefaultValues: (parameters: GetContextDefaultValues): Promise<Page<ContextDefaultValues>> =>
-        issueCustomFieldContexts.getContextDefaultValues(client, parameters),
+      getContextsForField: (
+        parameters: GetContextsForField,
+        options?: RequestOptions,
+      ): Promise<Page<CustomFieldContext>> => issueCustomFieldContexts.getContextsForField(client, parameters, options),
+      createCustomFieldContext: (
+        parameters: CreateCustomFieldContext,
+        options?: RequestOptions,
+      ): Promise<CreateCustomFieldContextModel> =>
+        issueCustomFieldContexts.createCustomFieldContext(client, parameters, options),
+      getContextDefaultValues: (
+        parameters: GetContextDefaultValues,
+        options?: RequestOptions,
+      ): Promise<Page<ContextDefaultValues>> =>
+        issueCustomFieldContexts.getContextDefaultValues(client, parameters, options),
       getIssueTypeMappingsForContexts: (
         parameters: GetIssueTypeMappingsForContexts,
+        options?: RequestOptions,
       ): Promise<Page<IssueTypeToContextMapping>> =>
-        issueCustomFieldContexts.getIssueTypeMappingsForContexts(client, parameters),
+        issueCustomFieldContexts.getIssueTypeMappingsForContexts(client, parameters, options),
       getCustomFieldContextsForProjectsAndIssueTypes: (
         parameters: GetCustomFieldContextsForProjectsAndIssueTypes,
+        options?: RequestOptions,
       ): Promise<Page<ContextForProjectAndIssueType>> =>
-        issueCustomFieldContexts.getCustomFieldContextsForProjectsAndIssueTypes(client, parameters),
+        issueCustomFieldContexts.getCustomFieldContextsForProjectsAndIssueTypes(client, parameters, options),
       getProjectContextMapping: (
         parameters: GetProjectContextMapping,
+        options?: RequestOptions,
       ): Promise<Page<CustomFieldContextProjectMapping>> =>
-        issueCustomFieldContexts.getProjectContextMapping(client, parameters),
-      updateCustomFieldContext: (parameters: UpdateCustomFieldContext): Promise<void> =>
-        issueCustomFieldContexts.updateCustomFieldContext(client, parameters),
-      deleteCustomFieldContext: (parameters: DeleteCustomFieldContext): Promise<void> =>
-        issueCustomFieldContexts.deleteCustomFieldContext(client, parameters),
-      addIssueTypesToContext: (parameters: AddIssueTypesToContext): Promise<void> =>
-        issueCustomFieldContexts.addIssueTypesToContext(client, parameters),
-      removeIssueTypesFromContext: (parameters: RemoveIssueTypesFromContext): Promise<void> =>
-        issueCustomFieldContexts.removeIssueTypesFromContext(client, parameters),
-      assignProjectsToCustomFieldContext: (parameters: AssignProjectsToCustomFieldContext): Promise<void> =>
-        issueCustomFieldContexts.assignProjectsToCustomFieldContext(client, parameters),
-      removeCustomFieldContextFromProjects: (parameters: RemoveCustomFieldContextFromProjects): Promise<void> =>
-        issueCustomFieldContexts.removeCustomFieldContextFromProjects(client, parameters),
+        issueCustomFieldContexts.getProjectContextMapping(client, parameters, options),
+      updateCustomFieldContext: (parameters: UpdateCustomFieldContext, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldContexts.updateCustomFieldContext(client, parameters, options),
+      deleteCustomFieldContext: (parameters: DeleteCustomFieldContext, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldContexts.deleteCustomFieldContext(client, parameters, options),
+      addIssueTypesToContext: (parameters: AddIssueTypesToContext, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldContexts.addIssueTypesToContext(client, parameters, options),
+      removeIssueTypesFromContext: (parameters: RemoveIssueTypesFromContext, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldContexts.removeIssueTypesFromContext(client, parameters, options),
+      assignProjectsToCustomFieldContext: (
+        parameters: AssignProjectsToCustomFieldContext,
+        options?: RequestOptions,
+      ): Promise<void> => issueCustomFieldContexts.assignProjectsToCustomFieldContext(client, parameters, options),
+      removeCustomFieldContextFromProjects: (
+        parameters: RemoveCustomFieldContextFromProjects,
+        options?: RequestOptions,
+      ): Promise<void> => issueCustomFieldContexts.removeCustomFieldContextFromProjects(client, parameters, options),
     },
     screens: {
-      getScreensForField: (parameters: GetScreensForField): Promise<Page<ScreenWithTab>> =>
-        screens.getScreensForField(client, parameters),
-      getScreens: (parameters?: GetScreens): Promise<Page<Screen>> => screens.getScreens(client, parameters),
-      addFieldToDefaultScreen: (parameters: AddFieldToDefaultScreen): Promise<void> =>
-        screens.addFieldToDefaultScreen(client, parameters),
-      getAvailableScreenFields: (parameters: GetAvailableScreenFields): Promise<ScreenableField[]> =>
-        screens.getAvailableScreenFields(client, parameters),
+      getScreensForField: (parameters: GetScreensForField, options?: RequestOptions): Promise<Page<ScreenWithTab>> =>
+        screens.getScreensForField(client, parameters, options),
+      getScreens: (parameters?: GetScreens, options?: RequestOptions): Promise<Page<Screen>> =>
+        screens.getScreens(client, parameters, options),
+      addFieldToDefaultScreen: (parameters: AddFieldToDefaultScreen, options?: RequestOptions): Promise<void> =>
+        screens.addFieldToDefaultScreen(client, parameters, options),
+      getAvailableScreenFields: (
+        parameters: GetAvailableScreenFields,
+        options?: RequestOptions,
+      ): Promise<ScreenableField[]> => screens.getAvailableScreenFields(client, parameters, options),
     },
     issueCustomFieldOptionsApps: {
-      getAllIssueFieldOptions: (parameters: GetAllIssueFieldOptions): Promise<Page<IssueFieldOption>> =>
-        issueCustomFieldOptionsApps.getAllIssueFieldOptions(client, parameters),
-      createIssueFieldOption: (parameters: CreateIssueFieldOption): Promise<IssueFieldOption> =>
-        issueCustomFieldOptionsApps.createIssueFieldOption(client, parameters),
-      getSelectableIssueFieldOptions: (parameters: GetSelectableIssueFieldOptions): Promise<Page<IssueFieldOption>> =>
-        issueCustomFieldOptionsApps.getSelectableIssueFieldOptions(client, parameters),
-      getVisibleIssueFieldOptions: (parameters: GetVisibleIssueFieldOptions): Promise<Page<IssueFieldOption>> =>
-        issueCustomFieldOptionsApps.getVisibleIssueFieldOptions(client, parameters),
-      getIssueFieldOption: (parameters: GetIssueFieldOption): Promise<IssueFieldOption> =>
-        issueCustomFieldOptionsApps.getIssueFieldOption(client, parameters),
-      updateIssueFieldOption: (parameters: UpdateIssueFieldOption): Promise<IssueFieldOption> =>
-        issueCustomFieldOptionsApps.updateIssueFieldOption(client, parameters),
-      deleteIssueFieldOption: (parameters: DeleteIssueFieldOption): Promise<void> =>
-        issueCustomFieldOptionsApps.deleteIssueFieldOption(client, parameters),
+      getAllIssueFieldOptions: (
+        parameters: GetAllIssueFieldOptions,
+        options?: RequestOptions,
+      ): Promise<Page<IssueFieldOption>> =>
+        issueCustomFieldOptionsApps.getAllIssueFieldOptions(client, parameters, options),
+      createIssueFieldOption: (
+        parameters: CreateIssueFieldOption,
+        options?: RequestOptions,
+      ): Promise<IssueFieldOption> => issueCustomFieldOptionsApps.createIssueFieldOption(client, parameters, options),
+      getSelectableIssueFieldOptions: (
+        parameters: GetSelectableIssueFieldOptions,
+        options?: RequestOptions,
+      ): Promise<Page<IssueFieldOption>> =>
+        issueCustomFieldOptionsApps.getSelectableIssueFieldOptions(client, parameters, options),
+      getVisibleIssueFieldOptions: (
+        parameters: GetVisibleIssueFieldOptions,
+        options?: RequestOptions,
+      ): Promise<Page<IssueFieldOption>> =>
+        issueCustomFieldOptionsApps.getVisibleIssueFieldOptions(client, parameters, options),
+      getIssueFieldOption: (parameters: GetIssueFieldOption, options?: RequestOptions): Promise<IssueFieldOption> =>
+        issueCustomFieldOptionsApps.getIssueFieldOption(client, parameters, options),
+      updateIssueFieldOption: (
+        parameters: UpdateIssueFieldOption,
+        options?: RequestOptions,
+      ): Promise<IssueFieldOption> => issueCustomFieldOptionsApps.updateIssueFieldOption(client, parameters, options),
+      deleteIssueFieldOption: (parameters: DeleteIssueFieldOption, options?: RequestOptions): Promise<void> =>
+        issueCustomFieldOptionsApps.deleteIssueFieldOption(client, parameters, options),
       replaceIssueFieldOption: (
         parameters: ReplaceIssueFieldOption,
+        options?: RequestOptions,
       ): Promise<TaskProgressRemoveOptionFromIssuesResult> =>
-        issueCustomFieldOptionsApps.replaceIssueFieldOption(client, parameters),
+        issueCustomFieldOptionsApps.replaceIssueFieldOption(client, parameters, options),
     },
     filters: {
-      createFilter: (parameters: CreateFilter): Promise<Filter> => filters.createFilter(client, parameters),
-      getFavouriteFilters: (parameters?: GetFavouriteFilters): Promise<Filter[]> =>
-        filters.getFavouriteFilters(client, parameters),
-      getMyFilters: (parameters?: GetMyFilters): Promise<Filter[]> => filters.getMyFilters(client, parameters),
-      getFiltersPaginated: (parameters?: GetFiltersPaginated): Promise<Page<FilterDetails>> =>
-        filters.getFiltersPaginated(client, parameters),
-      getFilter: (parameters: GetFilter): Promise<Filter> => filters.getFilter(client, parameters),
-      updateFilter: (parameters: UpdateFilter): Promise<Filter> => filters.updateFilter(client, parameters),
-      deleteFilter: (parameters: DeleteFilter): Promise<void> => filters.deleteFilter(client, parameters),
-      getColumns: (parameters: GetColumns): Promise<ColumnItem[]> => filters.getColumns(client, parameters),
-      setColumns: (parameters: SetColumns): Promise<void> => filters.setColumns(client, parameters),
-      resetColumns: (parameters: ResetColumns): Promise<void> => filters.resetColumns(client, parameters),
-      setFavouriteForFilter: (parameters: SetFavouriteForFilter): Promise<Filter> =>
-        filters.setFavouriteForFilter(client, parameters),
-      deleteFavouriteForFilter: (parameters: DeleteFavouriteForFilter): Promise<Filter> =>
-        filters.deleteFavouriteForFilter(client, parameters),
+      createFilter: (parameters: CreateFilter, options?: RequestOptions): Promise<Filter> =>
+        filters.createFilter(client, parameters, options),
+      getFavouriteFilters: (parameters?: GetFavouriteFilters, options?: RequestOptions): Promise<Filter[]> =>
+        filters.getFavouriteFilters(client, parameters, options),
+      getMyFilters: (parameters?: GetMyFilters, options?: RequestOptions): Promise<Filter[]> =>
+        filters.getMyFilters(client, parameters, options),
+      getFiltersPaginated: (parameters?: GetFiltersPaginated, options?: RequestOptions): Promise<Page<FilterDetails>> =>
+        filters.getFiltersPaginated(client, parameters, options),
+      getFilter: (parameters: GetFilter, options?: RequestOptions): Promise<Filter> =>
+        filters.getFilter(client, parameters, options),
+      updateFilter: (parameters: UpdateFilter, options?: RequestOptions): Promise<Filter> =>
+        filters.updateFilter(client, parameters, options),
+      deleteFilter: (parameters: DeleteFilter, options?: RequestOptions): Promise<void> =>
+        filters.deleteFilter(client, parameters, options),
+      getColumns: (parameters: GetColumns, options?: RequestOptions): Promise<ColumnItem[]> =>
+        filters.getColumns(client, parameters, options),
+      setColumns: (parameters: SetColumns, options?: RequestOptions): Promise<void> =>
+        filters.setColumns(client, parameters, options),
+      resetColumns: (parameters: ResetColumns, options?: RequestOptions): Promise<void> =>
+        filters.resetColumns(client, parameters, options),
+      setFavouriteForFilter: (parameters: SetFavouriteForFilter, options?: RequestOptions): Promise<Filter> =>
+        filters.setFavouriteForFilter(client, parameters, options),
+      deleteFavouriteForFilter: (parameters: DeleteFavouriteForFilter, options?: RequestOptions): Promise<Filter> =>
+        filters.deleteFavouriteForFilter(client, parameters, options),
     },
     filterSharing: {
-      getDefaultShareScope: (): Promise<DefaultShareScope> => filterSharing.getDefaultShareScope(client),
-      setDefaultShareScope: (parameters: SetDefaultShareScope): Promise<DefaultShareScope> =>
-        filterSharing.setDefaultShareScope(client, parameters),
-      getSharePermissions: (parameters: GetSharePermissions): Promise<SharePermission[]> =>
-        filterSharing.getSharePermissions(client, parameters),
-      addSharePermission: (parameters: AddSharePermission): Promise<SharePermission[]> =>
-        filterSharing.addSharePermission(client, parameters),
-      getSharePermission: (parameters: GetSharePermission): Promise<SharePermission> =>
-        filterSharing.getSharePermission(client, parameters),
-      deleteSharePermission: (parameters: DeleteSharePermission): Promise<void> =>
-        filterSharing.deleteSharePermission(client, parameters),
+      getDefaultShareScope: (options?: RequestOptions): Promise<DefaultShareScope> =>
+        filterSharing.getDefaultShareScope(client, options),
+      setDefaultShareScope: (parameters: SetDefaultShareScope, options?: RequestOptions): Promise<DefaultShareScope> =>
+        filterSharing.setDefaultShareScope(client, parameters, options),
+      getSharePermissions: (parameters: GetSharePermissions, options?: RequestOptions): Promise<SharePermission[]> =>
+        filterSharing.getSharePermissions(client, parameters, options),
+      addSharePermission: (parameters: AddSharePermission, options?: RequestOptions): Promise<SharePermission[]> =>
+        filterSharing.addSharePermission(client, parameters, options),
+      getSharePermission: (parameters: GetSharePermission, options?: RequestOptions): Promise<SharePermission> =>
+        filterSharing.getSharePermission(client, parameters, options),
+      deleteSharePermission: (parameters: DeleteSharePermission, options?: RequestOptions): Promise<void> =>
+        filterSharing.deleteSharePermission(client, parameters, options),
     },
     issuePanels: {
-      bulkPinUnpinProjectsAsync: (parameters: BulkPinUnpinProjectsAsync): Promise<ForgePanelProjectPinAsyncResponse> =>
-        issuePanels.bulkPinUnpinProjectsAsync(client, parameters),
+      bulkPinUnpinProjectsAsync: (
+        parameters: BulkPinUnpinProjectsAsync,
+        options?: RequestOptions,
+      ): Promise<ForgePanelProjectPinAsyncResponse> =>
+        issuePanels.bulkPinUnpinProjectsAsync(client, parameters, options),
     },
     groups: {
-      createGroup: (parameters: CreateGroup): Promise<Group> => groups.createGroup(client, parameters),
-      removeGroup: (parameters: RemoveGroup): Promise<void> => groups.removeGroup(client, parameters),
-      getUsersFromGroup: (parameters?: GetUsersFromGroup): Promise<Page<UserDetails>> =>
-        groups.getUsersFromGroup(client, parameters),
-      addUserToGroup: (parameters: AddUserToGroup): Promise<Group> => groups.addUserToGroup(client, parameters),
-      removeUserFromGroup: (parameters: RemoveUserFromGroup): Promise<void> =>
-        groups.removeUserFromGroup(client, parameters),
-      findGroups: (parameters?: FindGroups): Promise<FoundGroups> => groups.findGroups(client, parameters),
+      createGroup: (parameters: CreateGroup, options?: RequestOptions): Promise<Group> =>
+        groups.createGroup(client, parameters, options),
+      removeGroup: (parameters: RemoveGroup, options?: RequestOptions): Promise<void> =>
+        groups.removeGroup(client, parameters, options),
+      getUsersFromGroup: (parameters?: GetUsersFromGroup, options?: RequestOptions): Promise<Page<UserDetails>> =>
+        groups.getUsersFromGroup(client, parameters, options),
+      addUserToGroup: (parameters: AddUserToGroup, options?: RequestOptions): Promise<Group> =>
+        groups.addUserToGroup(client, parameters, options),
+      removeUserFromGroup: (parameters: RemoveUserFromGroup, options?: RequestOptions): Promise<void> =>
+        groups.removeUserFromGroup(client, parameters, options),
+      findGroups: (parameters?: FindGroups, options?: RequestOptions): Promise<FoundGroups> =>
+        groups.findGroups(client, parameters, options),
     },
     groupAndUserPicker: {
-      findUsersAndGroups: (parameters: FindUsersAndGroups): Promise<FoundUsersAndGroups> =>
-        groupAndUserPicker.findUsersAndGroups(client, parameters),
+      findUsersAndGroups: (parameters: FindUsersAndGroups, options?: RequestOptions): Promise<FoundUsersAndGroups> =>
+        groupAndUserPicker.findUsersAndGroups(client, parameters, options),
     },
     issueSearch: {
-      getIssuePickerResource: (parameters?: GetIssuePickerResource): Promise<IssuePickerSuggestions> =>
-        issueSearch.getIssuePickerResource(client, parameters),
-      matchIssues: (parameters: MatchIssues): Promise<IssueMatches> => issueSearch.matchIssues(client, parameters),
-      countIssues: (parameters: CountIssues): Promise<JQLCountResults> => issueSearch.countIssues(client, parameters),
+      getIssuePickerResource: (
+        parameters?: GetIssuePickerResource,
+        options?: RequestOptions,
+      ): Promise<IssuePickerSuggestions> => issueSearch.getIssuePickerResource(client, parameters, options),
+      matchIssues: (parameters: MatchIssues, options?: RequestOptions): Promise<IssueMatches> =>
+        issueSearch.matchIssues(client, parameters, options),
+      countIssues: (parameters: CountIssues, options?: RequestOptions): Promise<JQLCountResults> =>
+        issueSearch.countIssues(client, parameters, options),
       searchAndReconsileIssuesUsingJql: (
         parameters?: SearchAndReconsileIssuesUsingJql,
-      ): Promise<SearchAndReconcileResults> => issueSearch.searchAndReconsileIssuesUsingJql(client, parameters),
+        options?: RequestOptions,
+      ): Promise<SearchAndReconcileResults> =>
+        issueSearch.searchAndReconsileIssuesUsingJql(client, parameters, options),
       searchAndReconsileIssuesUsingJqlPost: (
         parameters: SearchAndReconsileIssuesUsingJqlPost,
-      ): Promise<SearchAndReconcileResults> => issueSearch.searchAndReconsileIssuesUsingJqlPost(client, parameters),
+        options?: RequestOptions,
+      ): Promise<SearchAndReconcileResults> =>
+        issueSearch.searchAndReconsileIssuesUsingJqlPost(client, parameters, options),
     },
     issueProperties: {
-      bulkSetIssuesPropertiesList: (parameters: BulkSetIssuesPropertiesList): Promise<void> =>
-        issueProperties.bulkSetIssuesPropertiesList(client, parameters),
-      bulkSetIssuePropertiesByIssue: (parameters: BulkSetIssuePropertiesByIssue): Promise<void> =>
-        issueProperties.bulkSetIssuePropertiesByIssue(client, parameters),
-      bulkSetIssueProperty: (parameters: BulkSetIssueProperty): Promise<void> =>
-        issueProperties.bulkSetIssueProperty(client, parameters),
-      bulkDeleteIssueProperty: (parameters: BulkDeleteIssueProperty): Promise<void> =>
-        issueProperties.bulkDeleteIssueProperty(client, parameters),
-      getIssuePropertyKeys: (parameters: GetIssuePropertyKeys): Promise<PropertyKeys> =>
-        issueProperties.getIssuePropertyKeys(client, parameters),
-      getIssueProperty: (parameters: GetIssueProperty): Promise<EntityProperty> =>
-        issueProperties.getIssueProperty(client, parameters),
-      setIssueProperty: (parameters: SetIssueProperty): Promise<void> =>
-        issueProperties.setIssueProperty(client, parameters),
-      deleteIssueProperty: (parameters: DeleteIssueProperty): Promise<void> =>
-        issueProperties.deleteIssueProperty(client, parameters),
+      bulkSetIssuesPropertiesList: (parameters: BulkSetIssuesPropertiesList, options?: RequestOptions): Promise<void> =>
+        issueProperties.bulkSetIssuesPropertiesList(client, parameters, options),
+      bulkSetIssuePropertiesByIssue: (
+        parameters: BulkSetIssuePropertiesByIssue,
+        options?: RequestOptions,
+      ): Promise<void> => issueProperties.bulkSetIssuePropertiesByIssue(client, parameters, options),
+      bulkSetIssueProperty: (parameters: BulkSetIssueProperty, options?: RequestOptions): Promise<void> =>
+        issueProperties.bulkSetIssueProperty(client, parameters, options),
+      bulkDeleteIssueProperty: (parameters: BulkDeleteIssueProperty, options?: RequestOptions): Promise<void> =>
+        issueProperties.bulkDeleteIssueProperty(client, parameters, options),
+      getIssuePropertyKeys: (parameters: GetIssuePropertyKeys, options?: RequestOptions): Promise<PropertyKeys> =>
+        issueProperties.getIssuePropertyKeys(client, parameters, options),
+      getIssueProperty: (parameters: GetIssueProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        issueProperties.getIssueProperty(client, parameters, options),
+      setIssueProperty: (parameters: SetIssueProperty, options?: RequestOptions): Promise<void> =>
+        issueProperties.setIssueProperty(client, parameters, options),
+      deleteIssueProperty: (parameters: DeleteIssueProperty, options?: RequestOptions): Promise<void> =>
+        issueProperties.deleteIssueProperty(client, parameters, options),
     },
     issueWatchers: {
-      getIsWatchingIssueBulk: (parameters: GetIsWatchingIssueBulk): Promise<BulkIssueIsWatching> =>
-        issueWatchers.getIsWatchingIssueBulk(client, parameters),
-      getIssueWatchers: (parameters: GetIssueWatchers): Promise<Watchers> =>
-        issueWatchers.getIssueWatchers(client, parameters),
-      addWatcher: (parameters: AddWatcher): Promise<void> => issueWatchers.addWatcher(client, parameters),
-      removeWatcher: (parameters: RemoveWatcher): Promise<void> => issueWatchers.removeWatcher(client, parameters),
+      getIsWatchingIssueBulk: (
+        parameters: GetIsWatchingIssueBulk,
+        options?: RequestOptions,
+      ): Promise<BulkIssueIsWatching> => issueWatchers.getIsWatchingIssueBulk(client, parameters, options),
+      getIssueWatchers: (parameters: GetIssueWatchers, options?: RequestOptions): Promise<Watchers> =>
+        issueWatchers.getIssueWatchers(client, parameters, options),
+      addWatcher: (parameters: AddWatcher, options?: RequestOptions): Promise<void> =>
+        issueWatchers.addWatcher(client, parameters, options),
+      removeWatcher: (parameters: RemoveWatcher, options?: RequestOptions): Promise<void> =>
+        issueWatchers.removeWatcher(client, parameters, options),
     },
     issueRemoteLinks: {
-      getRemoteIssueLinks: (parameters: GetRemoteIssueLinks): Promise<GetRemoteIssueLinksModel> =>
-        issueRemoteLinks.getRemoteIssueLinks(client, parameters),
-      createOrUpdateRemoteIssueLink: (parameters: CreateOrUpdateRemoteIssueLink): Promise<RemoteIssueLinkIdentifies> =>
-        issueRemoteLinks.createOrUpdateRemoteIssueLink(client, parameters),
-      deleteRemoteIssueLinkByGlobalId: (parameters: DeleteRemoteIssueLinkByGlobalId): Promise<void> =>
-        issueRemoteLinks.deleteRemoteIssueLinkByGlobalId(client, parameters),
-      getRemoteIssueLinkById: (parameters: GetRemoteIssueLinkById): Promise<RemoteIssueLink> =>
-        issueRemoteLinks.getRemoteIssueLinkById(client, parameters),
-      updateRemoteIssueLink: (parameters: UpdateRemoteIssueLink): Promise<void> =>
-        issueRemoteLinks.updateRemoteIssueLink(client, parameters),
-      deleteRemoteIssueLinkById: (parameters: DeleteRemoteIssueLinkById): Promise<void> =>
-        issueRemoteLinks.deleteRemoteIssueLinkById(client, parameters),
+      getRemoteIssueLinks: (
+        parameters: GetRemoteIssueLinks,
+        options?: RequestOptions,
+      ): Promise<GetRemoteIssueLinksModel> => issueRemoteLinks.getRemoteIssueLinks(client, parameters, options),
+      createOrUpdateRemoteIssueLink: (
+        parameters: CreateOrUpdateRemoteIssueLink,
+        options?: RequestOptions,
+      ): Promise<RemoteIssueLinkIdentifies> =>
+        issueRemoteLinks.createOrUpdateRemoteIssueLink(client, parameters, options),
+      deleteRemoteIssueLinkByGlobalId: (
+        parameters: DeleteRemoteIssueLinkByGlobalId,
+        options?: RequestOptions,
+      ): Promise<void> => issueRemoteLinks.deleteRemoteIssueLinkByGlobalId(client, parameters, options),
+      getRemoteIssueLinkById: (
+        parameters: GetRemoteIssueLinkById,
+        options?: RequestOptions,
+      ): Promise<RemoteIssueLink> => issueRemoteLinks.getRemoteIssueLinkById(client, parameters, options),
+      updateRemoteIssueLink: (parameters: UpdateRemoteIssueLink, options?: RequestOptions): Promise<void> =>
+        issueRemoteLinks.updateRemoteIssueLink(client, parameters, options),
+      deleteRemoteIssueLinkById: (parameters: DeleteRemoteIssueLinkById, options?: RequestOptions): Promise<void> =>
+        issueRemoteLinks.deleteRemoteIssueLinkById(client, parameters, options),
     },
     issueVotes: {
-      getVotes: (parameters: GetVotes): Promise<Votes> => issueVotes.getVotes(client, parameters),
-      addVote: (parameters: AddVote): Promise<void> => issueVotes.addVote(client, parameters),
-      removeVote: (parameters: RemoveVote): Promise<void> => issueVotes.removeVote(client, parameters),
+      getVotes: (parameters: GetVotes, options?: RequestOptions): Promise<Votes> =>
+        issueVotes.getVotes(client, parameters, options),
+      addVote: (parameters: AddVote, options?: RequestOptions): Promise<void> =>
+        issueVotes.addVote(client, parameters, options),
+      removeVote: (parameters: RemoveVote, options?: RequestOptions): Promise<void> =>
+        issueVotes.removeVote(client, parameters, options),
     },
     issueWorklogs: {
-      getIssueWorklog: (parameters: GetIssueWorklog): Promise<PageOfWorklogs> =>
-        issueWorklogs.getIssueWorklog(client, parameters),
-      addWorklog: (parameters: AddWorklog): Promise<Worklog> => issueWorklogs.addWorklog(client, parameters),
-      getWorklog: (parameters: GetWorklog): Promise<Worklog> => issueWorklogs.getWorklog(client, parameters),
-      updateWorklog: (parameters: UpdateWorklog): Promise<Worklog> => issueWorklogs.updateWorklog(client, parameters),
-      deleteWorklog: (parameters: DeleteWorklog): Promise<void> => issueWorklogs.deleteWorklog(client, parameters),
-      getIdsOfWorklogsDeletedSince: (parameters?: GetIdsOfWorklogsDeletedSince): Promise<ChangedWorklogs> =>
-        issueWorklogs.getIdsOfWorklogsDeletedSince(client, parameters),
-      getWorklogsForIds: (parameters: GetWorklogsForIds): Promise<Worklog[]> =>
-        issueWorklogs.getWorklogsForIds(client, parameters),
-      getIdsOfWorklogsModifiedSince: (parameters?: GetIdsOfWorklogsModifiedSince): Promise<ChangedWorklogs> =>
-        issueWorklogs.getIdsOfWorklogsModifiedSince(client, parameters),
+      getIssueWorklog: (parameters: GetIssueWorklog, options?: RequestOptions): Promise<PageOfWorklogs> =>
+        issueWorklogs.getIssueWorklog(client, parameters, options),
+      addWorklog: (parameters: AddWorklog, options?: RequestOptions): Promise<Worklog> =>
+        issueWorklogs.addWorklog(client, parameters, options),
+      getWorklog: (parameters: GetWorklog, options?: RequestOptions): Promise<Worklog> =>
+        issueWorklogs.getWorklog(client, parameters, options),
+      updateWorklog: (parameters: UpdateWorklog, options?: RequestOptions): Promise<Worklog> =>
+        issueWorklogs.updateWorklog(client, parameters, options),
+      deleteWorklog: (parameters: DeleteWorklog, options?: RequestOptions): Promise<void> =>
+        issueWorklogs.deleteWorklog(client, parameters, options),
+      getIdsOfWorklogsDeletedSince: (
+        parameters?: GetIdsOfWorklogsDeletedSince,
+        options?: RequestOptions,
+      ): Promise<ChangedWorklogs> => issueWorklogs.getIdsOfWorklogsDeletedSince(client, parameters, options),
+      getWorklogsForIds: (parameters: GetWorklogsForIds, options?: RequestOptions): Promise<Worklog[]> =>
+        issueWorklogs.getWorklogsForIds(client, parameters, options),
+      getIdsOfWorklogsModifiedSince: (
+        parameters?: GetIdsOfWorklogsModifiedSince,
+        options?: RequestOptions,
+      ): Promise<ChangedWorklogs> => issueWorklogs.getIdsOfWorklogsModifiedSince(client, parameters, options),
     },
     issueWorklogProperties: {
-      getWorklogPropertyKeys: (parameters: GetWorklogPropertyKeys): Promise<PropertyKeys> =>
-        issueWorklogProperties.getWorklogPropertyKeys(client, parameters),
-      getWorklogProperty: (parameters: GetWorklogProperty): Promise<EntityProperty> =>
-        issueWorklogProperties.getWorklogProperty(client, parameters),
-      setWorklogProperty: (parameters: SetWorklogProperty): Promise<void> =>
-        issueWorklogProperties.setWorklogProperty(client, parameters),
-      deleteWorklogProperty: (parameters: DeleteWorklogProperty): Promise<void> =>
-        issueWorklogProperties.deleteWorklogProperty(client, parameters),
+      getWorklogPropertyKeys: (parameters: GetWorklogPropertyKeys, options?: RequestOptions): Promise<PropertyKeys> =>
+        issueWorklogProperties.getWorklogPropertyKeys(client, parameters, options),
+      getWorklogProperty: (parameters: GetWorklogProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        issueWorklogProperties.getWorklogProperty(client, parameters, options),
+      setWorklogProperty: (parameters: SetWorklogProperty, options?: RequestOptions): Promise<void> =>
+        issueWorklogProperties.setWorklogProperty(client, parameters, options),
+      deleteWorklogProperty: (parameters: DeleteWorklogProperty, options?: RequestOptions): Promise<void> =>
+        issueWorklogProperties.deleteWorklogProperty(client, parameters, options),
     },
     issueLinks: {
-      linkIssues: (parameters: LinkIssues): Promise<void> => issueLinks.linkIssues(client, parameters),
-      getIssueLink: (parameters: GetIssueLink): Promise<IssueLink> => issueLinks.getIssueLink(client, parameters),
-      deleteIssueLink: (parameters: DeleteIssueLink): Promise<void> => issueLinks.deleteIssueLink(client, parameters),
+      linkIssues: (parameters: LinkIssues, options?: RequestOptions): Promise<void> =>
+        issueLinks.linkIssues(client, parameters, options),
+      getIssueLink: (parameters: GetIssueLink, options?: RequestOptions): Promise<IssueLink> =>
+        issueLinks.getIssueLink(client, parameters, options),
+      deleteIssueLink: (parameters: DeleteIssueLink, options?: RequestOptions): Promise<void> =>
+        issueLinks.deleteIssueLink(client, parameters, options),
     },
     issueLinkTypes: {
-      getIssueLinkTypes: (): Promise<IssueLinkTypes> => issueLinkTypes.getIssueLinkTypes(client),
-      createIssueLinkType: (parameters: CreateIssueLinkType): Promise<IssueLinkType> =>
-        issueLinkTypes.createIssueLinkType(client, parameters),
-      getIssueLinkType: (parameters: GetIssueLinkType): Promise<IssueLinkType> =>
-        issueLinkTypes.getIssueLinkType(client, parameters),
-      updateIssueLinkType: (parameters: UpdateIssueLinkType): Promise<IssueLinkType> =>
-        issueLinkTypes.updateIssueLinkType(client, parameters),
-      deleteIssueLinkType: (parameters: DeleteIssueLinkType): Promise<void> =>
-        issueLinkTypes.deleteIssueLinkType(client, parameters),
+      getIssueLinkTypes: (options?: RequestOptions): Promise<IssueLinkTypes> =>
+        issueLinkTypes.getIssueLinkTypes(client, options),
+      createIssueLinkType: (parameters: CreateIssueLinkType, options?: RequestOptions): Promise<IssueLinkType> =>
+        issueLinkTypes.createIssueLinkType(client, parameters, options),
+      getIssueLinkType: (parameters: GetIssueLinkType, options?: RequestOptions): Promise<IssueLinkType> =>
+        issueLinkTypes.getIssueLinkType(client, parameters, options),
+      updateIssueLinkType: (parameters: UpdateIssueLinkType, options?: RequestOptions): Promise<IssueLinkType> =>
+        issueLinkTypes.updateIssueLinkType(client, parameters, options),
+      deleteIssueLinkType: (parameters: DeleteIssueLinkType, options?: RequestOptions): Promise<void> =>
+        issueLinkTypes.deleteIssueLinkType(client, parameters, options),
     },
     issueSecuritySchemes: {
-      getIssueSecuritySchemes: (): Promise<SecuritySchemes> => issueSecuritySchemes.getIssueSecuritySchemes(client),
-      getIssueSecurityScheme: (parameters: GetIssueSecurityScheme): Promise<SecurityScheme> =>
-        issueSecuritySchemes.getIssueSecurityScheme(client, parameters),
+      getIssueSecuritySchemes: (options?: RequestOptions): Promise<SecuritySchemes> =>
+        issueSecuritySchemes.getIssueSecuritySchemes(client, options),
+      getIssueSecurityScheme: (parameters: GetIssueSecurityScheme, options?: RequestOptions): Promise<SecurityScheme> =>
+        issueSecuritySchemes.getIssueSecurityScheme(client, parameters, options),
     },
     issueSecurityLevel: {
       getIssueSecurityLevelMembers: (
         parameters: GetIssueSecurityLevelMembers,
-      ): Promise<Page<IssueSecurityLevelMember>> => issueSecurityLevel.getIssueSecurityLevelMembers(client, parameters),
-      getIssueSecurityLevel: (parameters: GetIssueSecurityLevel): Promise<SecurityLevel> =>
-        issueSecurityLevel.getIssueSecurityLevel(client, parameters),
+        options?: RequestOptions,
+      ): Promise<Page<IssueSecurityLevelMember>> =>
+        issueSecurityLevel.getIssueSecurityLevelMembers(client, parameters, options),
+      getIssueSecurityLevel: (parameters: GetIssueSecurityLevel, options?: RequestOptions): Promise<SecurityLevel> =>
+        issueSecurityLevel.getIssueSecurityLevel(client, parameters, options),
     },
     issueTypes: {
-      getIssueAllTypes: (): Promise<IssueTypeDetails[]> => issueTypes.getIssueAllTypes(client),
-      createIssueType: (parameters: CreateIssueType): Promise<IssueTypeDetails> =>
-        issueTypes.createIssueType(client, parameters),
-      getIssueType: (parameters: GetIssueType): Promise<IssueTypeDetails> =>
-        issueTypes.getIssueType(client, parameters),
-      updateIssueType: (parameters: UpdateIssueType): Promise<IssueTypeDetails> =>
-        issueTypes.updateIssueType(client, parameters),
-      deleteIssueType: (parameters: DeleteIssueType): Promise<void> => issueTypes.deleteIssueType(client, parameters),
-      getAlternativeIssueTypes: (parameters: GetAlternativeIssueTypes): Promise<IssueTypeDetails[]> =>
-        issueTypes.getAlternativeIssueTypes(client, parameters),
-      createIssueTypeAvatar: (parameters: CreateIssueTypeAvatar): Promise<Avatar> =>
-        issueTypes.createIssueTypeAvatar(client, parameters),
+      getIssueAllTypes: (options?: RequestOptions): Promise<IssueTypeDetails[]> =>
+        issueTypes.getIssueAllTypes(client, options),
+      createIssueType: (parameters: CreateIssueType, options?: RequestOptions): Promise<IssueTypeDetails> =>
+        issueTypes.createIssueType(client, parameters, options),
+      getIssueType: (parameters: GetIssueType, options?: RequestOptions): Promise<IssueTypeDetails> =>
+        issueTypes.getIssueType(client, parameters, options),
+      updateIssueType: (parameters: UpdateIssueType, options?: RequestOptions): Promise<IssueTypeDetails> =>
+        issueTypes.updateIssueType(client, parameters, options),
+      deleteIssueType: (parameters: DeleteIssueType, options?: RequestOptions): Promise<void> =>
+        issueTypes.deleteIssueType(client, parameters, options),
+      getAlternativeIssueTypes: (
+        parameters: GetAlternativeIssueTypes,
+        options?: RequestOptions,
+      ): Promise<IssueTypeDetails[]> => issueTypes.getAlternativeIssueTypes(client, parameters, options),
+      createIssueTypeAvatar: (parameters: CreateIssueTypeAvatar, options?: RequestOptions): Promise<Avatar> =>
+        issueTypes.createIssueTypeAvatar(client, parameters, options),
     },
     issueTypeProperties: {
-      getIssueTypePropertyKeys: (parameters: GetIssueTypePropertyKeys): Promise<PropertyKeys> =>
-        issueTypeProperties.getIssueTypePropertyKeys(client, parameters),
-      getIssueTypeProperty: (parameters: GetIssueTypeProperty): Promise<EntityProperty> =>
-        issueTypeProperties.getIssueTypeProperty(client, parameters),
-      setIssueTypeProperty: (parameters: SetIssueTypeProperty): Promise<void> =>
-        issueTypeProperties.setIssueTypeProperty(client, parameters),
-      deleteIssueTypeProperty: (parameters: DeleteIssueTypeProperty): Promise<void> =>
-        issueTypeProperties.deleteIssueTypeProperty(client, parameters),
+      getIssueTypePropertyKeys: (
+        parameters: GetIssueTypePropertyKeys,
+        options?: RequestOptions,
+      ): Promise<PropertyKeys> => issueTypeProperties.getIssueTypePropertyKeys(client, parameters, options),
+      getIssueTypeProperty: (parameters: GetIssueTypeProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        issueTypeProperties.getIssueTypeProperty(client, parameters, options),
+      setIssueTypeProperty: (parameters: SetIssueTypeProperty, options?: RequestOptions): Promise<void> =>
+        issueTypeProperties.setIssueTypeProperty(client, parameters, options),
+      deleteIssueTypeProperty: (parameters: DeleteIssueTypeProperty, options?: RequestOptions): Promise<void> =>
+        issueTypeProperties.deleteIssueTypeProperty(client, parameters, options),
     },
     issueTypeSchemes: {
-      getAllIssueTypeSchemes: (parameters?: GetAllIssueTypeSchemes): Promise<Page<IssueTypeScheme>> =>
-        issueTypeSchemes.getAllIssueTypeSchemes(client, parameters),
-      createIssueTypeScheme: (parameters: CreateIssueTypeScheme): Promise<IssueTypeSchemeID> =>
-        issueTypeSchemes.createIssueTypeScheme(client, parameters),
-      getIssueTypeSchemesMapping: (parameters?: GetIssueTypeSchemesMapping): Promise<Page<IssueTypeSchemeMapping>> =>
-        issueTypeSchemes.getIssueTypeSchemesMapping(client, parameters),
+      getAllIssueTypeSchemes: (
+        parameters?: GetAllIssueTypeSchemes,
+        options?: RequestOptions,
+      ): Promise<Page<IssueTypeScheme>> => issueTypeSchemes.getAllIssueTypeSchemes(client, parameters, options),
+      createIssueTypeScheme: (
+        parameters: CreateIssueTypeScheme,
+        options?: RequestOptions,
+      ): Promise<IssueTypeSchemeID> => issueTypeSchemes.createIssueTypeScheme(client, parameters, options),
+      getIssueTypeSchemesMapping: (
+        parameters?: GetIssueTypeSchemesMapping,
+        options?: RequestOptions,
+      ): Promise<Page<IssueTypeSchemeMapping>> =>
+        issueTypeSchemes.getIssueTypeSchemesMapping(client, parameters, options),
       getIssueTypeSchemeForProjects: (
         parameters: GetIssueTypeSchemeForProjects,
-      ): Promise<Page<IssueTypeSchemeProjects>> => issueTypeSchemes.getIssueTypeSchemeForProjects(client, parameters),
-      assignIssueTypeSchemeToProject: (parameters: AssignIssueTypeSchemeToProject): Promise<void> =>
-        issueTypeSchemes.assignIssueTypeSchemeToProject(client, parameters),
-      updateIssueTypeScheme: (parameters: UpdateIssueTypeScheme): Promise<void> =>
-        issueTypeSchemes.updateIssueTypeScheme(client, parameters),
-      deleteIssueTypeScheme: (parameters: DeleteIssueTypeScheme): Promise<void> =>
-        issueTypeSchemes.deleteIssueTypeScheme(client, parameters),
-      addIssueTypesToIssueTypeScheme: (parameters: AddIssueTypesToIssueTypeScheme): Promise<void> =>
-        issueTypeSchemes.addIssueTypesToIssueTypeScheme(client, parameters),
-      reorderIssueTypesInIssueTypeScheme: (parameters: ReorderIssueTypesInIssueTypeScheme): Promise<void> =>
-        issueTypeSchemes.reorderIssueTypesInIssueTypeScheme(client, parameters),
-      removeIssueTypeFromIssueTypeScheme: (parameters: RemoveIssueTypeFromIssueTypeScheme): Promise<void> =>
-        issueTypeSchemes.removeIssueTypeFromIssueTypeScheme(client, parameters),
+        options?: RequestOptions,
+      ): Promise<Page<IssueTypeSchemeProjects>> =>
+        issueTypeSchemes.getIssueTypeSchemeForProjects(client, parameters, options),
+      assignIssueTypeSchemeToProject: (
+        parameters: AssignIssueTypeSchemeToProject,
+        options?: RequestOptions,
+      ): Promise<void> => issueTypeSchemes.assignIssueTypeSchemeToProject(client, parameters, options),
+      updateIssueTypeScheme: (parameters: UpdateIssueTypeScheme, options?: RequestOptions): Promise<void> =>
+        issueTypeSchemes.updateIssueTypeScheme(client, parameters, options),
+      deleteIssueTypeScheme: (parameters: DeleteIssueTypeScheme, options?: RequestOptions): Promise<void> =>
+        issueTypeSchemes.deleteIssueTypeScheme(client, parameters, options),
+      addIssueTypesToIssueTypeScheme: (
+        parameters: AddIssueTypesToIssueTypeScheme,
+        options?: RequestOptions,
+      ): Promise<void> => issueTypeSchemes.addIssueTypesToIssueTypeScheme(client, parameters, options),
+      reorderIssueTypesInIssueTypeScheme: (
+        parameters: ReorderIssueTypesInIssueTypeScheme,
+        options?: RequestOptions,
+      ): Promise<void> => issueTypeSchemes.reorderIssueTypesInIssueTypeScheme(client, parameters, options),
+      removeIssueTypeFromIssueTypeScheme: (
+        parameters: RemoveIssueTypeFromIssueTypeScheme,
+        options?: RequestOptions,
+      ): Promise<void> => issueTypeSchemes.removeIssueTypeFromIssueTypeScheme(client, parameters, options),
     },
     issueTypeScreenSchemes: {
-      getIssueTypeScreenSchemes: (parameters?: GetIssueTypeScreenSchemes): Promise<Page<IssueTypeScreenScheme>> =>
-        issueTypeScreenSchemes.getIssueTypeScreenSchemes(client, parameters),
-      createIssueTypeScreenScheme: (parameters: CreateIssueTypeScreenScheme): Promise<IssueTypeScreenSchemeId> =>
-        issueTypeScreenSchemes.createIssueTypeScreenScheme(client, parameters),
+      getIssueTypeScreenSchemes: (
+        parameters?: GetIssueTypeScreenSchemes,
+        options?: RequestOptions,
+      ): Promise<Page<IssueTypeScreenScheme>> =>
+        issueTypeScreenSchemes.getIssueTypeScreenSchemes(client, parameters, options),
+      createIssueTypeScreenScheme: (
+        parameters: CreateIssueTypeScreenScheme,
+        options?: RequestOptions,
+      ): Promise<IssueTypeScreenSchemeId> =>
+        issueTypeScreenSchemes.createIssueTypeScreenScheme(client, parameters, options),
       getIssueTypeScreenSchemeMappings: (
         parameters?: GetIssueTypeScreenSchemeMappings,
+        options?: RequestOptions,
       ): Promise<Page<IssueTypeScreenSchemeItem>> =>
-        issueTypeScreenSchemes.getIssueTypeScreenSchemeMappings(client, parameters),
+        issueTypeScreenSchemes.getIssueTypeScreenSchemeMappings(client, parameters, options),
       getIssueTypeScreenSchemeProjectAssociations: (
         parameters: GetIssueTypeScreenSchemeProjectAssociations,
+        options?: RequestOptions,
       ): Promise<Page<IssueTypeScreenSchemesProjects>> =>
-        issueTypeScreenSchemes.getIssueTypeScreenSchemeProjectAssociations(client, parameters),
-      assignIssueTypeScreenSchemeToProject: (parameters: AssignIssueTypeScreenSchemeToProject): Promise<void> =>
-        issueTypeScreenSchemes.assignIssueTypeScreenSchemeToProject(client, parameters),
-      updateIssueTypeScreenScheme: (parameters: UpdateIssueTypeScreenScheme): Promise<void> =>
-        issueTypeScreenSchemes.updateIssueTypeScreenScheme(client, parameters),
-      deleteIssueTypeScreenScheme: (parameters: DeleteIssueTypeScreenScheme): Promise<void> =>
-        issueTypeScreenSchemes.deleteIssueTypeScreenScheme(client, parameters),
-      appendMappingsForIssueTypeScreenScheme: (parameters: AppendMappingsForIssueTypeScreenScheme): Promise<void> =>
-        issueTypeScreenSchemes.appendMappingsForIssueTypeScreenScheme(client, parameters),
-      updateDefaultScreenScheme: (parameters: UpdateDefaultScreenScheme): Promise<void> =>
-        issueTypeScreenSchemes.updateDefaultScreenScheme(client, parameters),
-      removeMappingsFromIssueTypeScreenScheme: (parameters: RemoveMappingsFromIssueTypeScreenScheme): Promise<void> =>
-        issueTypeScreenSchemes.removeMappingsFromIssueTypeScreenScheme(client, parameters),
+        issueTypeScreenSchemes.getIssueTypeScreenSchemeProjectAssociations(client, parameters, options),
+      assignIssueTypeScreenSchemeToProject: (
+        parameters: AssignIssueTypeScreenSchemeToProject,
+        options?: RequestOptions,
+      ): Promise<void> => issueTypeScreenSchemes.assignIssueTypeScreenSchemeToProject(client, parameters, options),
+      updateIssueTypeScreenScheme: (parameters: UpdateIssueTypeScreenScheme, options?: RequestOptions): Promise<void> =>
+        issueTypeScreenSchemes.updateIssueTypeScreenScheme(client, parameters, options),
+      deleteIssueTypeScreenScheme: (parameters: DeleteIssueTypeScreenScheme, options?: RequestOptions): Promise<void> =>
+        issueTypeScreenSchemes.deleteIssueTypeScreenScheme(client, parameters, options),
+      appendMappingsForIssueTypeScreenScheme: (
+        parameters: AppendMappingsForIssueTypeScreenScheme,
+        options?: RequestOptions,
+      ): Promise<void> => issueTypeScreenSchemes.appendMappingsForIssueTypeScreenScheme(client, parameters, options),
+      updateDefaultScreenScheme: (parameters: UpdateDefaultScreenScheme, options?: RequestOptions): Promise<void> =>
+        issueTypeScreenSchemes.updateDefaultScreenScheme(client, parameters, options),
+      removeMappingsFromIssueTypeScreenScheme: (
+        parameters: RemoveMappingsFromIssueTypeScreenScheme,
+        options?: RequestOptions,
+      ): Promise<void> => issueTypeScreenSchemes.removeMappingsFromIssueTypeScreenScheme(client, parameters, options),
       getProjectsForIssueTypeScreenScheme: (
         parameters: GetProjectsForIssueTypeScreenScheme,
+        options?: RequestOptions,
       ): Promise<Page<ProjectDetails>> =>
-        issueTypeScreenSchemes.getProjectsForIssueTypeScreenScheme(client, parameters),
+        issueTypeScreenSchemes.getProjectsForIssueTypeScreenScheme(client, parameters, options),
     },
     jql: {
-      getAutoComplete: (): Promise<JQLReferenceData> => jql.getAutoComplete(client),
-      getAutoCompletePost: (parameters: GetAutoCompletePost): Promise<JQLReferenceData> =>
-        jql.getAutoCompletePost(client, parameters),
+      getAutoComplete: (options?: RequestOptions): Promise<JQLReferenceData> => jql.getAutoComplete(client, options),
+      getAutoCompletePost: (parameters: GetAutoCompletePost, options?: RequestOptions): Promise<JQLReferenceData> =>
+        jql.getAutoCompletePost(client, parameters, options),
       getFieldAutoCompleteForQueryString: (
         parameters?: GetFieldAutoCompleteForQueryString,
-      ): Promise<AutoCompleteSuggestions> => jql.getFieldAutoCompleteForQueryString(client, parameters),
-      parseJqlQueries: (parameters: ParseJqlQueries): Promise<ParsedJqlQueries> =>
-        jql.parseJqlQueries(client, parameters),
-      migrateQueries: (parameters: MigrateQueries): Promise<ConvertedJQLQueries> =>
-        jql.migrateQueries(client, parameters),
+        options?: RequestOptions,
+      ): Promise<AutoCompleteSuggestions> => jql.getFieldAutoCompleteForQueryString(client, parameters, options),
+      parseJqlQueries: (parameters: ParseJqlQueries, options?: RequestOptions): Promise<ParsedJqlQueries> =>
+        jql.parseJqlQueries(client, parameters, options),
+      migrateQueries: (parameters: MigrateQueries, options?: RequestOptions): Promise<ConvertedJQLQueries> =>
+        jql.migrateQueries(client, parameters, options),
     },
     jqlFunctionsApps: {
-      getPrecomputations: (parameters?: GetPrecomputations): Promise<Page<JqlFunctionPrecomputation>> =>
-        jqlFunctionsApps.getPrecomputations(client, parameters),
-      updatePrecomputations: (parameters: UpdatePrecomputations): Promise<void> =>
-        jqlFunctionsApps.updatePrecomputations(client, parameters),
-      getPrecomputationsByID: (parameters: GetPrecomputationsByID): Promise<JqlFunctionPrecomputationGetByIdResponse> =>
-        jqlFunctionsApps.getPrecomputationsByID(client, parameters),
+      getPrecomputations: (
+        parameters?: GetPrecomputations,
+        options?: RequestOptions,
+      ): Promise<Page<JqlFunctionPrecomputation>> => jqlFunctionsApps.getPrecomputations(client, parameters, options),
+      updatePrecomputations: (parameters: UpdatePrecomputations, options?: RequestOptions): Promise<void> =>
+        jqlFunctionsApps.updatePrecomputations(client, parameters, options),
+      getPrecomputationsByID: (
+        parameters: GetPrecomputationsByID,
+        options?: RequestOptions,
+      ): Promise<JqlFunctionPrecomputationGetByIdResponse> =>
+        jqlFunctionsApps.getPrecomputationsByID(client, parameters, options),
     },
     labels: {
-      getAllLabels: (parameters?: GetAllLabels): Promise<PageString> => labels.getAllLabels(client, parameters),
+      getAllLabels: (parameters?: GetAllLabels, options?: RequestOptions): Promise<PageString> =>
+        labels.getAllLabels(client, parameters, options),
     },
     permissions: {
-      getMyPermissions: (parameters?: GetMyPermissions): Promise<Permissions> =>
-        permissions.getMyPermissions(client, parameters),
-      getAllPermissions: (): Promise<Permissions> => permissions.getAllPermissions(client),
-      getBulkPermissions: (parameters: GetBulkPermissions): Promise<BulkPermissionGrants> =>
-        permissions.getBulkPermissions(client, parameters),
-      getPermittedProjects: (parameters: GetPermittedProjects): Promise<PermittedProjects> =>
-        permissions.getPermittedProjects(client, parameters),
+      getMyPermissions: (parameters?: GetMyPermissions, options?: RequestOptions): Promise<Permissions> =>
+        permissions.getMyPermissions(client, parameters, options),
+      getAllPermissions: (options?: RequestOptions): Promise<Permissions> =>
+        permissions.getAllPermissions(client, options),
+      getBulkPermissions: (parameters: GetBulkPermissions, options?: RequestOptions): Promise<BulkPermissionGrants> =>
+        permissions.getBulkPermissions(client, parameters, options),
+      getPermittedProjects: (parameters: GetPermittedProjects, options?: RequestOptions): Promise<PermittedProjects> =>
+        permissions.getPermittedProjects(client, parameters, options),
     },
     myself: {
-      getPreference: (parameters: GetPreference): Promise<string> => myself.getPreference(client, parameters),
-      setPreference: (parameters: SetPreference): Promise<void> => myself.setPreference(client, parameters),
-      removePreference: (parameters: RemovePreference): Promise<void> => myself.removePreference(client, parameters),
-      getLocale: (): Promise<Locale> => myself.getLocale(client),
-      getCurrentUser: (parameters?: GetCurrentUser): Promise<DashboardUser> =>
-        myself.getCurrentUser(client, parameters),
+      getPreference: (parameters: GetPreference, options?: RequestOptions): Promise<string> =>
+        myself.getPreference(client, parameters, options),
+      setPreference: (parameters: SetPreference, options?: RequestOptions): Promise<void> =>
+        myself.setPreference(client, parameters, options),
+      removePreference: (parameters: RemovePreference, options?: RequestOptions): Promise<void> =>
+        myself.removePreference(client, parameters, options),
+      getLocale: (options?: RequestOptions): Promise<Locale> => myself.getLocale(client, options),
+      getCurrentUser: (parameters?: GetCurrentUser, options?: RequestOptions): Promise<DashboardUser> =>
+        myself.getCurrentUser(client, parameters, options),
     },
     issueNotificationSchemes: {
-      getNotificationSchemes: (parameters?: GetNotificationSchemes): Promise<Page<NotificationScheme>> =>
-        issueNotificationSchemes.getNotificationSchemes(client, parameters),
+      getNotificationSchemes: (
+        parameters?: GetNotificationSchemes,
+        options?: RequestOptions,
+      ): Promise<Page<NotificationScheme>> =>
+        issueNotificationSchemes.getNotificationSchemes(client, parameters, options),
       getNotificationSchemeToProjectMappings: (
         parameters?: GetNotificationSchemeToProjectMappings,
+        options?: RequestOptions,
       ): Promise<Page<NotificationSchemeAndProjectMapping>> =>
-        issueNotificationSchemes.getNotificationSchemeToProjectMappings(client, parameters),
-      getNotificationScheme: (parameters: GetNotificationScheme): Promise<NotificationScheme> =>
-        issueNotificationSchemes.getNotificationScheme(client, parameters),
-      addNotifications: (parameters: AddNotifications): Promise<void> =>
-        issueNotificationSchemes.addNotifications(client, parameters),
-      removeNotificationFromNotificationScheme: (parameters: RemoveNotificationFromNotificationScheme): Promise<void> =>
-        issueNotificationSchemes.removeNotificationFromNotificationScheme(client, parameters),
+        issueNotificationSchemes.getNotificationSchemeToProjectMappings(client, parameters, options),
+      getNotificationScheme: (
+        parameters: GetNotificationScheme,
+        options?: RequestOptions,
+      ): Promise<NotificationScheme> => issueNotificationSchemes.getNotificationScheme(client, parameters, options),
+      addNotifications: (parameters: AddNotifications, options?: RequestOptions): Promise<void> =>
+        issueNotificationSchemes.addNotifications(client, parameters, options),
+      removeNotificationFromNotificationScheme: (
+        parameters: RemoveNotificationFromNotificationScheme,
+        options?: RequestOptions,
+      ): Promise<void> =>
+        issueNotificationSchemes.removeNotificationFromNotificationScheme(client, parameters, options),
     },
     permissionSchemes: {
-      getAllPermissionSchemes: (parameters?: GetAllPermissionSchemes): Promise<PermissionSchemes> =>
-        permissionSchemes.getAllPermissionSchemes(client, parameters),
-      createPermissionScheme: (parameters: CreatePermissionScheme): Promise<PermissionScheme> =>
-        permissionSchemes.createPermissionScheme(client, parameters),
-      getPermissionScheme: (parameters: GetPermissionScheme): Promise<PermissionScheme> =>
-        permissionSchemes.getPermissionScheme(client, parameters),
-      updatePermissionScheme: (parameters: UpdatePermissionScheme): Promise<PermissionScheme> =>
-        permissionSchemes.updatePermissionScheme(client, parameters),
-      deletePermissionScheme: (parameters: DeletePermissionScheme): Promise<void> =>
-        permissionSchemes.deletePermissionScheme(client, parameters),
-      getPermissionSchemeGrants: (parameters: GetPermissionSchemeGrants): Promise<PermissionGrants> =>
-        permissionSchemes.getPermissionSchemeGrants(client, parameters),
-      createPermissionGrant: (parameters: CreatePermissionGrant): Promise<PermissionGrant> =>
-        permissionSchemes.createPermissionGrant(client, parameters),
-      getPermissionSchemeGrant: (parameters: GetPermissionSchemeGrant): Promise<PermissionGrant> =>
-        permissionSchemes.getPermissionSchemeGrant(client, parameters),
-      deletePermissionSchemeEntity: (parameters: DeletePermissionSchemeEntity): Promise<void> =>
-        permissionSchemes.deletePermissionSchemeEntity(client, parameters),
+      getAllPermissionSchemes: (
+        parameters?: GetAllPermissionSchemes,
+        options?: RequestOptions,
+      ): Promise<PermissionSchemes> => permissionSchemes.getAllPermissionSchemes(client, parameters, options),
+      createPermissionScheme: (
+        parameters: CreatePermissionScheme,
+        options?: RequestOptions,
+      ): Promise<PermissionScheme> => permissionSchemes.createPermissionScheme(client, parameters, options),
+      getPermissionScheme: (parameters: GetPermissionScheme, options?: RequestOptions): Promise<PermissionScheme> =>
+        permissionSchemes.getPermissionScheme(client, parameters, options),
+      updatePermissionScheme: (
+        parameters: UpdatePermissionScheme,
+        options?: RequestOptions,
+      ): Promise<PermissionScheme> => permissionSchemes.updatePermissionScheme(client, parameters, options),
+      deletePermissionScheme: (parameters: DeletePermissionScheme, options?: RequestOptions): Promise<void> =>
+        permissionSchemes.deletePermissionScheme(client, parameters, options),
+      getPermissionSchemeGrants: (
+        parameters: GetPermissionSchemeGrants,
+        options?: RequestOptions,
+      ): Promise<PermissionGrants> => permissionSchemes.getPermissionSchemeGrants(client, parameters, options),
+      createPermissionGrant: (parameters: CreatePermissionGrant, options?: RequestOptions): Promise<PermissionGrant> =>
+        permissionSchemes.createPermissionGrant(client, parameters, options),
+      getPermissionSchemeGrant: (
+        parameters: GetPermissionSchemeGrant,
+        options?: RequestOptions,
+      ): Promise<PermissionGrant> => permissionSchemes.getPermissionSchemeGrant(client, parameters, options),
+      deletePermissionSchemeEntity: (
+        parameters: DeletePermissionSchemeEntity,
+        options?: RequestOptions,
+      ): Promise<void> => permissionSchemes.deletePermissionSchemeEntity(client, parameters, options),
     },
     issuePriorities: {
-      createPriority: (parameters: CreatePriority): Promise<PriorityId> =>
-        issuePriorities.createPriority(client, parameters),
-      setDefaultPriority: (parameters: SetDefaultPriority): Promise<void> =>
-        issuePriorities.setDefaultPriority(client, parameters),
-      movePriorities: (parameters: MovePriorities): Promise<void> => issuePriorities.movePriorities(client, parameters),
-      searchPriorities: (parameters?: SearchPriorities): Promise<Page<Priority>> =>
-        issuePriorities.searchPriorities(client, parameters),
-      getPriority: (parameters: GetPriority): Promise<Priority> => issuePriorities.getPriority(client, parameters),
-      updatePriority: (parameters: UpdatePriority): Promise<void> => issuePriorities.updatePriority(client, parameters),
-      deletePriority: (parameters: DeletePriority): Promise<TaskProgressObject> =>
-        issuePriorities.deletePriority(client, parameters),
+      createPriority: (parameters: CreatePriority, options?: RequestOptions): Promise<PriorityId> =>
+        issuePriorities.createPriority(client, parameters, options),
+      setDefaultPriority: (parameters: SetDefaultPriority, options?: RequestOptions): Promise<void> =>
+        issuePriorities.setDefaultPriority(client, parameters, options),
+      movePriorities: (parameters: MovePriorities, options?: RequestOptions): Promise<void> =>
+        issuePriorities.movePriorities(client, parameters, options),
+      searchPriorities: (parameters?: SearchPriorities, options?: RequestOptions): Promise<Page<Priority>> =>
+        issuePriorities.searchPriorities(client, parameters, options),
+      getPriority: (parameters: GetPriority, options?: RequestOptions): Promise<Priority> =>
+        issuePriorities.getPriority(client, parameters, options),
+      updatePriority: (parameters: UpdatePriority, options?: RequestOptions): Promise<void> =>
+        issuePriorities.updatePriority(client, parameters, options),
+      deletePriority: (parameters: DeletePriority, options?: RequestOptions): Promise<TaskProgressObject> =>
+        issuePriorities.deletePriority(client, parameters, options),
     },
     projects: {
-      createProject: (parameters: CreateProject): Promise<ProjectIdentifiers> =>
-        projects.createProject(client, parameters),
-      searchProjects: (parameters?: SearchProjects): Promise<Page<Project>> =>
-        projects.searchProjects(client, parameters),
-      getProject: (parameters: GetProject): Promise<Project> => projects.getProject(client, parameters),
-      updateProject: (parameters: UpdateProject): Promise<Project> => projects.updateProject(client, parameters),
-      deleteProject: (parameters: DeleteProject): Promise<void> => projects.deleteProject(client, parameters),
-      archiveProject: (parameters: ArchiveProject): Promise<void> => projects.archiveProject(client, parameters),
-      getAllStatuses: (parameters: GetAllStatuses): Promise<IssueTypeWithStatus[]> =>
-        projects.getAllStatuses(client, parameters),
-      getHierarchy: (parameters: GetHierarchy): Promise<ProjectIssueTypeHierarchy> =>
-        projects.getHierarchy(client, parameters),
-      getNotificationSchemeForProject: (parameters: GetNotificationSchemeForProject): Promise<NotificationScheme> =>
-        projects.getNotificationSchemeForProject(client, parameters),
+      createProject: (parameters: CreateProject, options?: RequestOptions): Promise<ProjectIdentifiers> =>
+        projects.createProject(client, parameters, options),
+      searchProjects: (parameters?: SearchProjects, options?: RequestOptions): Promise<Page<Project>> =>
+        projects.searchProjects(client, parameters, options),
+      getProject: (parameters: GetProject, options?: RequestOptions): Promise<Project> =>
+        projects.getProject(client, parameters, options),
+      updateProject: (parameters: UpdateProject, options?: RequestOptions): Promise<Project> =>
+        projects.updateProject(client, parameters, options),
+      deleteProject: (parameters: DeleteProject, options?: RequestOptions): Promise<void> =>
+        projects.deleteProject(client, parameters, options),
+      archiveProject: (parameters: ArchiveProject, options?: RequestOptions): Promise<void> =>
+        projects.archiveProject(client, parameters, options),
+      getAllStatuses: (parameters: GetAllStatuses, options?: RequestOptions): Promise<IssueTypeWithStatus[]> =>
+        projects.getAllStatuses(client, parameters, options),
+      getHierarchy: (parameters: GetHierarchy, options?: RequestOptions): Promise<ProjectIssueTypeHierarchy> =>
+        projects.getHierarchy(client, parameters, options),
+      getNotificationSchemeForProject: (
+        parameters: GetNotificationSchemeForProject,
+        options?: RequestOptions,
+      ): Promise<NotificationScheme> => projects.getNotificationSchemeForProject(client, parameters, options),
     },
     projectTemplates: {
-      createProjectWithCustomTemplate: (parameters: CreateProjectWithCustomTemplate): Promise<void> =>
-        projectTemplates.createProjectWithCustomTemplate(client, parameters),
+      createProjectWithCustomTemplate: (
+        parameters: CreateProjectWithCustomTemplate,
+        options?: RequestOptions,
+      ): Promise<void> => projectTemplates.createProjectWithCustomTemplate(client, parameters, options),
     },
     projectTypes: {
-      getAllProjectTypes: (): Promise<ProjectType[]> => projectTypes.getAllProjectTypes(client),
-      getAllAccessibleProjectTypes: (): Promise<ProjectType[]> => projectTypes.getAllAccessibleProjectTypes(client),
-      getProjectTypeByKey: (parameters: GetProjectTypeByKey): Promise<ProjectType> =>
-        projectTypes.getProjectTypeByKey(client, parameters),
-      getAccessibleProjectTypeByKey: (parameters: GetAccessibleProjectTypeByKey): Promise<ProjectType> =>
-        projectTypes.getAccessibleProjectTypeByKey(client, parameters),
+      getAllProjectTypes: (options?: RequestOptions): Promise<ProjectType[]> =>
+        projectTypes.getAllProjectTypes(client, options),
+      getAllAccessibleProjectTypes: (options?: RequestOptions): Promise<ProjectType[]> =>
+        projectTypes.getAllAccessibleProjectTypes(client, options),
+      getProjectTypeByKey: (parameters: GetProjectTypeByKey, options?: RequestOptions): Promise<ProjectType> =>
+        projectTypes.getProjectTypeByKey(client, parameters, options),
+      getAccessibleProjectTypeByKey: (
+        parameters: GetAccessibleProjectTypeByKey,
+        options?: RequestOptions,
+      ): Promise<ProjectType> => projectTypes.getAccessibleProjectTypeByKey(client, parameters, options),
     },
     projectAvatars: {
-      updateProjectAvatar: (parameters: UpdateProjectAvatar): Promise<void> =>
-        projectAvatars.updateProjectAvatar(client, parameters),
-      deleteProjectAvatar: (parameters: DeleteProjectAvatar): Promise<void> =>
-        projectAvatars.deleteProjectAvatar(client, parameters),
-      createProjectAvatar: (parameters: CreateProjectAvatar): Promise<Avatar> =>
-        projectAvatars.createProjectAvatar(client, parameters),
-      getAllProjectAvatars: (parameters: GetAllProjectAvatars): Promise<ProjectAvatars> =>
-        projectAvatars.getAllProjectAvatars(client, parameters),
+      updateProjectAvatar: (parameters: UpdateProjectAvatar, options?: RequestOptions): Promise<void> =>
+        projectAvatars.updateProjectAvatar(client, parameters, options),
+      deleteProjectAvatar: (parameters: DeleteProjectAvatar, options?: RequestOptions): Promise<void> =>
+        projectAvatars.deleteProjectAvatar(client, parameters, options),
+      createProjectAvatar: (parameters: CreateProjectAvatar, options?: RequestOptions): Promise<Avatar> =>
+        projectAvatars.createProjectAvatar(client, parameters, options),
+      getAllProjectAvatars: (parameters: GetAllProjectAvatars, options?: RequestOptions): Promise<ProjectAvatars> =>
+        projectAvatars.getAllProjectAvatars(client, parameters, options),
     },
     projectFeatures: {
-      getFeaturesForProject: (parameters: GetFeaturesForProject): Promise<ContainerForProjectFeatures> =>
-        projectFeatures.getFeaturesForProject(client, parameters),
-      toggleFeatureForProject: (parameters: ToggleFeatureForProject): Promise<ContainerForProjectFeatures> =>
-        projectFeatures.toggleFeatureForProject(client, parameters),
+      getFeaturesForProject: (
+        parameters: GetFeaturesForProject,
+        options?: RequestOptions,
+      ): Promise<ContainerForProjectFeatures> => projectFeatures.getFeaturesForProject(client, parameters, options),
+      toggleFeatureForProject: (
+        parameters: ToggleFeatureForProject,
+        options?: RequestOptions,
+      ): Promise<ContainerForProjectFeatures> => projectFeatures.toggleFeatureForProject(client, parameters, options),
     },
     projectProperties: {
-      getProjectPropertyKeys: (parameters: GetProjectPropertyKeys): Promise<PropertyKeys> =>
-        projectProperties.getProjectPropertyKeys(client, parameters),
-      getProjectProperty: (parameters: GetProjectProperty): Promise<EntityProperty> =>
-        projectProperties.getProjectProperty(client, parameters),
-      setProjectProperty: (parameters: SetProjectProperty): Promise<void> =>
-        projectProperties.setProjectProperty(client, parameters),
-      deleteProjectProperty: (parameters: DeleteProjectProperty): Promise<void> =>
-        projectProperties.deleteProjectProperty(client, parameters),
+      getProjectPropertyKeys: (parameters: GetProjectPropertyKeys, options?: RequestOptions): Promise<PropertyKeys> =>
+        projectProperties.getProjectPropertyKeys(client, parameters, options),
+      getProjectProperty: (parameters: GetProjectProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        projectProperties.getProjectProperty(client, parameters, options),
+      setProjectProperty: (parameters: SetProjectProperty, options?: RequestOptions): Promise<void> =>
+        projectProperties.setProjectProperty(client, parameters, options),
+      deleteProjectProperty: (parameters: DeleteProjectProperty, options?: RequestOptions): Promise<void> =>
+        projectProperties.deleteProjectProperty(client, parameters, options),
     },
     projectRoles: {
-      getProjectRoles: (parameters: GetProjectRoles): Promise<GetProjectRolesModel> =>
-        projectRoles.getProjectRoles(client, parameters),
-      getProjectRole: (parameters: GetProjectRole): Promise<ProjectRole> =>
-        projectRoles.getProjectRole(client, parameters),
-      getProjectRoleDetails: (parameters: GetProjectRoleDetails): Promise<ProjectRoleDetails[]> =>
-        projectRoles.getProjectRoleDetails(client, parameters),
-      getAllProjectRoles: (): Promise<ProjectRole[]> => projectRoles.getAllProjectRoles(client),
-      createProjectRole: (parameters: CreateProjectRole): Promise<ProjectRole> =>
-        projectRoles.createProjectRole(client, parameters),
-      getProjectRoleById: (parameters: GetProjectRoleById): Promise<ProjectRole> =>
-        projectRoles.getProjectRoleById(client, parameters),
-      partialUpdateProjectRole: (parameters: PartialUpdateProjectRole): Promise<ProjectRole> =>
-        projectRoles.partialUpdateProjectRole(client, parameters),
-      fullyUpdateProjectRole: (parameters: FullyUpdateProjectRole): Promise<ProjectRole> =>
-        projectRoles.fullyUpdateProjectRole(client, parameters),
-      deleteProjectRole: (parameters: DeleteProjectRole): Promise<void> =>
-        projectRoles.deleteProjectRole(client, parameters),
+      getProjectRoles: (parameters: GetProjectRoles, options?: RequestOptions): Promise<GetProjectRolesModel> =>
+        projectRoles.getProjectRoles(client, parameters, options),
+      getProjectRole: (parameters: GetProjectRole, options?: RequestOptions): Promise<ProjectRole> =>
+        projectRoles.getProjectRole(client, parameters, options),
+      getProjectRoleDetails: (
+        parameters: GetProjectRoleDetails,
+        options?: RequestOptions,
+      ): Promise<ProjectRoleDetails[]> => projectRoles.getProjectRoleDetails(client, parameters, options),
+      getAllProjectRoles: (options?: RequestOptions): Promise<ProjectRole[]> =>
+        projectRoles.getAllProjectRoles(client, options),
+      createProjectRole: (parameters: CreateProjectRole, options?: RequestOptions): Promise<ProjectRole> =>
+        projectRoles.createProjectRole(client, parameters, options),
+      getProjectRoleById: (parameters: GetProjectRoleById, options?: RequestOptions): Promise<ProjectRole> =>
+        projectRoles.getProjectRoleById(client, parameters, options),
+      partialUpdateProjectRole: (
+        parameters: PartialUpdateProjectRole,
+        options?: RequestOptions,
+      ): Promise<ProjectRole> => projectRoles.partialUpdateProjectRole(client, parameters, options),
+      fullyUpdateProjectRole: (parameters: FullyUpdateProjectRole, options?: RequestOptions): Promise<ProjectRole> =>
+        projectRoles.fullyUpdateProjectRole(client, parameters, options),
+      deleteProjectRole: (parameters: DeleteProjectRole, options?: RequestOptions): Promise<void> =>
+        projectRoles.deleteProjectRole(client, parameters, options),
     },
     projectRoleActors: {
-      addActorUsers: (parameters: AddActorUsers): Promise<ProjectRole> =>
-        projectRoleActors.addActorUsers(client, parameters),
-      setActors: (parameters: SetActors): Promise<ProjectRole> => projectRoleActors.setActors(client, parameters),
-      deleteActor: (parameters: DeleteActor): Promise<void> => projectRoleActors.deleteActor(client, parameters),
-      getProjectRoleActorsForRole: (parameters: GetProjectRoleActorsForRole): Promise<ProjectRole> =>
-        projectRoleActors.getProjectRoleActorsForRole(client, parameters),
-      addProjectRoleActorsToRole: (parameters: AddProjectRoleActorsToRole): Promise<ProjectRole> =>
-        projectRoleActors.addProjectRoleActorsToRole(client, parameters),
-      deleteProjectRoleActorsFromRole: (parameters: DeleteProjectRoleActorsFromRole): Promise<ProjectRole> =>
-        projectRoleActors.deleteProjectRoleActorsFromRole(client, parameters),
+      addActorUsers: (parameters: AddActorUsers, options?: RequestOptions): Promise<ProjectRole> =>
+        projectRoleActors.addActorUsers(client, parameters, options),
+      setActors: (parameters: SetActors, options?: RequestOptions): Promise<ProjectRole> =>
+        projectRoleActors.setActors(client, parameters, options),
+      deleteActor: (parameters: DeleteActor, options?: RequestOptions): Promise<void> =>
+        projectRoleActors.deleteActor(client, parameters, options),
+      getProjectRoleActorsForRole: (
+        parameters: GetProjectRoleActorsForRole,
+        options?: RequestOptions,
+      ): Promise<ProjectRole> => projectRoleActors.getProjectRoleActorsForRole(client, parameters, options),
+      addProjectRoleActorsToRole: (
+        parameters: AddProjectRoleActorsToRole,
+        options?: RequestOptions,
+      ): Promise<ProjectRole> => projectRoleActors.addProjectRoleActorsToRole(client, parameters, options),
+      deleteProjectRoleActorsFromRole: (
+        parameters: DeleteProjectRoleActorsFromRole,
+        options?: RequestOptions,
+      ): Promise<ProjectRole> => projectRoleActors.deleteProjectRoleActorsFromRole(client, parameters, options),
     },
     projectVersions: {
-      getProjectVersionsPaginated: (parameters: GetProjectVersionsPaginated): Promise<Page<Version>> =>
-        projectVersions.getProjectVersionsPaginated(client, parameters),
-      getProjectVersions: (parameters: GetProjectVersions): Promise<Version[]> =>
-        projectVersions.getProjectVersions(client, parameters),
-      createVersion: (parameters: CreateVersion): Promise<Version> => projectVersions.createVersion(client, parameters),
-      getVersion: (parameters: GetVersion): Promise<Version> => projectVersions.getVersion(client, parameters),
-      updateVersion: (parameters: UpdateVersion): Promise<Version> => projectVersions.updateVersion(client, parameters),
-      mergeVersions: (parameters: MergeVersions): Promise<void> => projectVersions.mergeVersions(client, parameters),
-      moveVersion: (parameters: MoveVersion): Promise<Version> => projectVersions.moveVersion(client, parameters),
-      getVersionRelatedIssues: (parameters: GetVersionRelatedIssues): Promise<VersionIssueCounts> =>
-        projectVersions.getVersionRelatedIssues(client, parameters),
-      getRelatedWork: (parameters: GetRelatedWork): Promise<VersionRelatedWork[]> =>
-        projectVersions.getRelatedWork(client, parameters),
-      createRelatedWork: (parameters: CreateRelatedWork): Promise<VersionRelatedWork> =>
-        projectVersions.createRelatedWork(client, parameters),
-      updateRelatedWork: (parameters: UpdateRelatedWork): Promise<VersionRelatedWork> =>
-        projectVersions.updateRelatedWork(client, parameters),
-      deleteAndReplaceVersion: (parameters: DeleteAndReplaceVersion): Promise<void> =>
-        projectVersions.deleteAndReplaceVersion(client, parameters),
-      getVersionUnresolvedIssues: (parameters: GetVersionUnresolvedIssues): Promise<VersionUnresolvedIssuesCount> =>
-        projectVersions.getVersionUnresolvedIssues(client, parameters),
-      deleteRelatedWork: (parameters: DeleteRelatedWork): Promise<void> =>
-        projectVersions.deleteRelatedWork(client, parameters),
+      getProjectVersionsPaginated: (
+        parameters: GetProjectVersionsPaginated,
+        options?: RequestOptions,
+      ): Promise<Page<Version>> => projectVersions.getProjectVersionsPaginated(client, parameters, options),
+      getProjectVersions: (parameters: GetProjectVersions, options?: RequestOptions): Promise<Version[]> =>
+        projectVersions.getProjectVersions(client, parameters, options),
+      createVersion: (parameters: CreateVersion, options?: RequestOptions): Promise<Version> =>
+        projectVersions.createVersion(client, parameters, options),
+      getVersion: (parameters: GetVersion, options?: RequestOptions): Promise<Version> =>
+        projectVersions.getVersion(client, parameters, options),
+      updateVersion: (parameters: UpdateVersion, options?: RequestOptions): Promise<Version> =>
+        projectVersions.updateVersion(client, parameters, options),
+      mergeVersions: (parameters: MergeVersions, options?: RequestOptions): Promise<void> =>
+        projectVersions.mergeVersions(client, parameters, options),
+      moveVersion: (parameters: MoveVersion, options?: RequestOptions): Promise<Version> =>
+        projectVersions.moveVersion(client, parameters, options),
+      getVersionRelatedIssues: (
+        parameters: GetVersionRelatedIssues,
+        options?: RequestOptions,
+      ): Promise<VersionIssueCounts> => projectVersions.getVersionRelatedIssues(client, parameters, options),
+      getRelatedWork: (parameters: GetRelatedWork, options?: RequestOptions): Promise<VersionRelatedWork[]> =>
+        projectVersions.getRelatedWork(client, parameters, options),
+      createRelatedWork: (parameters: CreateRelatedWork, options?: RequestOptions): Promise<VersionRelatedWork> =>
+        projectVersions.createRelatedWork(client, parameters, options),
+      updateRelatedWork: (parameters: UpdateRelatedWork, options?: RequestOptions): Promise<VersionRelatedWork> =>
+        projectVersions.updateRelatedWork(client, parameters, options),
+      deleteAndReplaceVersion: (parameters: DeleteAndReplaceVersion, options?: RequestOptions): Promise<void> =>
+        projectVersions.deleteAndReplaceVersion(client, parameters, options),
+      getVersionUnresolvedIssues: (
+        parameters: GetVersionUnresolvedIssues,
+        options?: RequestOptions,
+      ): Promise<VersionUnresolvedIssuesCount> =>
+        projectVersions.getVersionUnresolvedIssues(client, parameters, options),
+      deleteRelatedWork: (parameters: DeleteRelatedWork, options?: RequestOptions): Promise<void> =>
+        projectVersions.deleteRelatedWork(client, parameters, options),
     },
     projectEmail: {
-      getProjectEmail: (parameters: GetProjectEmail): Promise<ProjectEmailAddress> =>
-        projectEmail.getProjectEmail(client, parameters),
-      updateProjectEmail: (parameters: UpdateProjectEmail): Promise<void> =>
-        projectEmail.updateProjectEmail(client, parameters),
+      getProjectEmail: (parameters: GetProjectEmail, options?: RequestOptions): Promise<ProjectEmailAddress> =>
+        projectEmail.getProjectEmail(client, parameters, options),
+      updateProjectEmail: (parameters: UpdateProjectEmail, options?: RequestOptions): Promise<void> =>
+        projectEmail.updateProjectEmail(client, parameters, options),
     },
     projectPermissionSchemes: {
-      getProjectIssueSecurityScheme: (parameters: GetProjectIssueSecurityScheme): Promise<SecurityScheme> =>
-        projectPermissionSchemes.getProjectIssueSecurityScheme(client, parameters),
-      getAssignedPermissionScheme: (parameters: GetAssignedPermissionScheme): Promise<PermissionScheme> =>
-        projectPermissionSchemes.getAssignedPermissionScheme(client, parameters),
-      assignPermissionScheme: (parameters: AssignPermissionScheme): Promise<PermissionScheme> =>
-        projectPermissionSchemes.assignPermissionScheme(client, parameters),
-      getSecurityLevelsForProject: (parameters: GetSecurityLevelsForProject): Promise<ProjectIssueSecurityLevels> =>
-        projectPermissionSchemes.getSecurityLevelsForProject(client, parameters),
+      getProjectIssueSecurityScheme: (
+        parameters: GetProjectIssueSecurityScheme,
+        options?: RequestOptions,
+      ): Promise<SecurityScheme> => projectPermissionSchemes.getProjectIssueSecurityScheme(client, parameters, options),
+      getAssignedPermissionScheme: (
+        parameters: GetAssignedPermissionScheme,
+        options?: RequestOptions,
+      ): Promise<PermissionScheme> => projectPermissionSchemes.getAssignedPermissionScheme(client, parameters, options),
+      assignPermissionScheme: (
+        parameters: AssignPermissionScheme,
+        options?: RequestOptions,
+      ): Promise<PermissionScheme> => projectPermissionSchemes.assignPermissionScheme(client, parameters, options),
+      getSecurityLevelsForProject: (
+        parameters: GetSecurityLevelsForProject,
+        options?: RequestOptions,
+      ): Promise<ProjectIssueSecurityLevels> =>
+        projectPermissionSchemes.getSecurityLevelsForProject(client, parameters, options),
     },
     projectCategories: {
-      getAllProjectCategories: (): Promise<ProjectCategory[]> => projectCategories.getAllProjectCategories(client),
-      createProjectCategory: (parameters: CreateProjectCategory): Promise<ProjectCategory> =>
-        projectCategories.createProjectCategory(client, parameters),
-      getProjectCategoryById: (parameters: GetProjectCategoryById): Promise<ProjectCategory> =>
-        projectCategories.getProjectCategoryById(client, parameters),
-      updateProjectCategory: (parameters: UpdateProjectCategory): Promise<UpdatedProjectCategory> =>
-        projectCategories.updateProjectCategory(client, parameters),
-      removeProjectCategory: (parameters: RemoveProjectCategory): Promise<void> =>
-        projectCategories.removeProjectCategory(client, parameters),
+      getAllProjectCategories: (options?: RequestOptions): Promise<ProjectCategory[]> =>
+        projectCategories.getAllProjectCategories(client, options),
+      createProjectCategory: (parameters: CreateProjectCategory, options?: RequestOptions): Promise<ProjectCategory> =>
+        projectCategories.createProjectCategory(client, parameters, options),
+      getProjectCategoryById: (
+        parameters: GetProjectCategoryById,
+        options?: RequestOptions,
+      ): Promise<ProjectCategory> => projectCategories.getProjectCategoryById(client, parameters, options),
+      updateProjectCategory: (
+        parameters: UpdateProjectCategory,
+        options?: RequestOptions,
+      ): Promise<UpdatedProjectCategory> => projectCategories.updateProjectCategory(client, parameters, options),
+      removeProjectCategory: (parameters: RemoveProjectCategory, options?: RequestOptions): Promise<void> =>
+        projectCategories.removeProjectCategory(client, parameters, options),
     },
     projectKeyAndNameValidation: {
-      validateProjectKey: (parameters?: ValidateProjectKey): Promise<ErrorCollection> =>
-        projectKeyAndNameValidation.validateProjectKey(client, parameters),
-      getValidProjectKey: (parameters?: GetValidProjectKey): Promise<string> =>
-        projectKeyAndNameValidation.getValidProjectKey(client, parameters),
-      getValidProjectName: (parameters: GetValidProjectName): Promise<string> =>
-        projectKeyAndNameValidation.getValidProjectName(client, parameters),
+      validateProjectKey: (parameters?: ValidateProjectKey, options?: RequestOptions): Promise<ErrorCollection> =>
+        projectKeyAndNameValidation.validateProjectKey(client, parameters, options),
+      getValidProjectKey: (parameters?: GetValidProjectKey, options?: RequestOptions): Promise<string> =>
+        projectKeyAndNameValidation.getValidProjectKey(client, parameters, options),
+      getValidProjectName: (parameters: GetValidProjectName, options?: RequestOptions): Promise<string> =>
+        projectKeyAndNameValidation.getValidProjectName(client, parameters, options),
     },
     issueRedaction: {
-      redact: (parameters: Redact): Promise<string> => issueRedaction.redact(client, parameters),
-      getRedactionStatus: (parameters: GetRedactionStatus): Promise<RedactionJobStatusResponse> =>
-        issueRedaction.getRedactionStatus(client, parameters),
+      redact: (parameters: Redact, options?: RequestOptions): Promise<string> =>
+        issueRedaction.redact(client, parameters, options),
+      getRedactionStatus: (
+        parameters: GetRedactionStatus,
+        options?: RequestOptions,
+      ): Promise<RedactionJobStatusResponse> => issueRedaction.getRedactionStatus(client, parameters, options),
     },
     issueResolutions: {
-      getResolution: (parameters: GetResolution): Promise<Resolution> =>
-        issueResolutions.getResolution(client, parameters),
+      getResolution: (parameters: GetResolution, options?: RequestOptions): Promise<Resolution> =>
+        issueResolutions.getResolution(client, parameters, options),
     },
     screenTabs: {
-      getAllScreenTabs: (parameters: GetAllScreenTabs): Promise<ScreenableTab[]> =>
-        screenTabs.getAllScreenTabs(client, parameters),
-      addScreenTab: (parameters: AddScreenTab): Promise<ScreenableTab> => screenTabs.addScreenTab(client, parameters),
-      renameScreenTab: (parameters: RenameScreenTab): Promise<ScreenableTab> =>
-        screenTabs.renameScreenTab(client, parameters),
-      deleteScreenTab: (parameters: DeleteScreenTab): Promise<void> => screenTabs.deleteScreenTab(client, parameters),
-      moveScreenTab: (parameters: MoveScreenTab): Promise<void> => screenTabs.moveScreenTab(client, parameters),
+      getAllScreenTabs: (parameters: GetAllScreenTabs, options?: RequestOptions): Promise<ScreenableTab[]> =>
+        screenTabs.getAllScreenTabs(client, parameters, options),
+      addScreenTab: (parameters: AddScreenTab, options?: RequestOptions): Promise<ScreenableTab> =>
+        screenTabs.addScreenTab(client, parameters, options),
+      renameScreenTab: (parameters: RenameScreenTab, options?: RequestOptions): Promise<ScreenableTab> =>
+        screenTabs.renameScreenTab(client, parameters, options),
+      deleteScreenTab: (parameters: DeleteScreenTab, options?: RequestOptions): Promise<void> =>
+        screenTabs.deleteScreenTab(client, parameters, options),
+      moveScreenTab: (parameters: MoveScreenTab, options?: RequestOptions): Promise<void> =>
+        screenTabs.moveScreenTab(client, parameters, options),
     },
     screenTabFields: {
-      getAllScreenTabFields: (parameters: GetAllScreenTabFields): Promise<ScreenableField[]> =>
-        screenTabFields.getAllScreenTabFields(client, parameters),
-      addScreenTabField: (parameters: AddScreenTabField): Promise<ScreenableField> =>
-        screenTabFields.addScreenTabField(client, parameters),
-      removeScreenTabField: (parameters: RemoveScreenTabField): Promise<void> =>
-        screenTabFields.removeScreenTabField(client, parameters),
-      moveScreenTabField: (parameters: MoveScreenTabField): Promise<void> =>
-        screenTabFields.moveScreenTabField(client, parameters),
+      getAllScreenTabFields: (
+        parameters: GetAllScreenTabFields,
+        options?: RequestOptions,
+      ): Promise<ScreenableField[]> => screenTabFields.getAllScreenTabFields(client, parameters, options),
+      addScreenTabField: (parameters: AddScreenTabField, options?: RequestOptions): Promise<ScreenableField> =>
+        screenTabFields.addScreenTabField(client, parameters, options),
+      removeScreenTabField: (parameters: RemoveScreenTabField, options?: RequestOptions): Promise<void> =>
+        screenTabFields.removeScreenTabField(client, parameters, options),
+      moveScreenTabField: (parameters: MoveScreenTabField, options?: RequestOptions): Promise<void> =>
+        screenTabFields.moveScreenTabField(client, parameters, options),
     },
     screenSchemes: {
-      getScreenSchemes: (parameters?: GetScreenSchemes): Promise<Page<ScreenScheme>> =>
-        screenSchemes.getScreenSchemes(client, parameters),
-      createScreenScheme: (parameters: CreateScreenScheme): Promise<ScreenSchemeId> =>
-        screenSchemes.createScreenScheme(client, parameters),
-      updateScreenScheme: (parameters: UpdateScreenScheme): Promise<void> =>
-        screenSchemes.updateScreenScheme(client, parameters),
-      deleteScreenScheme: (parameters: DeleteScreenScheme): Promise<void> =>
-        screenSchemes.deleteScreenScheme(client, parameters),
+      getScreenSchemes: (parameters?: GetScreenSchemes, options?: RequestOptions): Promise<Page<ScreenScheme>> =>
+        screenSchemes.getScreenSchemes(client, parameters, options),
+      createScreenScheme: (parameters: CreateScreenScheme, options?: RequestOptions): Promise<ScreenSchemeId> =>
+        screenSchemes.createScreenScheme(client, parameters, options),
+      updateScreenScheme: (parameters: UpdateScreenScheme, options?: RequestOptions): Promise<void> =>
+        screenSchemes.updateScreenScheme(client, parameters, options),
+      deleteScreenScheme: (parameters: DeleteScreenScheme, options?: RequestOptions): Promise<void> =>
+        screenSchemes.deleteScreenScheme(client, parameters, options),
     },
     serverInfo: {
-      getServerInfo: (): Promise<ServerInformation> => serverInfo.getServerInfo(client),
+      getServerInfo: (options?: RequestOptions): Promise<ServerInformation> =>
+        serverInfo.getServerInfo(client, options),
     },
     issueNavigatorSettings: {
-      getIssueNavigatorDefaultColumns: (): Promise<ColumnItem[]> =>
-        issueNavigatorSettings.getIssueNavigatorDefaultColumns(client),
-      setIssueNavigatorDefaultColumns: (parameters: SetIssueNavigatorDefaultColumns): Promise<void> =>
-        issueNavigatorSettings.setIssueNavigatorDefaultColumns(client, parameters),
+      getIssueNavigatorDefaultColumns: (options?: RequestOptions): Promise<ColumnItem[]> =>
+        issueNavigatorSettings.getIssueNavigatorDefaultColumns(client, options),
+      setIssueNavigatorDefaultColumns: (
+        parameters: SetIssueNavigatorDefaultColumns,
+        options?: RequestOptions,
+      ): Promise<void> => issueNavigatorSettings.setIssueNavigatorDefaultColumns(client, parameters, options),
     },
     workflowStatuses: {
-      getStatuses: (): Promise<StatusDetails[]> => workflowStatuses.getStatuses(client),
-      getStatus: (parameters: GetStatus): Promise<StatusDetails> => workflowStatuses.getStatus(client, parameters),
+      getStatuses: (options?: RequestOptions): Promise<StatusDetails[]> =>
+        workflowStatuses.getStatuses(client, options),
+      getStatus: (parameters: GetStatus, options?: RequestOptions): Promise<StatusDetails> =>
+        workflowStatuses.getStatus(client, parameters, options),
     },
     workflowStatusCategories: {
-      getStatusCategories: (): Promise<StatusCategory[]> => workflowStatusCategories.getStatusCategories(client),
-      getStatusCategory: (parameters: GetStatusCategory): Promise<StatusCategory> =>
-        workflowStatusCategories.getStatusCategory(client, parameters),
+      getStatusCategories: (options?: RequestOptions): Promise<StatusCategory[]> =>
+        workflowStatusCategories.getStatusCategories(client, options),
+      getStatusCategory: (parameters: GetStatusCategory, options?: RequestOptions): Promise<StatusCategory> =>
+        workflowStatusCategories.getStatusCategory(client, parameters, options),
     },
     status: {
-      getStatusesById: (parameters: GetStatusesById): Promise<JiraStatus[]> =>
-        status.getStatusesById(client, parameters),
-      createStatuses: (parameters: CreateStatuses): Promise<JiraStatus[]> => status.createStatuses(client, parameters),
-      updateStatuses: (parameters: UpdateStatuses): Promise<void> => status.updateStatuses(client, parameters),
-      deleteStatusesById: (parameters: DeleteStatusesById): Promise<void> =>
-        status.deleteStatusesById(client, parameters),
-      getStatusesByName: (parameters: GetStatusesByName): Promise<JiraStatus[]> =>
-        status.getStatusesByName(client, parameters),
-      search: (parameters?: Search): Promise<PageOfStatuses> => status.search(client, parameters),
+      getStatusesById: (parameters: GetStatusesById, options?: RequestOptions): Promise<JiraStatus[]> =>
+        status.getStatusesById(client, parameters, options),
+      createStatuses: (parameters: CreateStatuses, options?: RequestOptions): Promise<JiraStatus[]> =>
+        status.createStatuses(client, parameters, options),
+      updateStatuses: (parameters: UpdateStatuses, options?: RequestOptions): Promise<void> =>
+        status.updateStatuses(client, parameters, options),
+      deleteStatusesById: (parameters: DeleteStatusesById, options?: RequestOptions): Promise<void> =>
+        status.deleteStatusesById(client, parameters, options),
+      getStatusesByName: (parameters: GetStatusesByName, options?: RequestOptions): Promise<JiraStatus[]> =>
+        status.getStatusesByName(client, parameters, options),
+      search: (parameters?: Search, options?: RequestOptions): Promise<PageOfStatuses> =>
+        status.search(client, parameters, options),
       getProjectIssueTypeUsagesForStatus: (
         parameters: GetProjectIssueTypeUsagesForStatus,
-      ): Promise<StatusProjectIssueTypeUsageDTO> => status.getProjectIssueTypeUsagesForStatus(client, parameters),
-      getProjectUsagesForStatus: (parameters: GetProjectUsagesForStatus): Promise<StatusProjectUsageDTO> =>
-        status.getProjectUsagesForStatus(client, parameters),
-      getWorkflowUsagesForStatus: (parameters: GetWorkflowUsagesForStatus): Promise<StatusWorkflowUsageDTO> =>
-        status.getWorkflowUsagesForStatus(client, parameters),
+        options?: RequestOptions,
+      ): Promise<StatusProjectIssueTypeUsageDTO> =>
+        status.getProjectIssueTypeUsagesForStatus(client, parameters, options),
+      getProjectUsagesForStatus: (
+        parameters: GetProjectUsagesForStatus,
+        options?: RequestOptions,
+      ): Promise<StatusProjectUsageDTO> => status.getProjectUsagesForStatus(client, parameters, options),
+      getWorkflowUsagesForStatus: (
+        parameters: GetWorkflowUsagesForStatus,
+        options?: RequestOptions,
+      ): Promise<StatusWorkflowUsageDTO> => status.getWorkflowUsagesForStatus(client, parameters, options),
     },
     tasks: {
-      getTask: (parameters: GetTask): Promise<TaskProgressObject> => tasks.getTask(client, parameters),
+      getTask: (parameters: GetTask, options?: RequestOptions): Promise<TaskProgressObject> =>
+        tasks.getTask(client, parameters, options),
     },
     uiModificationsApps: {
-      getUiModifications: (parameters?: GetUiModifications): Promise<Page<UiModificationDetails>> =>
-        uiModificationsApps.getUiModifications(client, parameters),
-      createUiModification: (parameters: CreateUiModification): Promise<UiModificationIdentifiers> =>
-        uiModificationsApps.createUiModification(client, parameters),
-      updateUiModification: (parameters: UpdateUiModification): Promise<void> =>
-        uiModificationsApps.updateUiModification(client, parameters),
-      deleteUiModification: (parameters: DeleteUiModification): Promise<void> =>
-        uiModificationsApps.deleteUiModification(client, parameters),
+      getUiModifications: (
+        parameters?: GetUiModifications,
+        options?: RequestOptions,
+      ): Promise<Page<UiModificationDetails>> => uiModificationsApps.getUiModifications(client, parameters, options),
+      createUiModification: (
+        parameters: CreateUiModification,
+        options?: RequestOptions,
+      ): Promise<UiModificationIdentifiers> => uiModificationsApps.createUiModification(client, parameters, options),
+      updateUiModification: (parameters: UpdateUiModification, options?: RequestOptions): Promise<void> =>
+        uiModificationsApps.updateUiModification(client, parameters, options),
+      deleteUiModification: (parameters: DeleteUiModification, options?: RequestOptions): Promise<void> =>
+        uiModificationsApps.deleteUiModification(client, parameters, options),
     },
     users: {
-      getUser: (parameters?: GetUser): Promise<DashboardUser> => users.getUser(client, parameters),
-      createUser: (parameters: CreateUser): Promise<DashboardUser> => users.createUser(client, parameters),
-      removeUser: (parameters: RemoveUser): Promise<void> => users.removeUser(client, parameters),
-      getUserDefaultColumns: (parameters?: GetUserDefaultColumns): Promise<ColumnItem[]> =>
-        users.getUserDefaultColumns(client, parameters),
-      setUserColumns: (parameters: SetUserColumns): Promise<void> => users.setUserColumns(client, parameters),
-      resetUserColumns: (parameters: ResetUserColumns): Promise<void> => users.resetUserColumns(client, parameters),
-      getUserEmail: (parameters: GetUserEmail): Promise<UnrestrictedUserEmail> =>
-        users.getUserEmail(client, parameters),
-      getUserEmailBulk: (parameters: GetUserEmailBulk): Promise<UnrestrictedUserEmail> =>
-        users.getUserEmailBulk(client, parameters),
-      getUserGroups: (parameters: GetUserGroups): Promise<GroupName[]> => users.getUserGroups(client, parameters),
-      getAllUsersDefault: (parameters?: GetAllUsersDefault): Promise<DashboardUser[]> =>
-        users.getAllUsersDefault(client, parameters),
-      getAllUsers: (parameters?: GetAllUsers): Promise<DashboardUser[]> => users.getAllUsers(client, parameters),
+      getUser: (parameters?: GetUser, options?: RequestOptions): Promise<DashboardUser> =>
+        users.getUser(client, parameters, options),
+      createUser: (parameters: CreateUser, options?: RequestOptions): Promise<DashboardUser> =>
+        users.createUser(client, parameters, options),
+      removeUser: (parameters: RemoveUser, options?: RequestOptions): Promise<void> =>
+        users.removeUser(client, parameters, options),
+      getUserDefaultColumns: (parameters?: GetUserDefaultColumns, options?: RequestOptions): Promise<ColumnItem[]> =>
+        users.getUserDefaultColumns(client, parameters, options),
+      setUserColumns: (parameters: SetUserColumns, options?: RequestOptions): Promise<void> =>
+        users.setUserColumns(client, parameters, options),
+      resetUserColumns: (parameters: ResetUserColumns, options?: RequestOptions): Promise<void> =>
+        users.resetUserColumns(client, parameters, options),
+      getUserEmail: (parameters: GetUserEmail, options?: RequestOptions): Promise<UnrestrictedUserEmail> =>
+        users.getUserEmail(client, parameters, options),
+      getUserEmailBulk: (parameters: GetUserEmailBulk, options?: RequestOptions): Promise<UnrestrictedUserEmail> =>
+        users.getUserEmailBulk(client, parameters, options),
+      getUserGroups: (parameters: GetUserGroups, options?: RequestOptions): Promise<GroupName[]> =>
+        users.getUserGroups(client, parameters, options),
+      getAllUsersDefault: (parameters?: GetAllUsersDefault, options?: RequestOptions): Promise<DashboardUser[]> =>
+        users.getAllUsersDefault(client, parameters, options),
+      getAllUsers: (parameters?: GetAllUsers, options?: RequestOptions): Promise<DashboardUser[]> =>
+        users.getAllUsers(client, parameters, options),
     },
     userSearch: {
-      findBulkAssignableUsers: (parameters: FindBulkAssignableUsers): Promise<DashboardUser[]> =>
-        userSearch.findBulkAssignableUsers(client, parameters),
-      findAssignableUsers: (parameters?: FindAssignableUsers): Promise<DashboardUser[]> =>
-        userSearch.findAssignableUsers(client, parameters),
-      findUsersWithAllPermissions: (parameters: FindUsersWithAllPermissions): Promise<DashboardUser[]> =>
-        userSearch.findUsersWithAllPermissions(client, parameters),
-      findUsersForPicker: (parameters: FindUsersForPicker): Promise<FoundUsers> =>
-        userSearch.findUsersForPicker(client, parameters),
-      findUsers: (parameters?: FindUsers): Promise<DashboardUser[]> => userSearch.findUsers(client, parameters),
-      findUsersByQuery: (parameters: FindUsersByQuery): Promise<Page<DashboardUser>> =>
-        userSearch.findUsersByQuery(client, parameters),
-      findUserKeysByQuery: (parameters: FindUserKeysByQuery): Promise<Page<UserKey>> =>
-        userSearch.findUserKeysByQuery(client, parameters),
-      findUsersWithBrowsePermission: (parameters?: FindUsersWithBrowsePermission): Promise<DashboardUser[]> =>
-        userSearch.findUsersWithBrowsePermission(client, parameters),
+      findBulkAssignableUsers: (
+        parameters: FindBulkAssignableUsers,
+        options?: RequestOptions,
+      ): Promise<DashboardUser[]> => userSearch.findBulkAssignableUsers(client, parameters, options),
+      findAssignableUsers: (parameters?: FindAssignableUsers, options?: RequestOptions): Promise<DashboardUser[]> =>
+        userSearch.findAssignableUsers(client, parameters, options),
+      findUsersWithAllPermissions: (
+        parameters: FindUsersWithAllPermissions,
+        options?: RequestOptions,
+      ): Promise<DashboardUser[]> => userSearch.findUsersWithAllPermissions(client, parameters, options),
+      findUsersForPicker: (parameters: FindUsersForPicker, options?: RequestOptions): Promise<FoundUsers> =>
+        userSearch.findUsersForPicker(client, parameters, options),
+      findUsers: (parameters?: FindUsers, options?: RequestOptions): Promise<DashboardUser[]> =>
+        userSearch.findUsers(client, parameters, options),
+      findUsersByQuery: (parameters: FindUsersByQuery, options?: RequestOptions): Promise<Page<DashboardUser>> =>
+        userSearch.findUsersByQuery(client, parameters, options),
+      findUserKeysByQuery: (parameters: FindUserKeysByQuery, options?: RequestOptions): Promise<Page<UserKey>> =>
+        userSearch.findUserKeysByQuery(client, parameters, options),
+      findUsersWithBrowsePermission: (
+        parameters?: FindUsersWithBrowsePermission,
+        options?: RequestOptions,
+      ): Promise<DashboardUser[]> => userSearch.findUsersWithBrowsePermission(client, parameters, options),
     },
     userProperties: {
-      getUserPropertyKeys: (parameters?: GetUserPropertyKeys): Promise<PropertyKeys> =>
-        userProperties.getUserPropertyKeys(client, parameters),
-      getUserProperty: (parameters: GetUserProperty): Promise<EntityProperty> =>
-        userProperties.getUserProperty(client, parameters),
-      setUserProperty: (parameters: SetUserProperty): Promise<void> =>
-        userProperties.setUserProperty(client, parameters),
-      deleteUserProperty: (parameters: DeleteUserProperty): Promise<void> =>
-        userProperties.deleteUserProperty(client, parameters),
+      getUserPropertyKeys: (parameters?: GetUserPropertyKeys, options?: RequestOptions): Promise<PropertyKeys> =>
+        userProperties.getUserPropertyKeys(client, parameters, options),
+      getUserProperty: (parameters: GetUserProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        userProperties.getUserProperty(client, parameters, options),
+      setUserProperty: (parameters: SetUserProperty, options?: RequestOptions): Promise<void> =>
+        userProperties.setUserProperty(client, parameters, options),
+      deleteUserProperty: (parameters: DeleteUserProperty, options?: RequestOptions): Promise<void> =>
+        userProperties.deleteUserProperty(client, parameters, options),
     },
     webhooks: {
-      getDynamicWebhooksForApp: (parameters?: GetDynamicWebhooksForApp): Promise<Page<Webhook>> =>
-        webhooks.getDynamicWebhooksForApp(client, parameters),
-      registerDynamicWebhooks: (parameters: RegisterDynamicWebhooks): Promise<ContainerForRegisteredWebhooks> =>
-        webhooks.registerDynamicWebhooks(client, parameters),
-      deleteWebhookById: (parameters: DeleteWebhookById): Promise<void> =>
-        webhooks.deleteWebhookById(client, parameters),
-      refreshWebhooks: (parameters: RefreshWebhooks): Promise<WebhooksExpirationDate> =>
-        webhooks.refreshWebhooks(client, parameters),
+      getDynamicWebhooksForApp: (
+        parameters?: GetDynamicWebhooksForApp,
+        options?: RequestOptions,
+      ): Promise<Page<Webhook>> => webhooks.getDynamicWebhooksForApp(client, parameters, options),
+      registerDynamicWebhooks: (
+        parameters: RegisterDynamicWebhooks,
+        options?: RequestOptions,
+      ): Promise<ContainerForRegisteredWebhooks> => webhooks.registerDynamicWebhooks(client, parameters, options),
+      deleteWebhookById: (parameters: DeleteWebhookById, options?: RequestOptions): Promise<void> =>
+        webhooks.deleteWebhookById(client, parameters, options),
+      refreshWebhooks: (parameters: RefreshWebhooks, options?: RequestOptions): Promise<WebhooksExpirationDate> =>
+        webhooks.refreshWebhooks(client, parameters, options),
     },
     workflows: {
-      readWorkflowFromHistory: (parameters: ReadWorkflowFromHistory): Promise<WorkflowHistoryReadResponseDTO> =>
-        workflows.readWorkflowFromHistory(client, parameters),
-      listWorkflowHistory: (parameters: ListWorkflowHistory): Promise<WorkflowHistoryListResponseDTO> =>
-        workflows.listWorkflowHistory(client, parameters),
-      deleteInactiveWorkflow: (parameters: DeleteInactiveWorkflow): Promise<void> =>
-        workflows.deleteInactiveWorkflow(client, parameters),
+      readWorkflowFromHistory: (
+        parameters: ReadWorkflowFromHistory,
+        options?: RequestOptions,
+      ): Promise<WorkflowHistoryReadResponseDTO> => workflows.readWorkflowFromHistory(client, parameters, options),
+      listWorkflowHistory: (
+        parameters: ListWorkflowHistory,
+        options?: RequestOptions,
+      ): Promise<WorkflowHistoryListResponseDTO> => workflows.listWorkflowHistory(client, parameters, options),
+      deleteInactiveWorkflow: (parameters: DeleteInactiveWorkflow, options?: RequestOptions): Promise<void> =>
+        workflows.deleteInactiveWorkflow(client, parameters, options),
       getWorkflowProjectIssueTypeUsages: (
         parameters: GetWorkflowProjectIssueTypeUsages,
-      ): Promise<WorkflowProjectIssueTypeUsageDTO> => workflows.getWorkflowProjectIssueTypeUsages(client, parameters),
-      getProjectUsagesForWorkflow: (parameters: GetProjectUsagesForWorkflow): Promise<WorkflowProjectUsageDTO> =>
-        workflows.getProjectUsagesForWorkflow(client, parameters),
+        options?: RequestOptions,
+      ): Promise<WorkflowProjectIssueTypeUsageDTO> =>
+        workflows.getWorkflowProjectIssueTypeUsages(client, parameters, options),
+      getProjectUsagesForWorkflow: (
+        parameters: GetProjectUsagesForWorkflow,
+        options?: RequestOptions,
+      ): Promise<WorkflowProjectUsageDTO> => workflows.getProjectUsagesForWorkflow(client, parameters, options),
       getWorkflowSchemeUsagesForWorkflow: (
         parameters: GetWorkflowSchemeUsagesForWorkflow,
-      ): Promise<WorkflowSchemeUsageDTO> => workflows.getWorkflowSchemeUsagesForWorkflow(client, parameters),
-      readWorkflows: (parameters: ReadWorkflows): Promise<WorkflowReadResponse> =>
-        workflows.readWorkflows(client, parameters),
-      workflowCapabilities: (parameters?: WorkflowCapabilities): Promise<WorkflowCapabilitiesModel> =>
-        workflows.workflowCapabilities(client, parameters),
-      createWorkflows: (parameters: CreateWorkflows): Promise<WorkflowCreateResponse> =>
-        workflows.createWorkflows(client, parameters),
-      validateCreateWorkflows: (parameters: ValidateCreateWorkflows): Promise<WorkflowValidationErrorList> =>
-        workflows.validateCreateWorkflows(client, parameters),
-      getDefaultEditor: (): Promise<DefaultWorkflowEditorResponse> => workflows.getDefaultEditor(client),
-      readWorkflowPreviews: (parameters: ReadWorkflowPreviews): Promise<WorkflowPreviewResponse> =>
-        workflows.readWorkflowPreviews(client, parameters),
-      searchWorkflows: (parameters?: SearchWorkflows): Promise<WorkflowSearchResponse> =>
-        workflows.searchWorkflows(client, parameters),
-      updateWorkflows: (parameters: UpdateWorkflows): Promise<WorkflowUpdateResponse> =>
-        workflows.updateWorkflows(client, parameters),
-      validateUpdateWorkflows: (parameters: ValidateUpdateWorkflows): Promise<WorkflowValidationErrorList> =>
-        workflows.validateUpdateWorkflows(client, parameters),
+        options?: RequestOptions,
+      ): Promise<WorkflowSchemeUsageDTO> => workflows.getWorkflowSchemeUsagesForWorkflow(client, parameters, options),
+      readWorkflows: (parameters: ReadWorkflows, options?: RequestOptions): Promise<WorkflowReadResponse> =>
+        workflows.readWorkflows(client, parameters, options),
+      workflowCapabilities: (
+        parameters?: WorkflowCapabilities,
+        options?: RequestOptions,
+      ): Promise<WorkflowCapabilitiesModel> => workflows.workflowCapabilities(client, parameters, options),
+      createWorkflows: (parameters: CreateWorkflows, options?: RequestOptions): Promise<WorkflowCreateResponse> =>
+        workflows.createWorkflows(client, parameters, options),
+      validateCreateWorkflows: (
+        parameters: ValidateCreateWorkflows,
+        options?: RequestOptions,
+      ): Promise<WorkflowValidationErrorList> => workflows.validateCreateWorkflows(client, parameters, options),
+      getDefaultEditor: (options?: RequestOptions): Promise<DefaultWorkflowEditorResponse> =>
+        workflows.getDefaultEditor(client, options),
+      readWorkflowPreviews: (
+        parameters: ReadWorkflowPreviews,
+        options?: RequestOptions,
+      ): Promise<WorkflowPreviewResponse> => workflows.readWorkflowPreviews(client, parameters, options),
+      searchWorkflows: (parameters?: SearchWorkflows, options?: RequestOptions): Promise<WorkflowSearchResponse> =>
+        workflows.searchWorkflows(client, parameters, options),
+      updateWorkflows: (parameters: UpdateWorkflows, options?: RequestOptions): Promise<WorkflowUpdateResponse> =>
+        workflows.updateWorkflows(client, parameters, options),
+      validateUpdateWorkflows: (
+        parameters: ValidateUpdateWorkflows,
+        options?: RequestOptions,
+      ): Promise<WorkflowValidationErrorList> => workflows.validateUpdateWorkflows(client, parameters, options),
     },
     workflowTransitionRules: {
       getWorkflowTransitionRuleConfigurations: (
         parameters: GetWorkflowTransitionRuleConfigurations,
+        options?: RequestOptions,
       ): Promise<Page<WorkflowTransitionRules>> =>
-        workflowTransitionRules.getWorkflowTransitionRuleConfigurations(client, parameters),
+        workflowTransitionRules.getWorkflowTransitionRuleConfigurations(client, parameters, options),
       updateWorkflowTransitionRuleConfigurations: (
         parameters: UpdateWorkflowTransitionRuleConfigurations,
+        options?: RequestOptions,
       ): Promise<WorkflowTransitionRulesUpdateErrors> =>
-        workflowTransitionRules.updateWorkflowTransitionRuleConfigurations(client, parameters),
+        workflowTransitionRules.updateWorkflowTransitionRuleConfigurations(client, parameters, options),
       deleteWorkflowTransitionRuleConfigurations: (
         parameters: DeleteWorkflowTransitionRuleConfigurations,
+        options?: RequestOptions,
       ): Promise<WorkflowTransitionRulesUpdateErrors> =>
-        workflowTransitionRules.deleteWorkflowTransitionRuleConfigurations(client, parameters),
+        workflowTransitionRules.deleteWorkflowTransitionRuleConfigurations(client, parameters, options),
     },
     workflowSchemes: {
-      getAllWorkflowSchemes: (parameters?: GetAllWorkflowSchemes): Promise<Page<WorkflowScheme>> =>
-        workflowSchemes.getAllWorkflowSchemes(client, parameters),
-      createWorkflowScheme: (parameters: CreateWorkflowScheme): Promise<WorkflowScheme> =>
-        workflowSchemes.createWorkflowScheme(client, parameters),
-      readWorkflowSchemes: (parameters: ReadWorkflowSchemes): Promise<WorkflowSchemeReadResponse[]> =>
-        workflowSchemes.readWorkflowSchemes(client, parameters),
-      updateSchemes: (parameters: UpdateSchemes): Promise<TaskProgressObject> =>
-        workflowSchemes.updateSchemes(client, parameters),
+      getAllWorkflowSchemes: (
+        parameters?: GetAllWorkflowSchemes,
+        options?: RequestOptions,
+      ): Promise<Page<WorkflowScheme>> => workflowSchemes.getAllWorkflowSchemes(client, parameters, options),
+      createWorkflowScheme: (parameters: CreateWorkflowScheme, options?: RequestOptions): Promise<WorkflowScheme> =>
+        workflowSchemes.createWorkflowScheme(client, parameters, options),
+      readWorkflowSchemes: (
+        parameters: ReadWorkflowSchemes,
+        options?: RequestOptions,
+      ): Promise<WorkflowSchemeReadResponse[]> => workflowSchemes.readWorkflowSchemes(client, parameters, options),
+      updateSchemes: (parameters: UpdateSchemes, options?: RequestOptions): Promise<TaskProgressObject> =>
+        workflowSchemes.updateSchemes(client, parameters, options),
       getRequiredWorkflowSchemeMappings: (
         parameters: GetRequiredWorkflowSchemeMappings,
+        options?: RequestOptions,
       ): Promise<WorkflowSchemeUpdateRequiredMappingsResponse> =>
-        workflowSchemes.getRequiredWorkflowSchemeMappings(client, parameters),
-      getWorkflowScheme: (parameters: GetWorkflowScheme): Promise<WorkflowScheme> =>
-        workflowSchemes.getWorkflowScheme(client, parameters),
-      updateWorkflowScheme: (parameters: UpdateWorkflowScheme): Promise<WorkflowScheme> =>
-        workflowSchemes.updateWorkflowScheme(client, parameters),
-      deleteWorkflowScheme: (parameters: DeleteWorkflowScheme): Promise<void> =>
-        workflowSchemes.deleteWorkflowScheme(client, parameters),
-      getDefaultWorkflow: (parameters: GetDefaultWorkflow): Promise<DefaultWorkflow> =>
-        workflowSchemes.getDefaultWorkflow(client, parameters),
-      updateDefaultWorkflow: (parameters: UpdateDefaultWorkflow): Promise<WorkflowScheme> =>
-        workflowSchemes.updateDefaultWorkflow(client, parameters),
-      deleteDefaultWorkflow: (parameters: DeleteDefaultWorkflow): Promise<WorkflowScheme> =>
-        workflowSchemes.deleteDefaultWorkflow(client, parameters),
-      getWorkflowSchemeIssueType: (parameters: GetWorkflowSchemeIssueType): Promise<IssueTypeWorkflowMapping> =>
-        workflowSchemes.getWorkflowSchemeIssueType(client, parameters),
-      setWorkflowSchemeIssueType: (parameters: SetWorkflowSchemeIssueType): Promise<WorkflowScheme> =>
-        workflowSchemes.setWorkflowSchemeIssueType(client, parameters),
-      deleteWorkflowSchemeIssueType: (parameters: DeleteWorkflowSchemeIssueType): Promise<WorkflowScheme> =>
-        workflowSchemes.deleteWorkflowSchemeIssueType(client, parameters),
-      getWorkflow: (parameters: GetWorkflow): Promise<IssueTypesWorkflowMapping> =>
-        workflowSchemes.getWorkflow(client, parameters),
-      updateWorkflowMapping: (parameters: UpdateWorkflowMapping): Promise<WorkflowScheme> =>
-        workflowSchemes.updateWorkflowMapping(client, parameters),
-      deleteWorkflowMapping: (parameters: DeleteWorkflowMapping): Promise<void> =>
-        workflowSchemes.deleteWorkflowMapping(client, parameters),
+        workflowSchemes.getRequiredWorkflowSchemeMappings(client, parameters, options),
+      getWorkflowScheme: (parameters: GetWorkflowScheme, options?: RequestOptions): Promise<WorkflowScheme> =>
+        workflowSchemes.getWorkflowScheme(client, parameters, options),
+      updateWorkflowScheme: (parameters: UpdateWorkflowScheme, options?: RequestOptions): Promise<WorkflowScheme> =>
+        workflowSchemes.updateWorkflowScheme(client, parameters, options),
+      deleteWorkflowScheme: (parameters: DeleteWorkflowScheme, options?: RequestOptions): Promise<void> =>
+        workflowSchemes.deleteWorkflowScheme(client, parameters, options),
+      getDefaultWorkflow: (parameters: GetDefaultWorkflow, options?: RequestOptions): Promise<DefaultWorkflow> =>
+        workflowSchemes.getDefaultWorkflow(client, parameters, options),
+      updateDefaultWorkflow: (parameters: UpdateDefaultWorkflow, options?: RequestOptions): Promise<WorkflowScheme> =>
+        workflowSchemes.updateDefaultWorkflow(client, parameters, options),
+      deleteDefaultWorkflow: (parameters: DeleteDefaultWorkflow, options?: RequestOptions): Promise<WorkflowScheme> =>
+        workflowSchemes.deleteDefaultWorkflow(client, parameters, options),
+      getWorkflowSchemeIssueType: (
+        parameters: GetWorkflowSchemeIssueType,
+        options?: RequestOptions,
+      ): Promise<IssueTypeWorkflowMapping> => workflowSchemes.getWorkflowSchemeIssueType(client, parameters, options),
+      setWorkflowSchemeIssueType: (
+        parameters: SetWorkflowSchemeIssueType,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> => workflowSchemes.setWorkflowSchemeIssueType(client, parameters, options),
+      deleteWorkflowSchemeIssueType: (
+        parameters: DeleteWorkflowSchemeIssueType,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> => workflowSchemes.deleteWorkflowSchemeIssueType(client, parameters, options),
+      getWorkflow: (parameters: GetWorkflow, options?: RequestOptions): Promise<IssueTypesWorkflowMapping> =>
+        workflowSchemes.getWorkflow(client, parameters, options),
+      updateWorkflowMapping: (parameters: UpdateWorkflowMapping, options?: RequestOptions): Promise<WorkflowScheme> =>
+        workflowSchemes.updateWorkflowMapping(client, parameters, options),
+      deleteWorkflowMapping: (parameters: DeleteWorkflowMapping, options?: RequestOptions): Promise<void> =>
+        workflowSchemes.deleteWorkflowMapping(client, parameters, options),
       getProjectUsagesForWorkflowScheme: (
         parameters: GetProjectUsagesForWorkflowScheme,
+        options?: RequestOptions,
       ): Promise<WorkflowSchemeProjectUsageDTO> =>
-        workflowSchemes.getProjectUsagesForWorkflowScheme(client, parameters),
+        workflowSchemes.getProjectUsagesForWorkflowScheme(client, parameters, options),
     },
     workflowSchemeProjectAssociations: {
       getWorkflowSchemeProjectAssociations: (
         parameters: GetWorkflowSchemeProjectAssociations,
+        options?: RequestOptions,
       ): Promise<ContainerOfWorkflowSchemeAssociations> =>
-        workflowSchemeProjectAssociations.getWorkflowSchemeProjectAssociations(client, parameters),
-      assignSchemeToProject: (parameters: AssignSchemeToProject): Promise<void> =>
-        workflowSchemeProjectAssociations.assignSchemeToProject(client, parameters),
+        workflowSchemeProjectAssociations.getWorkflowSchemeProjectAssociations(client, parameters, options),
+      assignSchemeToProject: (parameters: AssignSchemeToProject, options?: RequestOptions): Promise<void> =>
+        workflowSchemeProjectAssociations.assignSchemeToProject(client, parameters, options),
     },
     workflowSchemeDrafts: {
-      createWorkflowSchemeDraftFromParent: (parameters: CreateWorkflowSchemeDraftFromParent): Promise<WorkflowScheme> =>
-        workflowSchemeDrafts.createWorkflowSchemeDraftFromParent(client, parameters),
-      getWorkflowSchemeDraft: (parameters: GetWorkflowSchemeDraft): Promise<WorkflowScheme> =>
-        workflowSchemeDrafts.getWorkflowSchemeDraft(client, parameters),
-      updateWorkflowSchemeDraft: (parameters: UpdateWorkflowSchemeDraft): Promise<WorkflowScheme> =>
-        workflowSchemeDrafts.updateWorkflowSchemeDraft(client, parameters),
-      deleteWorkflowSchemeDraft: (parameters: DeleteWorkflowSchemeDraft): Promise<void> =>
-        workflowSchemeDrafts.deleteWorkflowSchemeDraft(client, parameters),
-      getDraftDefaultWorkflow: (parameters: GetDraftDefaultWorkflow): Promise<DefaultWorkflow> =>
-        workflowSchemeDrafts.getDraftDefaultWorkflow(client, parameters),
-      updateDraftDefaultWorkflow: (parameters: UpdateDraftDefaultWorkflow): Promise<WorkflowScheme> =>
-        workflowSchemeDrafts.updateDraftDefaultWorkflow(client, parameters),
-      deleteDraftDefaultWorkflow: (parameters: DeleteDraftDefaultWorkflow): Promise<WorkflowScheme> =>
-        workflowSchemeDrafts.deleteDraftDefaultWorkflow(client, parameters),
+      createWorkflowSchemeDraftFromParent: (
+        parameters: CreateWorkflowSchemeDraftFromParent,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> =>
+        workflowSchemeDrafts.createWorkflowSchemeDraftFromParent(client, parameters, options),
+      getWorkflowSchemeDraft: (parameters: GetWorkflowSchemeDraft, options?: RequestOptions): Promise<WorkflowScheme> =>
+        workflowSchemeDrafts.getWorkflowSchemeDraft(client, parameters, options),
+      updateWorkflowSchemeDraft: (
+        parameters: UpdateWorkflowSchemeDraft,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> => workflowSchemeDrafts.updateWorkflowSchemeDraft(client, parameters, options),
+      deleteWorkflowSchemeDraft: (parameters: DeleteWorkflowSchemeDraft, options?: RequestOptions): Promise<void> =>
+        workflowSchemeDrafts.deleteWorkflowSchemeDraft(client, parameters, options),
+      getDraftDefaultWorkflow: (
+        parameters: GetDraftDefaultWorkflow,
+        options?: RequestOptions,
+      ): Promise<DefaultWorkflow> => workflowSchemeDrafts.getDraftDefaultWorkflow(client, parameters, options),
+      updateDraftDefaultWorkflow: (
+        parameters: UpdateDraftDefaultWorkflow,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> => workflowSchemeDrafts.updateDraftDefaultWorkflow(client, parameters, options),
+      deleteDraftDefaultWorkflow: (
+        parameters: DeleteDraftDefaultWorkflow,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> => workflowSchemeDrafts.deleteDraftDefaultWorkflow(client, parameters, options),
       getWorkflowSchemeDraftIssueType: (
         parameters: GetWorkflowSchemeDraftIssueType,
-      ): Promise<IssueTypeWorkflowMapping> => workflowSchemeDrafts.getWorkflowSchemeDraftIssueType(client, parameters),
-      setWorkflowSchemeDraftIssueType: (parameters: SetWorkflowSchemeDraftIssueType): Promise<WorkflowScheme> =>
-        workflowSchemeDrafts.setWorkflowSchemeDraftIssueType(client, parameters),
-      deleteWorkflowSchemeDraftIssueType: (parameters: DeleteWorkflowSchemeDraftIssueType): Promise<WorkflowScheme> =>
-        workflowSchemeDrafts.deleteWorkflowSchemeDraftIssueType(client, parameters),
-      publishDraftWorkflowScheme: (parameters: PublishDraftWorkflowScheme): Promise<void> =>
-        workflowSchemeDrafts.publishDraftWorkflowScheme(client, parameters),
-      getDraftWorkflow: (parameters: GetDraftWorkflow): Promise<IssueTypesWorkflowMapping> =>
-        workflowSchemeDrafts.getDraftWorkflow(client, parameters),
-      updateDraftWorkflowMapping: (parameters: UpdateDraftWorkflowMapping): Promise<WorkflowScheme> =>
-        workflowSchemeDrafts.updateDraftWorkflowMapping(client, parameters),
-      deleteDraftWorkflowMapping: (parameters: DeleteDraftWorkflowMapping): Promise<void> =>
-        workflowSchemeDrafts.deleteDraftWorkflowMapping(client, parameters),
+        options?: RequestOptions,
+      ): Promise<IssueTypeWorkflowMapping> =>
+        workflowSchemeDrafts.getWorkflowSchemeDraftIssueType(client, parameters, options),
+      setWorkflowSchemeDraftIssueType: (
+        parameters: SetWorkflowSchemeDraftIssueType,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> => workflowSchemeDrafts.setWorkflowSchemeDraftIssueType(client, parameters, options),
+      deleteWorkflowSchemeDraftIssueType: (
+        parameters: DeleteWorkflowSchemeDraftIssueType,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> =>
+        workflowSchemeDrafts.deleteWorkflowSchemeDraftIssueType(client, parameters, options),
+      publishDraftWorkflowScheme: (parameters: PublishDraftWorkflowScheme, options?: RequestOptions): Promise<void> =>
+        workflowSchemeDrafts.publishDraftWorkflowScheme(client, parameters, options),
+      getDraftWorkflow: (parameters: GetDraftWorkflow, options?: RequestOptions): Promise<IssueTypesWorkflowMapping> =>
+        workflowSchemeDrafts.getDraftWorkflow(client, parameters, options),
+      updateDraftWorkflowMapping: (
+        parameters: UpdateDraftWorkflowMapping,
+        options?: RequestOptions,
+      ): Promise<WorkflowScheme> => workflowSchemeDrafts.updateDraftWorkflowMapping(client, parameters, options),
+      deleteDraftWorkflowMapping: (parameters: DeleteDraftWorkflowMapping, options?: RequestOptions): Promise<void> =>
+        workflowSchemeDrafts.deleteDraftWorkflowMapping(client, parameters, options),
     },
     appProperties: {
-      getAddonProperties: (parameters: GetAddonProperties): Promise<PropertyKeys> =>
-        appProperties.getAddonProperties(client, parameters),
-      getAddonProperty: (parameters: GetAddonProperty): Promise<EntityProperty> =>
-        appProperties.getAddonProperty(client, parameters),
-      putAddonProperty: (parameters: PutAddonProperty): Promise<OperationMessage> =>
-        appProperties.putAddonProperty(client, parameters),
-      deleteAddonProperty: (parameters: DeleteAddonProperty): Promise<void> =>
-        appProperties.deleteAddonProperty(client, parameters),
-      getForgeAppPropertyKeys: (): Promise<GetForgeAppPropertyKeys> => appProperties.getForgeAppPropertyKeys(client),
-      getForgeAppProperty: (parameters: GetForgeAppProperty): Promise<GetForgeAppPropertyModel> =>
-        appProperties.getForgeAppProperty(client, parameters),
-      putForgeAppProperty: (parameters: PutForgeAppProperty): Promise<OperationMessage> =>
-        appProperties.putForgeAppProperty(client, parameters),
-      deleteForgeAppProperty: (parameters: DeleteForgeAppProperty): Promise<void> =>
-        appProperties.deleteForgeAppProperty(client, parameters),
+      getAddonProperties: (parameters: GetAddonProperties, options?: RequestOptions): Promise<PropertyKeys> =>
+        appProperties.getAddonProperties(client, parameters, options),
+      getAddonProperty: (parameters: GetAddonProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        appProperties.getAddonProperty(client, parameters, options),
+      putAddonProperty: (parameters: PutAddonProperty, options?: RequestOptions): Promise<OperationMessage> =>
+        appProperties.putAddonProperty(client, parameters, options),
+      deleteAddonProperty: (parameters: DeleteAddonProperty, options?: RequestOptions): Promise<void> =>
+        appProperties.deleteAddonProperty(client, parameters, options),
+      getForgeAppPropertyKeys: (options?: RequestOptions): Promise<GetForgeAppPropertyKeys> =>
+        appProperties.getForgeAppPropertyKeys(client, options),
+      getForgeAppProperty: (
+        parameters: GetForgeAppProperty,
+        options?: RequestOptions,
+      ): Promise<GetForgeAppPropertyModel> => appProperties.getForgeAppProperty(client, parameters, options),
+      putForgeAppProperty: (parameters: PutForgeAppProperty, options?: RequestOptions): Promise<OperationMessage> =>
+        appProperties.putForgeAppProperty(client, parameters, options),
+      deleteForgeAppProperty: (parameters: DeleteForgeAppProperty, options?: RequestOptions): Promise<void> =>
+        appProperties.deleteForgeAppProperty(client, parameters, options),
     },
     dynamicModules: {
-      getModules: (): Promise<ConnectModules> => dynamicModules.getModules(client),
-      registerModules: (parameters: RegisterModules): Promise<void> =>
-        dynamicModules.registerModules(client, parameters),
-      removeModules: (parameters: RemoveModules): Promise<void> => dynamicModules.removeModules(client, parameters),
+      getModules: (options?: RequestOptions): Promise<ConnectModules> => dynamicModules.getModules(client, options),
+      registerModules: (parameters: RegisterModules, options?: RequestOptions): Promise<void> =>
+        dynamicModules.registerModules(client, parameters, options),
+      removeModules: (parameters: RemoveModules, options?: RequestOptions): Promise<void> =>
+        dynamicModules.removeModules(client, parameters, options),
     },
     appMigration: {
-      updateIssueFields: (parameters: UpdateIssueFields): Promise<void> =>
-        appMigration.updateIssueFields(client, parameters),
-      updateEntityPropertiesValue: (parameters: UpdateEntityPropertiesValue): Promise<void> =>
-        appMigration.updateEntityPropertiesValue(client, parameters),
-      workflowRuleSearch: (parameters: WorkflowRuleSearch): Promise<WorkflowRulesSearchDetails> =>
-        appMigration.workflowRuleSearch(client, parameters),
+      updateIssueFields: (parameters: UpdateIssueFields, options?: RequestOptions): Promise<void> =>
+        appMigration.updateIssueFields(client, parameters, options),
+      updateEntityPropertiesValue: (parameters: UpdateEntityPropertiesValue, options?: RequestOptions): Promise<void> =>
+        appMigration.updateEntityPropertiesValue(client, parameters, options),
+      workflowRuleSearch: (
+        parameters: WorkflowRuleSearch,
+        options?: RequestOptions,
+      ): Promise<WorkflowRulesSearchDetails> => appMigration.workflowRuleSearch(client, parameters, options),
     },
     migrationOfConnectModulesToForge: {
-      fetchMigrationTask: (parameters: FetchMigrationTask): Promise<TaskProgress> =>
-        migrationOfConnectModulesToForge.fetchMigrationTask(client, parameters),
-      submitTask: (parameters: SubmitTask): Promise<void> =>
-        migrationOfConnectModulesToForge.submitTask(client, parameters),
+      fetchMigrationTask: (parameters: FetchMigrationTask, options?: RequestOptions): Promise<TaskProgress> =>
+        migrationOfConnectModulesToForge.fetchMigrationTask(client, parameters, options),
+      submitTask: (parameters: SubmitTask, options?: RequestOptions): Promise<void> =>
+        migrationOfConnectModulesToForge.submitTask(client, parameters, options),
     },
     api: {
       getWorklogsByIssueIdAndWorklogId: (
         parameters: GetWorklogsByIssueIdAndWorklogId,
-      ): Promise<BulkWorklogKeyResponse> => api.getWorklogsByIssueIdAndWorklogId(client, parameters),
+        options?: RequestOptions,
+      ): Promise<BulkWorklogKeyResponse> => api.getWorklogsByIssueIdAndWorklogId(client, parameters, options),
     },
   };
 }

--- a/src/cloud/models/bulkFetchIssueRequest.ts
+++ b/src/cloud/models/bulkFetchIssueRequest.ts
@@ -18,6 +18,10 @@ export const BulkFetchIssueRequestSchema = apiObject({
    *   changelogs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-changelog/#api-rest-api-3-changelog-bulkfetch-post).
    * - `versionedRepresentations` Instead of `fields`, returns `versionedRepresentations` a JSON array containing each
    *   version of a field's value, with the highest numbered item representing the most recent version.
+   *
+   * To request up to 1000 issues in a single call, do not include `changelog`, `editmeta`, `operations`,
+   * `renderedFields`, `transitions`, or `versionedRepresentations` in `expand`. Requests that include any of these can
+   * include at most 100 issues; larger requests are rejected with a 400 error.
    */
   expand: z.array(z.string()).optional(),
   /**
@@ -41,11 +45,22 @@ export const BulkFetchIssueRequestSchema = apiObject({
    * Note: All navigable fields are returned by default. This differs from [GET
    * issue](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueIdOrKey-get)
    * where the default is all fields.
+   *
+   * To request up to 1000 issues in a single call, explicitly list the fields you need: at least one field must be a
+   * positive include (a request containing only exclusions is not eligible), the `*all` and `*navigable` wildcards and
+   * the default navigable field set are not eligible for the higher limit, no more than 100 fields may be listed, and
+   * none of the included fields returns multiple values (for example `comment`, `worklog`, or `attachment`). Requests
+   * that do not meet these conditions can include at most 100 issues; larger requests are rejected with a 400 error.
    */
   fields: z.array(z.string()).optional(),
   /** Reference fields by their key (rather than ID). The default is `false`. */
   fieldsByKeys: z.boolean().optional(),
-  /** An array of issue IDs or issue keys to fetch. You can mix issue IDs and keys in the same query. */
+  /**
+   * An array of issue IDs or issue keys to fetch. You can mix issue IDs and keys in the same query. You can request up
+   * to 100 issues per call. Requests can include up to 1000 issues per call when they meet all of the conditions
+   * described for the `fields` and `expand` parameters. Requests that exceed the applicable limit are rejected with a
+   * 400 error.
+   */
   issueIdsOrKeys: z.array(z.string()),
   /**
    * A list of issue property keys of issue properties to be included in the results. A maximum of 5 issue property keys

--- a/src/cloud/models/createProjectRequest.ts
+++ b/src/cloud/models/createProjectRequest.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { apiObject } from '#/core';
-import { CreateProjectDetailsSchema } from '../models';
+import { CreateProjectDetailsSchema } from './createProjectDetails';
 
 export const CreateProjectRequestSchema = apiObject(CreateProjectDetailsSchema.shape).extend({
   leadAccountId: z.string(),

--- a/src/cloud/models/fieldIdIdentifier.ts
+++ b/src/cloud/models/fieldIdIdentifier.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { apiObject } from '#/core';
-import { FieldIdentifierObjectSchema } from '../models';
+import { FieldIdentifierObjectSchema } from './fieldIdentifierObject';
 
 export const FieldIdIdentifierSchema = apiObject(FieldIdentifierObjectSchema.shape).extend({
   identifier: z.string().optional(),

--- a/src/cloud/models/index.ts
+++ b/src/cloud/models/index.ts
@@ -990,6 +990,8 @@ export * from './licenseMetric';
 
 export * from './licensedApplication';
 
+export * from './limitExceededResponse';
+
 export * from './linkGroup';
 
 export * from './linkIssueRequest';

--- a/src/cloud/models/issueLimitReportResponse.ts
+++ b/src/cloud/models/issueLimitReportResponse.ts
@@ -2,6 +2,12 @@ import { z } from 'zod';
 import { apiObject } from '#/core';
 
 export const IssueLimitReportResponseSchema = apiObject({
+  /**
+   * For each field, the ids of the individual entities breaching the limit, grouped by the id or key of the issue they
+   * belong to. Fields that hold a single value, such as description and environment, map to an empty list because the
+   * issue itself identifies the breaching content
+   */
+  entitiesBreachingLimit: z.record(z.string(), z.any()).optional(),
   /** A list of ids of issues approaching the limit and their field count */
   issuesApproachingLimit: z.record(z.string(), z.any()).optional(),
   /** A list of ids of issues breaching the limit and their field count */

--- a/src/cloud/models/limitExceededResponse.ts
+++ b/src/cloud/models/limitExceededResponse.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { apiObject } from '#/core';
+
+export const LimitExceededResponseSchema = apiObject({
+  current_count: z.number().optional(),
+  entity_type: z.string().optional(),
+  error_code: z.string().optional(),
+  limit_type: z.string().optional(),
+  max_allowed_limit: z.number().optional(),
+  message: z.string().optional(),
+  scope_id: z.string().optional(),
+});
+
+export type LimitExceededResponse = z.infer<typeof LimitExceededResponseSchema>;

--- a/src/cloud/models/projectIdAssociationContext.ts
+++ b/src/cloud/models/projectIdAssociationContext.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { apiObject } from '#/core';
-import { AssociationContextObjectSchema } from '../models';
+import { AssociationContextObjectSchema } from './associationContextObject';
 
 export const ProjectIdAssociationContextSchema = apiObject(AssociationContextObjectSchema.shape).extend({
   identifier: z.number().optional(),

--- a/src/cloud/models/uiModificationContextDetails.ts
+++ b/src/cloud/models/uiModificationContextDetails.ts
@@ -23,8 +23,11 @@ export const UiModificationContextDetailsSchema = apiObject({
    */
   projectId: z.string().optional(),
   /**
-   * The request type ID of the context. Only required for Jira Service Management request create portal view
-   * (`JSMRequestCreate`).
+   * The request type ID of the context. Required for Jira Service Management request create portal view
+   * (`JSMRequestCreate`). Optional for Agent view types (`GICAgentView`, `IssueViewAgentView`,
+   * `IssueTransitionAgentView`): when set on an agent view context, the UI modification applies only to issues with
+   * that request type. Omitting `requestTypeId` does not create a wildcard — it means the context is not scoped to any
+   * specific request type.
    */
   requestTypeId: z.string().optional(),
   /**
@@ -34,13 +37,28 @@ export const UiModificationContextDetailsSchema = apiObject({
    * - `IssueView` - Jira issue view
    * - `IssueTransition` - Jira issue transition
    * - `JSMRequestCreate` - Jira Service Management request create portal view
+   * - `GICAgentView` - Agent view variant of Jira global issue create
+   * - `IssueViewAgentView` - Agent view variant of Jira issue view
+   * - `IssueTransitionAgentView` - Agent view variant of Jira issue transition
    *
-   * For Jira view types (`GIC`, `IssueView`, `IssueTransition`), null is treated as a wildcard, meaning the UI
-   * modification will be applied to all view types. Each Jira context can have a maximum of one wildcard.
+   * For Jira and Agent view types (`GIC`, `IssueView`, `IssueTransition`, `GICAgentView`, `IssueViewAgentView`,
+   * `IssueTransitionAgentView`), null is treated as a wildcard, meaning the UI modification will be applied to all view
+   * types. Each Jira or Agent context can have a maximum of one wildcard.
+   *
+   * Agent view contexts use `projectId` and `issueTypeId` like Jira contexts, and may optionally also set
+   * `requestTypeId`. Agent view contexts must not set `portalId`.
    *
    * Wildcards are not applicable for JSM contexts.
    */
-  viewType: openEnum(['GIC', 'IssueView', 'IssueTransition', 'JSMRequestCreate']).optional(),
+  viewType: openEnum([
+    'GIC',
+    'IssueView',
+    'IssueTransition',
+    'JSMRequestCreate',
+    'GICAgentView',
+    'IssueViewAgentView',
+    'IssueTransitionAgentView',
+  ]).optional(),
 });
 
 export type UiModificationContextDetails = z.infer<typeof UiModificationContextDetailsSchema>;

--- a/src/cloud/parameters/addWatcher.ts
+++ b/src/cloud/parameters/addWatcher.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const AddWatcherSchema = z.object({
   /** The ID or key of the issue. */
   issueIdOrKey: z.string(),
-  body: z.record(z.string(), z.any()),
+  body: z.string(),
 });
 
 export type AddWatcher = z.input<typeof AddWatcherSchema>;

--- a/src/cloud/parameters/setPreference.ts
+++ b/src/cloud/parameters/setPreference.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const SetPreferenceSchema = z.object({
   /** The key of the preference. The maximum length is 255 characters. */
   key: z.string(),
-  body: z.record(z.string(), z.any()),
+  body: z.string(),
 });
 
 export type SetPreference = z.input<typeof SetPreferenceSchema>;

--- a/src/cloud/parameters/updateEntityPropertiesValue.ts
+++ b/src/cloud/parameters/updateEntityPropertiesValue.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { openEnum } from '#/core';
+import { EntityPropertyDetailsSchema } from '../models';
 
 export const UpdateEntityPropertiesValueSchema = z.object({
   /** The app migration transfer ID. */
@@ -16,7 +17,7 @@ export const UpdateEntityPropertiesValueSchema = z.object({
     'BoardProperty',
     'SprintProperty',
   ]),
-  body: z.record(z.string(), z.any()),
+  body: z.array(EntityPropertyDetailsSchema),
 });
 
 export type UpdateEntityPropertiesValue = z.input<typeof UpdateEntityPropertiesValueSchema>;

--- a/src/core/bodyToFetchBody.ts
+++ b/src/core/bodyToFetchBody.ts
@@ -30,9 +30,43 @@ function isBinaryBody(body: unknown): boolean {
   return false;
 }
 
-export function bodyToFetchBody(body: unknown): BodyInit | AsyncIterable<unknown> {
+const FORM_URLENCODED = 'application/x-www-form-urlencoded';
+
+/**
+ * Encodes a plain object the way a form would, dropping what has nothing to send.
+ *
+ * An array becomes a repeated key rather than a comma-joined string, because that is what Jira's column setters read:
+ * `columns=summary&columns=status` sets two columns, `columns=summary,status` sets one with a comma in its name.
+ */
+function toFormBody(body: unknown): URLSearchParams {
+  const encoded = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    if (value === undefined || value === null) continue;
+
+    if (Array.isArray(value)) {
+      for (const item of value) encoded.append(key, String(item));
+
+      continue;
+    }
+
+    encoded.append(key, String(value));
+  }
+
+  return encoded;
+}
+
+export function bodyToFetchBody(body: unknown, contentType?: string): BodyInit | AsyncIterable<unknown> {
   if (isBinaryBody(body)) {
     return body as BodyInit | AsyncIterable<unknown>;
+  }
+
+  if (contentType === FORM_URLENCODED && typeof body === 'object' && body !== null) {
+    return toFormBody(body);
+  }
+
+  if (contentType !== undefined && typeof body === 'string') {
+    return body;
   }
 
   return JSON.stringify(body);

--- a/src/core/createClient.ts
+++ b/src/core/createClient.ts
@@ -4,6 +4,7 @@ import type { Auth, ClientConfig, SendRequestOptions } from './schemas/index.js'
 import type { Client } from './interfaces/index.js';
 import type { OAuth2Manager } from './oauth/index.js';
 import {
+  AuthError,
   createApiError,
   isNetworkError,
   SchemaMismatchError,
@@ -17,6 +18,7 @@ import type { SchemaMismatchReport } from './schemaMismatch.js';
 import { buildUrlWithSearchParams } from './serializeSearchParams.js';
 import { clientConfigSchema } from './schemas/index.js';
 import { createOAuth2Manager } from './oauth/index.js';
+import { createServerOAuth2Manager } from './oauthServer/index.js';
 
 /**
  * Whether this 401 means "missing scope" rather than "stale token".
@@ -48,8 +50,8 @@ function describeValue(value: unknown): string {
  * The value the API sent where the schema listed a set, as text for the report.
  *
  * Audit-only, like everything else on this path, and the value is the whole finding: an enum that grew is repaired by
- * adding the value it grew by, which a type name does not carry. Anything that is not a string is described rather than
- * quoted — a set of numbers or booleans is rare enough that naming its shape is answer enough.
+ * adding the value it grew by, which a type name does not carry. Anything that is not a string is described rather
+ * than quoted — a set of numbers or booleans is rare enough that naming its shape is answer enough.
  */
 function describeValueAtPath(body: unknown, path: readonly PropertyKey[]): string {
   let target = body;
@@ -73,11 +75,7 @@ function describeValueAtPath(body: unknown, path: readonly PropertyKey[]): strin
  * `path` is a zod issue path, so every segment is an object key or an array index, and anything no longer there is
  * simply skipped — the walk describes a body that was just parsed, not an arbitrary structure.
  */
-function takeKeyTypes(
-  body: unknown,
-  path: readonly PropertyKey[],
-  keys: readonly PropertyKey[],
-): Record<string, string> {
+function takeKeyTypes(body: unknown, path: readonly PropertyKey[], keys: readonly PropertyKey[]): Record<string, string> {
   let target = body;
 
   for (const segment of path) {
@@ -99,8 +97,8 @@ function takeKeyTypes(
 }
 
 type DriftFinding =
-  | { kind: 'keys'; path: PropertyKey[]; keys: PropertyKey[] }
-  | { kind: 'value'; path: PropertyKey[]; documented: string[] };
+  | { kind: 'keys', path: PropertyKey[], keys: PropertyKey[] }
+  | { kind: 'value', path: PropertyKey[], documented: string[] };
 
 /**
  * Reads a validation failure as pure schema drift, or decides it is not.
@@ -110,8 +108,8 @@ type DriftFinding =
  *
  * Two kinds count. An undocumented key is a field the specification never described. A value outside a documented set
  * is the same gap one level down: the field is described, its list of values is not complete. Both are the vendor's
- * documentation falling behind the vendor's API, and reporting either as breakage sends the reader after a fault in the
- * wrong codebase.
+ * documentation falling behind the vendor's API, and reporting either as breakage sends the reader after a fault in
+ * the wrong codebase.
  *
  * Unions need the recursion. Zod reports each branch it tried, and branches that failed for their own reasons are
  * simply the wrong branch; what identifies the right one is a branch whose only complaint is undocumented keys. Without
@@ -165,6 +163,83 @@ function isClient(value: ClientConfig | Client): value is Client {
 }
 
 /**
+ * The `X-Seraph-LoginReason` values that mean the credentials were presented and refused.
+ *
+ * `AUTHORISATION_FAILED` is deliberately absent: it means the user is who they claim and merely lacks a permission,
+ * which the status already says and which `ForbiddenError` already describes. `OUT` is absent for the same kind of
+ * reason — a Data Center instance behind SSO sets it on responses that are perfectly legitimate.
+ */
+const SERAPH_LOGIN_FAILURES = new Set(['AUTHENTICATED_FAILED', 'AUTHENTICATION_DENIED']);
+
+/**
+ * Whether the credentials were refused, whatever status the response carries.
+ *
+ * An endpoint that permits anonymous access answers `200` with an anonymous-scope body when the API token is expired
+ * or wrong — an empty list where the caller expected their own data — and says so nowhere but this header. Measured
+ * against a live Cloud site, the header rides on `200`, `400` and `401` alike; measured against Data Center, on `403`
+ * as well. A genuine permission denial is outside the set either way: Cloud sends no header at all, Data Center sends
+ * `OK`.
+ */
+function credentialsRejected(response: Response, hasAuth: boolean): boolean {
+  return hasAuth && SERAPH_LOGIN_FAILURES.has(response.headers.get('x-seraph-loginreason') ?? '');
+}
+
+/**
+ * The headers that were actually given.
+ *
+ * An optional header parameter the caller left out reaches here as `undefined`. Dropping it before the merge does two
+ * things: it keeps the literal text `undefined` off the wire, and it stops an omitted parameter from shadowing a
+ * header the client itself was configured with.
+ */
+function definedHeaders(headers: Record<string, string | undefined> | undefined): Record<string, string> {
+  const defined: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    if (value !== undefined) defined[name] = value;
+  }
+
+  return defined;
+}
+
+/**
+ * `setTimeout` as a promise the signal can cut short.
+ *
+ * Without this an abort would still wait out the whole back-off before anyone noticed it.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal!.reason);
+    };
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** The response body as text and, where it parses, as JSON — the pair every error built here carries. */
+async function readBody(response: Response): Promise<{ text: string, detail: unknown }> {
+  const text = await response.text();
+
+  try {
+    return { text, detail: JSON.parse(text) };
+  } catch {
+    return { text, detail: text };
+  }
+}
+
+/**
  * Base64 for the Basic auth header, the same way in every runtime.
  *
  * `btoa` alone mangles anything outside Latin-1, so the string is encoded to UTF-8 bytes first — a credential may well
@@ -180,13 +255,42 @@ function base64Encode(value: string): string {
   return btoa(binary);
 }
 
+function createManagerFor(
+  auth: Auth | undefined,
+  host: string | undefined,
+  customFetch: ClientConfig['fetch'],
+): OAuth2Manager | undefined {
+  if (auth?.type === 'oauth2') return createOAuth2Manager({ ...auth, fetch: customFetch });
+
+  if (auth?.type === 'oauth2Server') return createServerOAuth2Manager({ ...auth, host: host!, fetch: customFetch });
+
+  return undefined;
+}
+
+function contentTypeHeader(
+  contentType: string | undefined,
+  body: unknown,
+  rawBody: unknown,
+  method: string | undefined,
+): Record<string, string> {
+  if (contentType !== undefined) {
+    return body instanceof URLSearchParams ? {} : { 'Content-Type': contentType };
+  }
+
+  if (shouldSetJsonContentType(rawBody, method)) return { 'Content-Type': 'application/json' };
+
+  return {};
+}
+
 async function getAuthHeaders(auth: Auth): Promise<Record<string, string>> {
-  if (auth.type === 'oauth2') {
+  if (auth.type === 'oauth2' || auth.type === 'oauth2Server') {
     return auth.accessToken ? { Authorization: `Bearer ${auth.accessToken}` } : {};
   }
 
   if (auth.type === 'basic') {
-    const encoded = base64Encode(`${auth.email}:${auth.apiToken}`);
+    const encoded = 'email' in auth
+      ? base64Encode(`${auth.email}:${auth.apiToken}`)
+      : base64Encode(`${auth.username}:${auth.password}`);
 
     return { Authorization: `Basic ${encoded}` };
   }
@@ -201,13 +305,12 @@ async function getAuthHeaders(auth: Auth): Promise<Record<string, string>> {
 }
 
 /**
- * Creates a low-level Confluence API client.
+ * Creates a low-level API client.
  *
- * The client carries only transport, auth and retry policy — it is version agnostic, so one instance drives both
- * `confluence.js/v1` and `confluence.js/v2`.
+ * The client carries only transport, auth and retry policy — it knows nothing about any one API version, so a single
+ * instance drives every surface the package exposes, and with it a single set of credentials.
  *
- * Prefer `createV1Client` / `createV2Client` from `confluence.js` unless you want the flat functions and a smaller
- * bundle.
+ * Prefer the surface factories the package exports unless you want the flat functions and a smaller bundle.
  *
  * @public
  */
@@ -216,14 +319,24 @@ export function createClient(config: ClientConfig | Client): Client {
 
   clientConfigSchema.parse(config);
 
-  const { host, auth, headers: configHeaders = {}, getAuthOn401, retry, onSchemaMismatch = 'warn' } = config;
+  const {
+    host,
+    auth,
+    headers: configHeaders = {},
+    getAuthOn401,
+    retry,
+    onSchemaMismatch = 'warn',
+    fetch: customFetch,
+  } = config;
   const retryMaxAttempts = Math.max(1, retry?.maxAttempts ?? 1);
   const retryInitialDelayMs = retry?.initialDelayMs ?? 500;
   const retryBackoffFactor = retry?.backoffFactor ?? 2;
 
-  const oauth2Manager: OAuth2Manager | undefined = auth?.type === 'oauth2' ? createOAuth2Manager(auth) : undefined;
+  const oauth2Manager = createManagerFor(auth, host, customFetch);
 
   return {
+    host,
+
     async sendRequest<T>(requestConfig: SendRequestOptions<T>): Promise<T> {
       const path = requestConfig.url.startsWith('/') ? requestConfig.url : `/${requestConfig.url}`;
       const effectiveHost = oauth2Manager ? await oauth2Manager.getBaseUrl() : host;
@@ -233,28 +346,30 @@ export function createClient(config: ClientConfig | Client): Client {
       const fullUrl = buildUrlWithSearchParams(url, requestConfig.searchParams);
 
       const rawBody = requestConfig.body;
-      const body = rawBody === undefined || rawBody === null ? undefined : bodyToFetchBody(rawBody);
+      const requestContentType = requestConfig.contentType;
+      const body = rawBody === undefined || rawBody === null ? undefined : bodyToFetchBody(rawBody, requestContentType);
 
       const doRequest = async (authHeaders: Record<string, string>): Promise<Response> => {
         const headers: Record<string, string> = {
           Accept: 'application/json',
-          ...(shouldSetJsonContentType(rawBody, requestConfig.method) ? { 'Content-Type': 'application/json' } : {}),
+          ...contentTypeHeader(requestContentType, body, rawBody, requestConfig.method),
           ...authHeaders,
           ...configHeaders,
-          ...requestConfig.headers,
+          ...definedHeaders(requestConfig.headers),
         };
 
         const init: RequestInit & { duplex?: 'half' } = {
           method: requestConfig.method,
           headers: Object.keys(headers).length > 0 ? headers : undefined,
           body: body as BodyInit,
+          signal: requestConfig.signal,
         };
 
         if (requiresDuplex(rawBody)) {
           init.duplex = 'half';
         }
 
-        return fetch(fullUrl, init);
+        return customFetch ? customFetch(fullUrl, init) : fetch(fullUrl, init);
       };
 
       const currentAuthHeaders = async (): Promise<Record<string, string>> => {
@@ -274,11 +389,13 @@ export function createClient(config: ClientConfig | Client): Client {
         try {
           response = await doRequest(derivedAuthHeaders);
         } catch (err) {
+          if (requestConfig.signal?.aborted) throw err;
+
           const networkError = isNetworkError(err) ? err : toNetworkError(err, fullUrl);
 
           if (networkAttempt + 1 < retryMaxAttempts && networkError.transient) {
             networkAttempt += 1;
-            await new Promise<void>(resolve => setTimeout(resolve, delayMs));
+            await sleep(delayMs, requestConfig.signal);
             delayMs = Math.round(delayMs * retryBackoffFactor);
             continue;
           }
@@ -286,7 +403,9 @@ export function createClient(config: ClientConfig | Client): Client {
           throw networkError;
         }
 
-        if (response.status === 401 && !reauthenticated && !(await isScopeMismatchResponse(response))) {
+        const unauthenticated = response.status === 401 || credentialsRejected(response, auth !== undefined);
+
+        if (unauthenticated && !reauthenticated && !(await isScopeMismatchResponse(response))) {
           if (oauth2Manager?.canRefresh()) {
             reauthenticated = true;
             await oauth2Manager.forceRefresh();
@@ -303,7 +422,7 @@ export function createClient(config: ClientConfig | Client): Client {
 
         if (TRANSIENT_HTTP_STATUSES.has(response.status) && networkAttempt + 1 < retryMaxAttempts) {
           networkAttempt += 1;
-          await new Promise<void>(resolve => setTimeout(resolve, delayMs));
+          await sleep(delayMs, requestConfig.signal);
           delayMs = Math.round(delayMs * retryBackoffFactor);
           continue;
         }
@@ -311,12 +430,28 @@ export function createClient(config: ClientConfig | Client): Client {
         break;
       }
 
+      if (credentialsRejected(response, auth !== undefined)) {
+        const reason = response.headers.get('x-seraph-loginreason');
+        const challenge = response.headers.get('x-authentication-denied-reason');
+        const { text, detail } = await readBody(response);
+        const advice = challenge
+          ? 'The credentials may well be correct: Jira is refusing the sign-in until a challenge is answered '
+            + `(${challenge}).`
+          : 'The API token or password may be expired, revoked or mistyped.';
+        const anonymously = response.ok ? ' and answered as an anonymous user' : '';
+
+        throw new AuthError(
+          `Request failed: Jira rejected the credentials (x-seraph-loginreason: ${reason})${anonymously}. `
+          + `${advice}${text ? ` - ${text}` : ''}`,
+          response.statusText,
+          detail,
+          { status: response.status },
+        );
+      }
+
       if (!response.ok) {
-        const text = await response.text();
-        let detail: unknown = text;
-        try {
-          detail = JSON.parse(text);
-        } catch {}
+        const { text, detail } = await readBody(response);
+
         throw createApiError(
           `Request failed: ${response.status} ${response.statusText}${text ? ` - ${text}` : ''}`,
           response.status,
@@ -334,9 +469,6 @@ export function createClient(config: ClientConfig | Client): Client {
         return BufferSchema.parse(new Uint8Array(await response.arrayBuffer())) as T;
       }
 
-      // A `Blob` carries the content type with the bytes, which is the whole reason these endpoints ask for one: the
-      // same avatar URL answers with SVG for a system avatar and PNG for an uploaded one, and nothing in the request
-      // says which is coming.
       if ((requestConfig.schema as unknown) === BlobSchema) {
         return BlobSchema.parse(await response.blob()) as T;
       }
@@ -402,11 +534,6 @@ export function createClient(config: ClientConfig | Client): Client {
               });
             }
 
-            // Undocumented keys are stripped as they are recorded, so the body can be validated for real once they are
-            // gone. A value outside a documented set cannot be taken out the same way — removing the field would leave
-            // a hole where the schema wants a value — so the response is handed back unvalidated instead. Either way
-            // it reaches the caller: everything wrong with it has been recorded, and one stale schema must not cut the
-            // audit short.
             const cleaned = requestConfig.schema.safeParse(data);
 
             return cleaned.success ? (cleaned.data as T) : (data as T);

--- a/src/core/errors/apiError.ts
+++ b/src/core/errors/apiError.ts
@@ -6,7 +6,7 @@ export interface ApiErrorOptions {
 }
 
 /**
- * Thrown when Confluence returns a non-2xx HTTP response.
+ * Thrown when the API returns a non-2xx HTTP response.
  *
  * The subclasses below cover the statuses worth branching on. Catch this one to catch them all, or a subclass — or use
  * the predicates, which survive a duplicated install of this package.
@@ -36,16 +36,29 @@ export class ApiError extends Error {
   }
 }
 
+export interface AuthErrorOptions extends ApiErrorOptions {
+  /**
+   * The status the response actually carried. Defaults to 401.
+   *
+   * Overridden where the credentials were refused behind a status that says otherwise: an endpoint permitting
+   * anonymous access answers `200` with an anonymous-scope body and reports the refusal in `X-Seraph-LoginReason`.
+   * Recording 401 there would name a status that never crossed the wire.
+   */
+  status?: number;
+}
+
 /**
- * 401 — the credentials are missing, expired or rejected.
+ * The credentials are missing, expired or rejected.
+ *
+ * Usually a 401. Not always: see {@link AuthErrorOptions.status}.
  *
  * @public
  */
 export class AuthError extends ApiError {
   override readonly [ERROR_KINDS]: readonly ErrorKind[] = ['api', 'auth'];
 
-  constructor(message: string, statusText: string, body: unknown, options?: ApiErrorOptions) {
-    super(message, 401, statusText, body, options);
+  constructor(message: string, statusText: string, body: unknown, options?: AuthErrorOptions) {
+    super(message, options?.status ?? 401, statusText, body, options);
     this.name = 'AuthError';
   }
 
@@ -62,9 +75,8 @@ export class AuthError extends ApiError {
  * so the client does not try. The app needs the scope added in the developer console and the user has to consent
  * again.
  *
- * Under 3LO this is also how the two API versions bite: v2 endpoints want granular scopes (`read:page:confluence`), v1
- * endpoints want classic ones (`read:confluence-content.all`). An app that holds only one family gets this error from
- * the other.
+ * Which scope is missing is the operation's own business, and its API documentation names it. `PRODUCT.scopeHint`
+ * carries whatever else is worth saying for this product, and the thrown message repeats it.
  *
  * @public
  */
@@ -82,7 +94,7 @@ export class ScopeError extends AuthError {
 }
 
 /**
- * 403 — authenticated, but not allowed. Usually a Confluence permission rather than a scope.
+ * 403 — authenticated, but not allowed. Usually a product permission rather than a scope.
  *
  * @public
  */
@@ -102,7 +114,7 @@ export class ForbiddenError extends ApiError {
 /**
  * 404 — no such thing, or no permission to know it exists.
  *
- * Confluence returns 404 for both, deliberately: telling the two apart would leak the existence of restricted content.
+ * The API returns 404 for both, deliberately: telling the two apart would leak the existence of restricted content.
  *
  * @public
  */
@@ -120,7 +132,7 @@ export class NotFoundError extends ApiError {
 }
 
 export interface RateLimitErrorOptions extends ApiErrorOptions {
-  /** How long to wait before retrying, in ms, when Confluence said so. */
+  /** How long to wait before retrying, in ms, when the API said so. */
   retryAfterMs?: number;
 }
 
@@ -150,7 +162,7 @@ export class RateLimitError extends ApiError {
 }
 
 /**
- * 5xx — Confluence failed on its own side.
+ * 5xx — the API failed on its own side.
  *
  * @public
  */

--- a/src/core/errors/fromResponse.ts
+++ b/src/core/errors/fromResponse.ts
@@ -88,7 +88,7 @@ export function parseRetryAfter(header: string | null, now = Date.now()): number
 /**
  * Whether a 401 is really a missing scope.
  *
- * Confluence says so in the body — `{"code":401,"message":"Unauthorized; scope does not match"}` — and nowhere else, so
+ * The API says so in the body — `{"code":401,"message":"Unauthorized; scope does not match"}` — and nowhere else, so
  * the message is the only signal there is. Matched loosely, since the wording is Atlassian's to change; a miss only
  * costs the caller a plain `AuthError`.
  */

--- a/src/core/errors/index.ts
+++ b/src/core/errors/index.ts
@@ -7,6 +7,7 @@ export {
   ScopeError,
   ServerError,
   type ApiErrorOptions,
+  type AuthErrorOptions,
   type RateLimitErrorOptions,
 } from './apiError.js';
 

--- a/src/core/errors/predicates.ts
+++ b/src/core/errors/predicates.ts
@@ -13,7 +13,7 @@ import type { SchemaMismatchError } from './schemaMismatchError.js';
 import { hasErrorKind } from './kinds.js';
 
 /**
- * Any non-2xx response from Confluence, including every subclass.
+ * Any non-2xx response from the API, including every subclass.
  *
  * Prefer these predicates to `instanceof` in library code and in anything that might load two copies of this package:
  * they check a branded marker instead of the prototype chain.
@@ -61,7 +61,7 @@ export function isRateLimitError(value: unknown): value is RateLimitError {
 }
 
 /**
- * 5xx — Confluence failed on its side.
+ * 5xx — the API failed on its side.
  *
  * @public
  */
@@ -125,7 +125,7 @@ export function isReauthorizationRequired(value: unknown): value is OAuthError {
  * The token is valid but lacks a scope this endpoint requires.
  *
  * Distinct from {@link isAuthError} because the remedy is different: refreshing cannot help, the app needs the scope
- * added and the user has to consent again. Confluence reports it as a 401 with `Unauthorized; scope does not match`.
+ * added and the user has to consent again. The API reports it as a 401 with `Unauthorized; scope does not match`.
  *
  * @public
  */

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,6 +24,7 @@ export {
   isScopeError,
   type ErrorKind,
   type ApiErrorOptions,
+  type AuthErrorOptions,
   type RateLimitErrorOptions,
   type OAuthErrorOptions,
 } from './errors/index.js';
@@ -43,15 +44,19 @@ export {
   authBasicSchema,
   authBearerSchema,
   authOAuth2Schema,
+  authOAuth2ServerSchema,
   sendRequestOptionsSchema,
   type HttpMethod,
   type ClientConfig,
   type CommonClientConfig,
   type ParsedClientConfig,
+  type FetchLike,
+  type RequestOptions,
   type Auth,
   type AuthBasic,
   type AuthBearer,
   type AuthOAuth2,
+  type AuthOAuth2Server,
   type SendRequestOptions,
 } from './schemas/index.js';
 
@@ -63,6 +68,15 @@ export {
   parseCallbackUrl,
   createOAuth2Manager,
 } from './oauth/index.js';
+
+export {
+  generateServerAuthorizationUrl,
+  exchangeServerAuthorizationCode,
+  refreshServerOAuth2Token,
+  createServerOAuth2Manager,
+} from './oauthServer/index.js';
+
+export type { ServerOAuth2Scope, ServerOAuth2ManagerOptions } from './oauthServer/index.js';
 
 export type {
   CallbackParams,

--- a/src/core/interfaces/client.ts
+++ b/src/core/interfaces/client.ts
@@ -2,4 +2,13 @@ import type { SendRequestOptions } from '../schemas/index.js';
 
 export interface Client {
   sendRequest<T>(options: SendRequestOptions<T>): Promise<T>;
+
+  /**
+   * The site this client sends to, as configured.
+   *
+   * Absent under Cloud OAuth 2.0 (3LO), where the base URL is derived per request from the accessible resources, and
+   * absent on a client written by hand. A caller that needs to name the site — `getTenantContext` does — must treat
+   * it as optional.
+   */
+  readonly host?: string;
 }

--- a/src/core/oauth/helpers.ts
+++ b/src/core/oauth/helpers.ts
@@ -1,4 +1,5 @@
 import type { AccessibleResource, OAuth2TokenResponse } from './types.js';
+import type { FetchLike } from '../schemas/clientConfig.js';
 import { OAuthError } from '../errors/index.js';
 
 const AUTHORIZE_URL = 'https://auth.atlassian.com/authorize';
@@ -26,11 +27,11 @@ function mapTokenResponse(data: RawTokenResponse): OAuth2TokenResponse {
 }
 
 /** `fetch` does not reject on a non-2xx status, so the status is checked here and turned into an `OAuthError`. */
-async function requestJson<T>(url: string, init: RequestInit): Promise<T> {
+async function requestJson<T>(url: string, init: RequestInit, fetchImpl?: FetchLike): Promise<T> {
   let response: Response;
 
   try {
-    response = await fetch(url, init);
+    response = await (fetchImpl ? fetchImpl(url, init) : fetch(url, init));
   } catch (err) {
     throw new OAuthError(`Request to ${url} failed before a response arrived`, { cause: err });
   }
@@ -90,6 +91,8 @@ export async function exchangeAuthorizationCode(params: {
   clientSecret: string;
   code: string;
   redirectUri: string;
+  /** The `fetch` to reach Atlassian by. Defaults to the global one. */
+  fetch?: FetchLike;
 }): Promise<OAuth2TokenResponse> {
   const data = await requestJson<RawTokenResponse>(TOKEN_URL, {
     method: 'POST',
@@ -101,7 +104,7 @@ export async function exchangeAuthorizationCode(params: {
       code: params.code,
       redirect_uri: params.redirectUri,
     }),
-  });
+  }, params.fetch);
 
   return mapTokenResponse(data);
 }
@@ -118,6 +121,8 @@ export async function refreshOAuth2Token(params: {
   clientId: string;
   clientSecret: string;
   refreshToken: string;
+  /** The `fetch` to reach Atlassian by. Defaults to the global one. */
+  fetch?: FetchLike;
 }): Promise<OAuth2TokenResponse> {
   const data = await requestJson<RawTokenResponse>(TOKEN_URL, {
     method: 'POST',
@@ -128,19 +133,19 @@ export async function refreshOAuth2Token(params: {
       client_secret: params.clientSecret,
       refresh_token: params.refreshToken,
     }),
-  });
+  }, params.fetch);
 
   return mapTokenResponse(data);
 }
 
 /**
- * List the Confluence sites this access token can reach. The `id` of an entry is its cloud id.
+ * List the sites this access token can reach. The `id` of an entry is its cloud id.
  *
  * @public
  */
-export async function getAccessibleResources(accessToken: string): Promise<AccessibleResource[]> {
+export async function getAccessibleResources(accessToken: string, fetchImpl?: FetchLike): Promise<AccessibleResource[]> {
   return requestJson<AccessibleResource[]>(ACCESSIBLE_RESOURCES_URL, {
     method: 'GET',
     headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
-  });
+  }, fetchImpl);
 }

--- a/src/core/oauth/oauth2Manager.ts
+++ b/src/core/oauth/oauth2Manager.ts
@@ -1,4 +1,5 @@
 import type { AccessibleResource, OnTokenRefresh } from './types.js';
+import type { FetchLike } from '../schemas/clientConfig.js';
 import { getAccessibleResources, refreshOAuth2Token } from './helpers.js';
 import { isOAuthError, OAuthError } from '../errors/index.js';
 import { PRODUCT } from '../productInfo.js';
@@ -17,6 +18,8 @@ export interface OAuth2ManagerOptions {
   cloudId?: string;
   siteUrl?: string;
   onTokenRefresh?: OnTokenRefresh;
+  /** The `fetch` the client was configured with, so a proxy or a log covers the token calls too. */
+  fetch?: FetchLike;
 }
 
 export interface OAuth2Manager {
@@ -46,7 +49,7 @@ function normalizeUrl(url: string): string {
  * produce one token call, not N.
  */
 export function createOAuth2Manager(options: OAuth2ManagerOptions): OAuth2Manager {
-  const { clientId, clientSecret, siteUrl, onTokenRefresh } = options;
+  const { clientId, clientSecret, siteUrl, onTokenRefresh, fetch: fetchImpl } = options;
 
   let accessToken = options.accessToken;
   let refreshToken = options.refreshToken;
@@ -79,6 +82,7 @@ export function createOAuth2Manager(options: OAuth2ManagerOptions): OAuth2Manage
       clientId: clientId!,
       clientSecret: clientSecret!,
       refreshToken: refreshToken!,
+      fetch: fetchImpl,
     });
 
     accessToken = response.accessToken;
@@ -124,21 +128,21 @@ export function createOAuth2Manager(options: OAuth2ManagerOptions): OAuth2Manage
    */
   const listResources = async (): Promise<AccessibleResource[]> => {
     try {
-      return await getAccessibleResources(await ensureAccessToken());
+      return await getAccessibleResources(await ensureAccessToken(), fetchImpl);
     } catch (err) {
       if (!isOAuthError(err) || err.status !== 401 || !canRefresh()) throw err;
 
       await refresh();
 
-      return getAccessibleResources(await ensureAccessToken());
+      return getAccessibleResources(await ensureAccessToken(), fetchImpl);
     }
   };
 
   const selectResource = (resources: AccessibleResource[]): AccessibleResource => {
     if (resources.length === 0) {
       throw new OAuthError(
-        'No accessible Confluence resources were returned for this OAuth 2.0 token. Check the granted scopes and ' +
-          'that the user has access to at least one Confluence site.',
+        'No accessible resources were returned for this OAuth 2.0 token. Check the granted scopes and that the ' +
+          'user has access to at least one site.',
       );
     }
 
@@ -157,7 +161,7 @@ export function createOAuth2Manager(options: OAuth2ManagerOptions): OAuth2Manage
 
     if (resources.length > 1) {
       throw new OAuthError(
-        'Multiple accessible Confluence resources found; pass `cloudId` or `siteUrl` to disambiguate. Available: ' +
+        'Multiple accessible resources found; pass `cloudId` or `siteUrl` to disambiguate. Available: ' +
           `${resources.map(r => r.url).join(', ')}.`,
       );
     }

--- a/src/core/oauthServer/helpers.ts
+++ b/src/core/oauthServer/helpers.ts
@@ -1,0 +1,155 @@
+import type { OAuth2TokenResponse } from '../oauth/types.js';
+import type { FetchLike } from '../schemas/clientConfig.js';
+import { OAuthError } from '../errors/index.js';
+
+/**
+ * Data Center is its own authorization server.
+ *
+ * Nothing here goes near `auth.atlassian.com` or `api.atlassian.com`: a self-hosted instance issues its own tokens on
+ * its own domain, so every call takes the site as an argument. There is no cloud id and no gateway, which is why this
+ * cannot be a parameter on the Cloud helpers — the two flows differ in what they talk to, not in how.
+ */
+const AUTHORIZE_PATH = '/rest/oauth2/latest/authorize';
+const TOKEN_PATH = '/rest/oauth2/latest/token';
+
+/**
+ * The four access levels a Data Center incoming link can grant. Each implies the ones above it: `WRITE` includes
+ * `READ`, `ADMIN` includes both, and `SYSTEM_ADMIN` includes all three.
+ */
+export type ServerOAuth2Scope = 'READ' | 'WRITE' | 'ADMIN' | 'SYSTEM_ADMIN';
+
+interface RawTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+}
+
+function normalizeHost(host: string): string {
+  return host.endsWith('/') ? host.slice(0, -1) : host;
+}
+
+function mapTokenResponse(data: RawTokenResponse): OAuth2TokenResponse {
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+    scope: data.scope,
+    tokenType: data.token_type,
+  };
+}
+
+/** `fetch` does not reject on a non-2xx status, so the status is checked here and turned into an `OAuthError`. */
+async function requestToken(
+  url: string,
+  form: Record<string, string>,
+  fetchImpl?: FetchLike,
+): Promise<OAuth2TokenResponse> {
+  let response: Response;
+
+  const init: RequestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+    body: new URLSearchParams(form).toString(),
+  };
+
+  try {
+    response = await (fetchImpl ? fetchImpl(url, init) : fetch(url, init));
+  } catch (err) {
+    throw new OAuthError(`Request to ${url} failed before a response arrived`, { cause: err });
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    let body: unknown = text;
+
+    try {
+      body = JSON.parse(text);
+    } catch {}
+
+    throw new OAuthError(
+      `Request to ${url} failed with status ${response.status} ${response.statusText}${text ? `: ${text}` : ''}`,
+      { status: response.status, body },
+    );
+  }
+
+  return mapTokenResponse((await response.json()) as RawTokenResponse);
+}
+
+/**
+ * Build the URL to send the user to so they can grant access to a Data Center instance.
+ *
+ * `state` is yours to generate and to verify when the callback comes back — it is what stops CSRF on the redirect.
+ *
+ * The `clientId` and `redirectUri` are the ones an administrator registered as an incoming application link; a
+ * `redirectUri` that does not match the registration is rejected by the instance rather than by this function.
+ *
+ * @public
+ */
+export function generateServerAuthorizationUrl(params: {
+  host: string;
+  clientId: string;
+  scopes: ServerOAuth2Scope[];
+  redirectUri: string;
+  state: string;
+}): string {
+  const query = new URLSearchParams({
+    client_id: params.clientId,
+    scope: params.scopes.join(' '),
+    redirect_uri: params.redirectUri,
+    state: params.state,
+    response_type: 'code',
+  });
+
+  return `${normalizeHost(params.host)}${AUTHORIZE_PATH}?${query.toString()}`;
+}
+
+/**
+ * Exchange the authorization `code` from the redirect callback for tokens.
+ *
+ * @public
+ */
+export async function exchangeServerAuthorizationCode(params: {
+  host: string;
+  clientId: string;
+  clientSecret: string;
+  code: string;
+  redirectUri: string;
+  /** The `fetch` to reach the instance by. Defaults to the global one. */
+  fetch?: FetchLike;
+}): Promise<OAuth2TokenResponse> {
+  return requestToken(`${normalizeHost(params.host)}${TOKEN_PATH}`, {
+    grant_type: 'authorization_code',
+    client_id: params.clientId,
+    client_secret: params.clientSecret,
+    code: params.code,
+    redirect_uri: params.redirectUri,
+  }, params.fetch);
+}
+
+/**
+ * Refresh an access token against a Data Center instance.
+ *
+ * `redirectUri` is required here where the specification does not ask for it: the Data Center provider validates it on
+ * the refresh grant as well, and omitting it earns an `invalid_grant` that names nothing.
+ *
+ * @public
+ */
+export async function refreshServerOAuth2Token(params: {
+  host: string;
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  redirectUri: string;
+  /** The `fetch` to reach the instance by. Defaults to the global one. */
+  fetch?: FetchLike;
+}): Promise<OAuth2TokenResponse> {
+  return requestToken(`${normalizeHost(params.host)}${TOKEN_PATH}`, {
+    grant_type: 'refresh_token',
+    client_id: params.clientId,
+    client_secret: params.clientSecret,
+    refresh_token: params.refreshToken,
+    redirect_uri: params.redirectUri,
+  }, params.fetch);
+}

--- a/src/core/oauthServer/index.ts
+++ b/src/core/oauthServer/index.ts
@@ -1,0 +1,11 @@
+export {
+  generateServerAuthorizationUrl,
+  exchangeServerAuthorizationCode,
+  refreshServerOAuth2Token,
+} from './helpers.js';
+
+export type { ServerOAuth2Scope } from './helpers.js';
+
+export { createServerOAuth2Manager } from './serverOAuth2Manager.js';
+
+export type { ServerOAuth2ManagerOptions } from './serverOAuth2Manager.js';

--- a/src/core/oauthServer/serverOAuth2Manager.ts
+++ b/src/core/oauthServer/serverOAuth2Manager.ts
@@ -1,0 +1,125 @@
+import type { OnTokenRefresh } from '../oauth/types.js';
+import type { FetchLike } from '../schemas/clientConfig.js';
+import type { OAuth2Manager } from '../oauth/oauth2Manager.js';
+import { refreshServerOAuth2Token } from './helpers.js';
+import { OAuthError } from '../errors/index.js';
+
+/** Refresh this many ms before `expiresAt`, to absorb clock skew and in-flight latency. */
+const EXPIRY_SKEW_MS = 60_000;
+
+export interface ServerOAuth2ManagerOptions {
+  /** The instance the tokens belong to. Also the base URL for every request, since there is no gateway. */
+  host: string;
+  accessToken?: string;
+  refreshToken?: string;
+  clientId?: string;
+  clientSecret?: string;
+  /** The redirect URI the incoming link was registered with. The provider validates it on refresh too. */
+  redirectUri?: string;
+  /** Access-token expiry as epoch milliseconds. */
+  expiresAt?: number;
+  onTokenRefresh?: OnTokenRefresh;
+  /** The `fetch` the client was configured with, so a proxy or a log covers the token calls too. */
+  fetch?: FetchLike;
+}
+
+/**
+ * Holds the OAuth 2.0 token state for one Data Center client.
+ *
+ * The Cloud manager's counterpart to this file spends most of its length resolving a cloud id and picking between the
+ * sites a 3LO token can reach. None of that exists here: a self-hosted instance is the one site, and `getBaseUrl`
+ * hands back the host it was given. What remains is the part that is genuinely shared — refresh before expiry, single
+ * -flighted so N concurrent requests produce one token call, and report the rotated refresh token onwards.
+ *
+ * Implements the same interface as the Cloud manager so the transport keeps one code path for both.
+ */
+export function createServerOAuth2Manager(options: ServerOAuth2ManagerOptions): OAuth2Manager {
+  const { host, clientId, clientSecret, redirectUri, onTokenRefresh, fetch: fetchImpl } = options;
+
+  let accessToken = options.accessToken;
+  let refreshToken = options.refreshToken;
+  let expiresAt = options.expiresAt;
+
+  let refreshPromise: Promise<void> | undefined;
+
+  const canRefresh = (): boolean =>
+    refreshToken !== undefined
+    && clientId !== undefined
+    && clientSecret !== undefined
+    && redirectUri !== undefined;
+
+  const needsRefresh = (): boolean => {
+    if (!canRefresh()) return false;
+
+    if (accessToken === undefined) return true;
+
+    if (expiresAt === undefined) return false;
+
+    return Date.now() >= expiresAt - EXPIRY_SKEW_MS;
+  };
+
+  const doRefresh = async (): Promise<void> => {
+    if (!canRefresh()) {
+      throw new OAuthError(
+        'Cannot refresh the OAuth 2.0 access token: `refreshToken`, `clientId`, `clientSecret` and `redirectUri` '
+          + 'are required.',
+      );
+    }
+
+    const response = await refreshServerOAuth2Token({
+      host,
+      clientId: clientId!,
+      clientSecret: clientSecret!,
+      refreshToken: refreshToken!,
+      redirectUri: redirectUri!,
+      fetch: fetchImpl,
+    });
+
+    accessToken = response.accessToken;
+
+    if (response.refreshToken) {
+      refreshToken = response.refreshToken;
+    }
+
+    expiresAt = Date.now() + response.expiresIn * 1000;
+
+    await onTokenRefresh?.({ accessToken, refreshToken, expiresAt });
+  };
+
+  const refresh = async (): Promise<void> => {
+    refreshPromise ??= doRefresh();
+
+    try {
+      await refreshPromise;
+    } finally {
+      refreshPromise = undefined;
+    }
+  };
+
+  const ensureAccessToken = async (): Promise<string> => {
+    if (needsRefresh()) await refresh();
+
+    if (accessToken === undefined) {
+      throw new OAuthError(
+        'No OAuth 2.0 access token is available and it cannot be refreshed. Provide an `accessToken`, or the full '
+          + 'refresh credentials (`refreshToken`, `clientId`, `clientSecret`, `redirectUri`).',
+      );
+    }
+
+    return accessToken;
+  };
+
+  return {
+    canRefresh,
+
+    async getAuthorizationHeader() {
+      return `Bearer ${await ensureAccessToken()}`;
+    },
+
+    getBaseUrl() {
+      return Promise.resolve(host);
+    },
+
+    forceRefresh: refresh,
+  };
+}

--- a/src/core/openEnum.ts
+++ b/src/core/openEnum.ts
@@ -8,9 +8,9 @@ import { isSchemaAuditEnabled } from './schemaAudit.js';
  * behind the API it describes. A value the vendor added and did not write down is not a bug in the caller's code, and
  * it must not turn into a warning in their logs.
  *
- * The documented values survive where they are actually useful — in the type. `z.infer` gives `'software' |
- * 'service_desk' | 'business' | (string & {})`, so an editor still suggests all three while the compiler accepts
- * whatever the API turns out to send. They also survive in the failure message, which names them.
+ * The documented values survive where they are actually useful — in the type. `z.infer` gives
+ * `'software' | 'service_desk' | 'business' | (string & {})`, so an editor still suggests all three while the compiler
+ * accepts whatever the API turns out to send. They also survive in the failure message, which names them.
  *
  * Under `AUDIT_SCHEMAS=true` it builds a real `z.enum` instead, which is how the audit run learns that a list has gone
  * stale. That is the run whose job is to compare the schemas against what the API sends; a caller's process is not.
@@ -22,7 +22,6 @@ import { isSchemaAuditEnabled } from './schemaAudit.js';
 export function openEnum<const T extends readonly string[]>(values: T) {
   const documented = values.map(value => `'${value}'`).join(' | ');
 
-  // `string & {}`, not `string`: a plain `string` in the union swallows the literals and takes the suggestions with them.
   const open = z.custom<T[number] | (string & {})>(value => typeof value === 'string', {
     message: `one of ${documented}, or another string`,
   });

--- a/src/core/productInfo.ts
+++ b/src/core/productInfo.ts
@@ -1,8 +1,9 @@
 /**
  * The handful of places where the shared core has to name its own product.
  *
- * This file is generated. Everything else under `core/` is identical across the libraries, and stays that way by
- * reading these values rather than hard-coding a product name.
+ * This file is generated. Nothing else under `core/` names a product: whatever has to differ is read from here, so
+ * a library can take a newer core without a rename. The libraries are not obliged to be on the same core generation,
+ * and in practice they are not.
  */
 export interface ProductInfo {
   packageName: string;
@@ -23,8 +24,7 @@ export const PRODUCT: ProductInfo = {
   gatewaySlug: 'jira',
 
   /** Product-specific advice appended to a scope-mismatch 401, where the scope families differ per product. */
-  scopeHint:
-    'Jira scopes are granted per operation rather than per API version — the scope the failing operation names in its API documentation is the one to add.',
+  scopeHint: 'Jira scopes are granted per operation rather than per API version — the scope the failing operation names in its API documentation is the one to add.',
 };
 
 /**

--- a/src/core/schemaAudit.ts
+++ b/src/core/schemaAudit.ts
@@ -30,8 +30,8 @@ export interface UndocumentedKeys extends DriftLocation {
  * A value outside the set the schema lists for a field.
  *
  * The counterpart of an undocumented key, and every bit as much a gap in the specification rather than breakage: the
- * field is described, its list of values is not complete. Kept apart from the other kind because the repair differs — a
- * missing key has to be added to a schema, a missing value to an enum.
+ * field is described, its list of values is not complete. Kept apart from the other kind because the repair differs —
+ * a missing key has to be added to a schema, a missing value to an enum.
  */
 export interface UndocumentedValue extends DriftLocation {
   kind: 'value';

--- a/src/core/schemaMismatch.ts
+++ b/src/core/schemaMismatch.ts
@@ -8,8 +8,8 @@ export interface SchemaMismatchIssue {
   /** What the schema expected there. */
   expected: string;
   /**
-   * What arrived, named by its type rather than quoted — except when the schema named a closed set of values, where the
-   * value that was not in the set is quoted instead. See the note on `SchemaMismatchReport`.
+   * What arrived, named by its type rather than quoted — except when the schema named a closed set of values, where
+   * the value that was not in the set is quoted instead. See the note on `SchemaMismatchReport`.
    */
   received: string;
 }
@@ -21,11 +21,11 @@ export interface SchemaMismatchIssue {
  * whoever ran the request — issue summaries, account names, custom field contents. A report that leaks those turns a
  * schema bug into someone else's incident.
  *
- * One value does get quoted: the one that failed a closed set. A field the schema describes with a fixed list of values
- * cannot be holding free text, by construction — free-text fields are declared as plain strings and no list ever
- * rejects them. So quoting it risks nothing, and withholding it costs the reader the whole diagnosis: knowing that
- * `projectTypeKey` was not one of three listed values, without being told it was `product_discovery`, leaves them to go
- * and ask the API themselves.
+ * One value does get quoted: the one that failed a closed set. A field the schema describes with a fixed list of
+ * values cannot be holding free text, by construction — free-text fields are declared as plain strings and no list
+ * ever rejects them. So quoting it risks nothing, and withholding it costs the reader the whole diagnosis: knowing
+ * that `projectTypeKey` was not one of three listed values, without being told it was `product_discovery`, leaves
+ * them to go and ask the API themselves.
  */
 export interface SchemaMismatchReport {
   /** Method and path, without the query string — `GET /rest/api/3/project/{projectIdOrKey}/role`. */
@@ -61,11 +61,11 @@ function describeValue(value: unknown): string {
  * The value sitting at a zod issue's path, walked out of the body that failed.
  *
  * Walked rather than read off `issue.input`: zod declares that field optional and leaves it off the issues it hands
- * back, so it is never there when this runs. Every segment of an issue path is an object key or an array index, so the
- * walk always has an answer, and anything no longer reachable is reported as absent — which is itself the answer when
- * the complaint is a missing field.
+ * back, so it is never there when this runs. Every segment of an issue path is an object key or an array index, so
+ * the walk always has an answer, and anything no longer reachable is reported as absent — which is itself the answer
+ * when the complaint is a missing field.
  */
-function readValueAtPath(body: unknown, path: readonly PropertyKey[]): { reachable: boolean; value: unknown } {
+function readValueAtPath(body: unknown, path: readonly PropertyKey[]): { reachable: boolean, value: unknown } {
   let target = body;
 
   for (const segment of path) {
@@ -147,8 +147,8 @@ function describeExpectation(issue: zodCore.$ZodIssue): string {
  *
  * Union branches are flattened rather than nested: a caller reading this wants to know which field is wrong, and
  * telling them the response failed all four branches of a union is a fact about zod, not about their data. The two
- * container codes are flattened for the same reason — a bad key or element is a problem with what is inside, and zod's
- * own nesting of it says nothing the inner issue does not.
+ * container codes are flattened for the same reason — a bad key or element is a problem with what is inside, and
+ * zod's own nesting of it says nothing the inner issue does not.
  */
 export function describeIssues(
   issues: readonly zodCore.$ZodIssue[],
@@ -179,7 +179,6 @@ export function describeIssues(
       continue;
     }
 
-    // The value itself only for a closed set — see the note on SchemaMismatchReport.
     const quoted = issue.code === 'invalid_value' ? quoteValue(readValueAtPath(body, path).value) : undefined;
 
     described.push({

--- a/src/core/schemas/auth.ts
+++ b/src/core/schemas/auth.ts
@@ -1,11 +1,28 @@
 import { z } from 'zod';
 import type { OnTokenRefresh } from '../oauth/types.js';
 
-export const authBasicSchema = z.object({
+/** Cloud: an Atlassian account address and an API token minted for it. */
+export const authBasicApiTokenSchema = z.object({
   type: z.literal('basic'),
   email: z.string().email(),
   apiToken: z.string().min(1),
 });
+
+/**
+ * Data Center: a local account name and its password.
+ *
+ * A separate branch rather than a loosened `email`, because the two are not interchangeable — a Cloud site rejects a
+ * username, a self-hosted one has no notion of an API token, and a typo that swaps them should be a validation error
+ * rather than a 401 an hour later. Personal access tokens, which Data Center has had since 8.14 and prefers, go
+ * through `bearer` instead.
+ */
+export const authBasicPasswordSchema = z.object({
+  type: z.literal('basic'),
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+
+export const authBasicSchema = z.union([authBasicApiTokenSchema, authBasicPasswordSchema]);
 
 export const authBearerTokenSchema = z.object({
   type: z.literal('bearer'),
@@ -70,11 +87,82 @@ export const authOAuth2Schema = z
     },
   );
 
-export const authSchema = z.union([authBasicSchema, authBearerSchema, authOAuth2Schema]);
+/**
+ * OAuth 2.0 against a Data Center instance's own provider.
+ *
+ * A separate strategy from `oauth2` rather than a flag on it, because the two differ in what they talk to. Cloud 3LO
+ * tokens are minted by `auth.atlassian.com` and accepted only through the Atlassian gateway, so `host` is derived from
+ * a cloud id; a Data Center instance is its own authorization server and its own API host, so `host` is required and
+ * is the only address involved. Folding them together would mean one strategy where `host` is both forbidden and
+ * mandatory.
+ *
+ * `redirectUri` sits with the refresh credentials because the Data Center provider validates it on the refresh grant,
+ * not only on the initial exchange.
+ */
+export const authOAuth2ServerSchema = z
+  .object({
+    type: z.literal('oauth2Server'),
+    accessToken: z.string().min(1).optional(),
+    refreshToken: z.string().min(1).optional(),
+    clientId: z.string().min(1).optional(),
+    clientSecret: z.string().min(1).optional(),
+    /** The redirect URI the incoming application link was registered with. */
+    redirectUri: z.string().min(1).optional(),
+    /** Access-token expiry as epoch milliseconds, e.g. `Date.now() + expiresIn * 1000`. */
+    expiresAt: z.number().optional(),
+    /** Called after every refresh. Persist the rotated `refreshToken` here — the previous one is dead. */
+    onTokenRefresh: z
+      .custom<OnTokenRefresh>(val => typeof val === 'function', { message: 'onTokenRefresh must be a function' })
+      .optional(),
+  })
+  .refine(
+    data =>
+      data.accessToken !== undefined
+      || (data.refreshToken !== undefined
+        && data.clientId !== undefined
+        && data.clientSecret !== undefined
+        && data.redirectUri !== undefined),
+    {
+      message:
+        'Data Center OAuth 2.0 requires either an `accessToken` or a full refresh credential set (`refreshToken`, '
+        + '`clientId`, `clientSecret`, `redirectUri`).',
+    },
+  )
+  .refine(
+    data => {
+      const anyRefreshField =
+        data.refreshToken !== undefined
+        || data.clientId !== undefined
+        || data.clientSecret !== undefined
+        || data.redirectUri !== undefined;
+
+      if (!anyRefreshField) return true;
+
+      return (
+        data.refreshToken !== undefined
+        && data.clientId !== undefined
+        && data.clientSecret !== undefined
+        && data.redirectUri !== undefined
+      );
+    },
+    {
+      message:
+        'When using Data Center OAuth 2.0 token refresh, `refreshToken`, `clientId`, `clientSecret` and '
+        + '`redirectUri` must all be provided together.',
+    },
+  );
+
+export const authSchema = z.union([authBasicSchema, authBearerSchema, authOAuth2Schema, authOAuth2ServerSchema]);
+
+export type AuthBasicApiToken = z.infer<typeof authBasicApiTokenSchema>;
+
+export type AuthBasicPassword = z.infer<typeof authBasicPasswordSchema>;
 
 export type AuthBasic = z.infer<typeof authBasicSchema>;
 
 export type AuthOAuth2 = z.infer<typeof authOAuth2Schema>;
+
+export type AuthOAuth2Server = z.infer<typeof authOAuth2ServerSchema>;
 
 export type AuthBearerToken = z.infer<typeof authBearerTokenSchema>;
 

--- a/src/core/schemas/clientConfig.ts
+++ b/src/core/schemas/clientConfig.ts
@@ -1,7 +1,17 @@
 import { z } from 'zod';
 import { authSchema } from './auth.js';
-import type { AuthBasic, AuthBearer, AuthOAuth2 } from './auth.js';
+import type { AuthBasic, AuthBearer, AuthOAuth2, AuthOAuth2Server } from './auth.js';
 import type { SchemaMismatchBehavior } from '../schemaMismatch.js';
+
+/**
+ * The shape the client calls `fetch` by.
+ *
+ * Narrower than `typeof globalThis.fetch` on purpose: undici's `fetch` declares its own `RequestInit` — one with
+ * `dispatcher` and without `duplex` — and a proxy wrapper would not type-check against the global signature.
+ *
+ * @public
+ */
+export type FetchLike = (url: string, init: RequestInit) => Promise<Response>;
 
 export const transientRetrySchema = z.object({
   /** Total number of attempts including the first. Default: 1 (no retries). */
@@ -20,12 +30,35 @@ export const clientConfigSchema = z
      * The bare site URL, e.g. `https://your-domain.atlassian.net` — the API path belongs to the request, not here.
      *
      * Optional only under OAuth 2.0: 3LO tokens are not accepted on the site's own domain, so the client routes through
-     * `https://api.atlassian.com/ex/confluence/{cloudId}` and derives that URL itself.
+     * `https://api.atlassian.com/ex/{product}/{cloudId}` and derives that URL itself.
      */
     host: z.url().optional(),
     auth: authSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),
+    /**
+     * Called once when the credentials are refused, to supply fresh ones and retry.
+     *
+     * Usually that is a 401. Not always: an endpoint permitting anonymous access answers `200` with an anonymous-scope
+     * body and reports the refusal only in `X-Seraph-LoginReason`, and this is called there too.
+     */
     getAuthOn401: z.custom<() => Promise<z.infer<typeof authSchema>>>(val => typeof val === 'function').optional(),
+    /**
+     * The `fetch` every request goes through, including the OAuth 2.0 token and cloud-id calls. Defaults to the global.
+     *
+     * The one seam the transport offers: wrap it to log, to trace, to route through a proxy, or to record fixtures.
+     *
+     * ```ts
+     * import { fetch as undiciFetch, ProxyAgent } from 'undici';
+     *
+     * const dispatcher = new ProxyAgent(process.env.HTTPS_PROXY!);
+     *
+     * createClient({ host, auth, fetch: (url, init) => undiciFetch(url, { ...init, dispatcher }) });
+     * ```
+     *
+     * A wrapper that logs request bodies will see `client_secret` and `refresh_token` on the token call. That is your
+     * own credential passing through your own code, but it is a log file it should not reach.
+     */
+    fetch: z.custom<FetchLike>(val => typeof val === 'function').optional(),
     /**
      * Opt-in retry for transient transport failures only — network errors (ECONNRESET, ETIMEDOUT, ENOTFOUND, EAI_AGAIN,
      * EPIPE, UND_ERR_SOCKET, ERR_SSL_*) and HTTP 502/503/504. Never retries 4xx (including 401, 429) or 5xx other than
@@ -60,4 +93,4 @@ export type CommonClientConfig = Omit<ParsedClientConfig, 'host' | 'auth'>;
  */
 export type ClientConfig =
   | (CommonClientConfig & { host?: string; auth: AuthOAuth2 })
-  | (CommonClientConfig & { host: string; auth?: AuthBasic | AuthBearer });
+  | (CommonClientConfig & { host: string; auth?: AuthBasic | AuthBearer | AuthOAuth2Server });

--- a/src/core/schemas/index.ts
+++ b/src/core/schemas/index.ts
@@ -2,13 +2,15 @@ export { httpMethodSchema } from './httpMethod.js';
 
 export type { HttpMethod } from './httpMethod.js';
 
-export { authSchema, authBasicSchema, authBearerSchema, authOAuth2Schema } from './auth.js';
+export { authSchema, authBasicSchema, authBearerSchema, authOAuth2Schema, authOAuth2ServerSchema } from './auth.js';
 
-export type { Auth, AuthBasic, AuthBearer, AuthOAuth2 } from './auth.js';
+export type { Auth, AuthBasic, AuthBearer, AuthOAuth2, AuthOAuth2Server } from './auth.js';
 
 export { clientConfigSchema } from './clientConfig.js';
 
-export type { ClientConfig, CommonClientConfig, ParsedClientConfig } from './clientConfig.js';
+export type { ClientConfig, CommonClientConfig, ParsedClientConfig, FetchLike } from './clientConfig.js';
+
+export type { RequestOptions } from './requestOptions.js';
 
 export { sendRequestOptionsSchema } from './sendRequestOptions.js';
 

--- a/src/core/schemas/requestOptions.ts
+++ b/src/core/schemas/requestOptions.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-call transport options — the last argument of every generated operation.
+ *
+ * Kept apart from the operation's own parameters, which are a faithful projection of the specification: a field named
+ * here can never be mistaken for one the API declares, and the exported parameter types stay exactly what they
+ * describe.
+ *
+ * @public
+ */
+export interface RequestOptions {
+  /**
+   * Aborts the request, and any retry back-off it is waiting out.
+   *
+   * The reason the signal carries is rethrown untouched — a `DOMException` named `AbortError` by default, whatever was
+   * passed to `abort()` otherwise, and a `TimeoutError` from `AbortSignal.timeout()`. It is never wrapped in a
+   * `NetworkError`: an abort is not a transport failure, and callers branch on the reason they supplied.
+   */
+  signal?: AbortSignal;
+}

--- a/src/core/schemas/sendRequestOptions.ts
+++ b/src/core/schemas/sendRequestOptions.ts
@@ -4,11 +4,32 @@ import { httpMethodSchema } from './httpMethod.js';
 export const sendRequestOptionsSchema = z.object({
   url: z.string(),
   method: httpMethodSchema.optional(),
-  headers: z.record(z.string(), z.string()).optional(),
+  /**
+   * The headers to send.
+   *
+   * A value of `undefined` is a header the caller left out — every optional header parameter arrives that way — and is
+   * dropped rather than sent, exactly as an absent `searchParams` entry or body field is.
+   */
+  headers: z.record(z.string(), z.string().optional()).optional(),
   body: z.unknown().optional(),
   searchParams: z.record(z.string(), z.unknown()).optional(),
+  /**
+   * The media type to send the body as, for the endpoints that do not take JSON.
+   *
+   * Generated onto the handful that declare `text/plain` or a form encoding. A `Blob` or `FormData` body needs none:
+   * both carry their own type, and naming one here would fight the boundary `fetch` sets for multipart.
+   */
+  contentType: z.string().optional(),
 });
 
 export type SendRequestOptions<T = unknown> = z.infer<typeof sendRequestOptionsSchema> & {
   schema?: z.ZodType<T>;
+  /**
+   * Aborts the request, and any retry back-off it is waiting out.
+   *
+   * Declared on the type rather than in the schema above: `z.custom<AbortSignal>(v => v instanceof AbortSignal)` is
+   * wrong the moment a signal crosses a realm — jsdom, undici and a worker each have their own constructor — and
+   * nothing here parses these options at runtime anyway.
+   */
+  signal?: AbortSignal;
 };

--- a/src/core/withRetry.ts
+++ b/src/core/withRetry.ts
@@ -8,7 +8,7 @@ export interface RetryOptions {
   /** Exponential backoff multiplier. Default: 2. */
   backoffFactor?: number;
   /**
-   * Also retry a 429, waiting out `Retry-After` when Confluence sent one. Off by default: a rate limit asks you to slow
+   * Also retry a 429, waiting out `Retry-After` when the API sent one. Off by default: a rate limit asks you to slow
    * the whole client down, and retrying one call in place papers over that.
    */
   retryRateLimit?: boolean;

--- a/src/serviceDesk/api/assets.ts
+++ b/src/serviceDesk/api/assets.ts
@@ -5,7 +5,7 @@ import { PagedInsightWorkspaceSchema } from '../models/pagedInsightWorkspace';
 import type { InsightWorkspace } from '../models/insightWorkspace';
 import type { GetAssetsWorkspaces } from '../parameters/getAssetsWorkspaces';
 import type { GetInsightWorkspaces } from '../parameters/getInsightWorkspaces';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * Returns a list of Assets workspace IDs. Include a workspace ID in the path to access the [Assets REST
@@ -16,6 +16,7 @@ import type { Client, SendRequestOptions } from '#/core';
 export async function getAssetsWorkspaces(
   client: Client,
   parameters?: GetAssetsWorkspaces,
+  options?: RequestOptions,
 ): Promise<Page<AssetsWorkspace>> {
   const config: SendRequestOptions<Page<AssetsWorkspace>> = {
     url: '/rest/servicedeskapi/assets/workspace',
@@ -25,6 +26,7 @@ export async function getAssetsWorkspaces(
       limit: parameters?.limit,
     },
     schema: PagedAssetsWorkspaceSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -34,6 +36,7 @@ export async function getAssetsWorkspaces(
 export async function getInsightWorkspaces(
   client: Client,
   parameters?: GetInsightWorkspaces,
+  options?: RequestOptions,
 ): Promise<Page<InsightWorkspace>> {
   const config: SendRequestOptions<Page<InsightWorkspace>> = {
     url: '/rest/servicedeskapi/insight/workspace',
@@ -43,6 +46,7 @@ export async function getInsightWorkspaces(
       limit: parameters?.limit,
     },
     schema: PagedInsightWorkspaceSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/serviceDesk/api/customer.ts
+++ b/src/serviceDesk/api/customer.ts
@@ -2,7 +2,7 @@ import { UserSchema, type User } from '../models/user';
 import type { CreateCustomer } from '../parameters/createCustomer';
 import type { CreateCustomerSkippingPermissionCheck } from '../parameters/createCustomerSkippingPermissionCheck';
 import type { RevokePortalOnlyAccessForUser } from '../parameters/revokePortalOnlyAccessForUser';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * This method adds a customer to the Jira Service Management instance by passing a JSON file including an email address
@@ -12,7 +12,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Jira
  * Administrator Global permission
  */
-export async function createCustomer(client: Client, parameters: CreateCustomer): Promise<User> {
+export async function createCustomer(
+  client: Client,
+  parameters: CreateCustomer,
+  options?: RequestOptions,
+): Promise<User> {
   const config: SendRequestOptions<User> = {
     url: '/rest/servicedeskapi/customer',
     method: 'POST',
@@ -25,6 +29,7 @@ export async function createCustomer(client: Client, parameters: CreateCustomer)
       fullName: parameters.fullName,
     },
     schema: UserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -43,6 +48,7 @@ export async function createCustomer(client: Client, parameters: CreateCustomer)
 export async function createCustomerSkippingPermissionCheck(
   client: Client,
   parameters: CreateCustomerSkippingPermissionCheck,
+  options?: RequestOptions,
 ): Promise<User> {
   const config: SendRequestOptions<User> = {
     url: '/rest/servicedeskapi/customer/skip-permission-check',
@@ -56,6 +62,7 @@ export async function createCustomerSkippingPermissionCheck(
       fullName: parameters.fullName,
     },
     schema: UserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -72,10 +79,12 @@ export async function createCustomerSkippingPermissionCheck(
 export async function revokePortalOnlyAccessForUser(
   client: Client,
   parameters: RevokePortalOnlyAccessForUser,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/customer/user/${parameters.accountId}/revoke-portal-only-access`,
     method: 'PUT',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/serviceDesk/api/info.ts
+++ b/src/serviceDesk/api/info.ts
@@ -1,5 +1,5 @@
 import { SoftwareInfoSchema, type SoftwareInfo } from '../models/softwareInfo';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * This method retrieves information about the Jira Service Management instance such as software version, builds, and
@@ -8,11 +8,12 @@ import type { Client, SendRequestOptions } from '#/core';
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: None, the
  * user does not need to be logged in.
  */
-export async function getInfo(client: Client): Promise<SoftwareInfo> {
+export async function getInfo(client: Client, options?: RequestOptions): Promise<SoftwareInfo> {
   const config: SendRequestOptions<SoftwareInfo> = {
     url: '/rest/servicedeskapi/info',
     method: 'GET',
     schema: SoftwareInfoSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/serviceDesk/api/knowledgebase.ts
+++ b/src/serviceDesk/api/knowledgebase.ts
@@ -3,7 +3,7 @@ import type { Page } from '../models/page';
 import type { Article } from '../models/article';
 import type { GetArticles } from '../parameters/getArticles';
 import type { ViewArticle } from '../parameters/viewArticle';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 import { z } from 'zod';
 
 /**
@@ -13,7 +13,11 @@ import { z } from 'zod';
  * Permission to access the [customer
  * portal](https://confluence.atlassian.com/servicedeskcloud/configuring-the-customer-portal-732528918.html).
  */
-export async function getArticles(client: Client, parameters: GetArticles): Promise<Page<Article>> {
+export async function getArticles(
+  client: Client,
+  parameters: GetArticles,
+  options?: RequestOptions,
+): Promise<Page<Article>> {
   const config: SendRequestOptions<Page<Article>> = {
     url: '/rest/servicedeskapi/knowledgebase/article',
     method: 'GET',
@@ -26,16 +30,18 @@ export async function getArticles(client: Client, parameters: GetArticles): Prom
       prev: parameters.prev,
     },
     schema: PagedArticleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
 }
 
-export async function viewArticle(client: Client, parameters: ViewArticle): Promise<string> {
+export async function viewArticle(client: Client, parameters: ViewArticle, options?: RequestOptions): Promise<string> {
   const config: SendRequestOptions<string> = {
     url: `/rest/servicedeskapi/knowledgebase/article/view/${parameters.pageId}`,
     method: 'GET',
     schema: z.string(),
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/serviceDesk/api/organization.ts
+++ b/src/serviceDesk/api/organization.ts
@@ -19,7 +19,7 @@ import type { RemoveUsersFromOrganization } from '../parameters/removeUsersFromO
 import type { GetServiceDeskOrganizations } from '../parameters/getServiceDeskOrganizations';
 import type { AddOrganization } from '../parameters/addOrganization';
 import type { RemoveOrganization } from '../parameters/removeOrganization';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * This method returns a list of organizations in the Jira Service Management instance. Use this method when you want to
@@ -31,7 +31,11 @@ import type { Client, SendRequestOptions } from '#/core';
  * **Response limitations**: If the user is a customer, only those organizations of which the customer is a member are
  * listed.
  */
-export async function getOrganizations(client: Client, parameters?: GetOrganizations): Promise<Page<Organization>> {
+export async function getOrganizations(
+  client: Client,
+  parameters?: GetOrganizations,
+  options?: RequestOptions,
+): Promise<Page<Organization>> {
   const config: SendRequestOptions<Page<Organization>> = {
     url: '/rest/servicedeskapi/organization',
     method: 'GET',
@@ -41,6 +45,7 @@ export async function getOrganizations(client: Client, parameters?: GetOrganizat
       accountId: parameters?.accountId,
     },
     schema: PagedOrganizationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -55,7 +60,11 @@ export async function getOrganizations(client: Client, parameters?: GetOrganizat
  * management](https://confluence.atlassian.com/servicedeskcloud/setting-up-service-desk-users-732528877.html#Settingupservicedeskusers-manageorgsManageorganizations)**
  * feature.
  */
-export async function createOrganization(client: Client, parameters: CreateOrganization): Promise<Organization> {
+export async function createOrganization(
+  client: Client,
+  parameters: CreateOrganization,
+  options?: RequestOptions,
+): Promise<Organization> {
   const config: SendRequestOptions<Organization> = {
     url: '/rest/servicedeskapi/organization',
     method: 'POST',
@@ -63,6 +72,7 @@ export async function createOrganization(client: Client, parameters: CreateOrgan
       name: parameters.name,
     },
     schema: OrganizationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -80,11 +90,16 @@ export async function createOrganization(client: Client, parameters: CreateOrgan
  *
  * **Response limitations**: Customers can only retrieve organization of which they are members.
  */
-export async function getOrganization(client: Client, parameters: GetOrganization): Promise<Organization> {
+export async function getOrganization(
+  client: Client,
+  parameters: GetOrganization,
+  options?: RequestOptions,
+): Promise<Organization> {
   const config: SendRequestOptions<Organization> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}`,
     method: 'GET',
     schema: OrganizationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -97,10 +112,15 @@ export async function getOrganization(client: Client, parameters: GetOrganizatio
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Jira
  * administrator.
  */
-export async function deleteOrganization(client: Client, parameters: DeleteOrganization): Promise<void> {
+export async function deleteOrganization(
+  client: Client,
+  parameters: DeleteOrganization,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -119,11 +139,16 @@ export async function deleteOrganization(client: Client, parameters: DeleteOrgan
  *
  * **Response limitations**: Customers can only access properties of organizations of which they are members.
  */
-export async function getPropertiesKeys(client: Client, parameters: GetPropertiesKeys): Promise<PropertyKeys> {
+export async function getPropertiesKeys(
+  client: Client,
+  parameters: GetPropertiesKeys,
+  options?: RequestOptions,
+): Promise<PropertyKeys> {
   const config: SendRequestOptions<PropertyKeys> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}/property`,
     method: 'GET',
     schema: PropertyKeysSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -142,11 +167,16 @@ export async function getPropertiesKeys(client: Client, parameters: GetPropertie
  *
  * **Response limitations**: Customers can only access properties of organizations of which they are members.
  */
-export async function getProperty(client: Client, parameters: GetProperty): Promise<EntityProperty> {
+export async function getProperty(
+  client: Client,
+  parameters: GetProperty,
+  options?: RequestOptions,
+): Promise<EntityProperty> {
   const config: SendRequestOptions<EntityProperty> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}/property/${parameters.propertyKey}`,
     method: 'GET',
     schema: EntityPropertySchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -169,11 +199,12 @@ export async function getProperty(client: Client, parameters: GetProperty): Prom
  * management](https://confluence.atlassian.com/servicedeskcloud/setting-up-service-desk-users-732528877.html#Settingupservicedeskusers-manageorgsManageorganizations)**
  * feature.
  */
-export async function setProperty(client: Client, parameters: SetProperty): Promise<void> {
+export async function setProperty(client: Client, parameters: SetProperty, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}/property/${parameters.propertyKey}`,
     method: 'PUT',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -196,10 +227,15 @@ export async function setProperty(client: Client, parameters: SetProperty): Prom
  * management](https://confluence.atlassian.com/servicedeskcloud/setting-up-service-desk-users-732528877.html#Settingupservicedeskusers-manageorgsManageorganizations)**
  * feature.
  */
-export async function deleteProperty(client: Client, parameters: DeleteProperty): Promise<void> {
+export async function deleteProperty(
+  client: Client,
+  parameters: DeleteProperty,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}/property/${parameters.propertyKey}`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -212,7 +248,11 @@ export async function deleteProperty(client: Client, parameters: DeleteProperty)
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk administrator or agent.
  */
-export async function getUsersInOrganization(client: Client, parameters: GetUsersInOrganization): Promise<Page<User>> {
+export async function getUsersInOrganization(
+  client: Client,
+  parameters: GetUsersInOrganization,
+  options?: RequestOptions,
+): Promise<Page<User>> {
   const config: SendRequestOptions<Page<User>> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}/user`,
     method: 'GET',
@@ -221,6 +261,7 @@ export async function getUsersInOrganization(client: Client, parameters: GetUser
       limit: parameters.limit,
     },
     schema: PagedUserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -235,11 +276,16 @@ export async function getUsersInOrganization(client: Client, parameters: GetUser
  * management](https://confluence.atlassian.com/servicedeskcloud/setting-up-service-desk-users-732528877.html#Settingupservicedeskusers-manageorgsManageorganizations)**
  * feature.
  */
-export async function addUsersToOrganization(client: Client, parameters: AddUsersToOrganization): Promise<void> {
+export async function addUsersToOrganization(
+  client: Client,
+  parameters: AddUsersToOrganization,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}/user`,
     method: 'POST',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -257,11 +303,13 @@ export async function addUsersToOrganization(client: Client, parameters: AddUser
 export async function removeUsersFromOrganization(
   client: Client,
   parameters: RemoveUsersFromOrganization,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/organization/${parameters.organizationId}/user`,
     method: 'DELETE',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -276,6 +324,7 @@ export async function removeUsersFromOrganization(
 export async function getServiceDeskOrganizations(
   client: Client,
   parameters: GetServiceDeskOrganizations,
+  options?: RequestOptions,
 ): Promise<Page<Organization>> {
   const config: SendRequestOptions<Page<Organization>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/organization`,
@@ -286,6 +335,7 @@ export async function getServiceDeskOrganizations(
       accountId: parameters.accountId,
     },
     schema: PagedOrganizationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -298,11 +348,16 @@ export async function getServiceDeskOrganizations(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk's agent.
  */
-export async function addOrganization(client: Client, parameters: AddOrganization): Promise<void> {
+export async function addOrganization(
+  client: Client,
+  parameters: AddOrganization,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/organization`,
     method: 'POST',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -315,11 +370,16 @@ export async function addOrganization(client: Client, parameters: AddOrganizatio
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk's agent.
  */
-export async function removeOrganization(client: Client, parameters: RemoveOrganization): Promise<void> {
+export async function removeOrganization(
+  client: Client,
+  parameters: RemoveOrganization,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/organization`,
     method: 'DELETE',
     body: parameters.body,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/serviceDesk/api/request.ts
+++ b/src/serviceDesk/api/request.ts
@@ -1,6 +1,7 @@
 import { PagedCustomerRequestSchema } from '../models/pagedCustomerRequest';
 import type { Page } from '../models/page';
 import { CustomerRequestSchema, type CustomerRequest } from '../models/customerRequest';
+import { RequestValidationResultSchema, type RequestValidationResult } from '../models/requestValidationResult';
 import { PagedApprovalSchema } from '../models/pagedApproval';
 import { ApprovalSchema, type Approval } from '../models/approval';
 import { PagedAttachmentSchema } from '../models/pagedAttachment';
@@ -22,6 +23,7 @@ import { PagedCustomerTransitionSchema } from '../models/pagedCustomerTransition
 import type { CustomerTransition } from '../models/customerTransition';
 import type { GetCustomerRequests } from '../parameters/getCustomerRequests';
 import type { CreateCustomerRequest } from '../parameters/createCustomerRequest';
+import type { ValidateCustomerRequest } from '../parameters/validateCustomerRequest';
 import type { GetCustomerRequestByIdOrKey } from '../parameters/getCustomerRequestByIdOrKey';
 import type { GetApprovals } from '../parameters/getApprovals';
 import type { GetApprovalById } from '../parameters/getApprovalById';
@@ -44,7 +46,7 @@ import type { GetSlaInformationById } from '../parameters/getSlaInformationById'
 import type { GetCustomerRequestStatus } from '../parameters/getCustomerRequestStatus';
 import type { GetCustomerTransitions } from '../parameters/getCustomerTransitions';
 import type { PerformCustomerTransition } from '../parameters/performCustomerTransition';
-import { type Client, type SendRequestOptions, BufferSchema, type Buffer } from '#/core';
+import { type Client, type RequestOptions, type SendRequestOptions, BufferSchema, type Buffer } from '#/core';
 
 /**
  * This method returns all customer requests for the user executing the query.
@@ -61,6 +63,7 @@ import { type Client, type SendRequestOptions, BufferSchema, type Buffer } from 
 export async function getCustomerRequests(
   client: Client,
   parameters?: GetCustomerRequests,
+  options?: RequestOptions,
 ): Promise<Page<CustomerRequest>> {
   const config: SendRequestOptions<Page<CustomerRequest>> = {
     url: '/rest/servicedeskapi/request',
@@ -78,6 +81,7 @@ export async function getCustomerRequests(
       limit: parameters?.limit,
     },
     schema: PagedCustomerRequestSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -106,6 +110,7 @@ export async function getCustomerRequests(
 export async function createCustomerRequest(
   client: Client,
   parameters: CreateCustomerRequest,
+  options?: RequestOptions,
 ): Promise<CustomerRequest> {
   const config: SendRequestOptions<CustomerRequest> = {
     url: '/rest/servicedeskapi/request',
@@ -121,6 +126,48 @@ export async function createCustomerRequest(
       serviceDeskId: parameters.serviceDeskId,
     },
     schema: CustomerRequestSchema,
+    signal: options?.signal,
+  };
+
+  return await client.sendRequest(config);
+}
+
+/**
+ * Validates a customer request payload without creating (persisting) a request.
+ *
+ * This endpoint runs exactly the same structural and semantic validations as [Create customer
+ * request](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#api-request-post) — including ProForma
+ * form validation — but performs **no mutation**: no issue is created and no side effects (attachments, comments,
+ * analytics) run.
+ *
+ * The response is intentionally verbose and structured so that it can be consumed by automated agents (for example an
+ * LLM repairing an invalid payload): every failure carries a machine-readable location (field id / form entity) and a
+ * human-readable reason. A valid payload returns HTTP 200 with `valid: true`; an invalid payload returns HTTP 400 with
+ * `valid: false` together with the field, form and general validation errors.
+ *
+ * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
+ * Permission to create requests in the specified service desk.
+ */
+export async function validateCustomerRequest(
+  client: Client,
+  parameters: ValidateCustomerRequest,
+  options?: RequestOptions,
+): Promise<RequestValidationResult> {
+  const config: SendRequestOptions<RequestValidationResult> = {
+    url: '/rest/servicedeskapi/request/validate',
+    method: 'POST',
+    body: {
+      channel: parameters.channel,
+      form: parameters.form,
+      isAdfRequest: parameters.isAdfRequest,
+      raiseOnBehalfOf: parameters.raiseOnBehalfOf,
+      requestFieldValues: parameters.requestFieldValues,
+      requestParticipants: parameters.requestParticipants,
+      requestTypeId: parameters.requestTypeId,
+      serviceDeskId: parameters.serviceDeskId,
+    },
+    schema: RequestValidationResultSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -142,6 +189,7 @@ export async function createCustomerRequest(
 export async function getCustomerRequestByIdOrKey(
   client: Client,
   parameters: GetCustomerRequestByIdOrKey,
+  options?: RequestOptions,
 ): Promise<CustomerRequest> {
   const config: SendRequestOptions<CustomerRequest> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}`,
@@ -150,6 +198,7 @@ export async function getCustomerRequestByIdOrKey(
       expand: parameters.expand,
     },
     schema: CustomerRequestSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -161,7 +210,11 @@ export async function getCustomerRequestByIdOrKey(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the customer request.
  */
-export async function getApprovals(client: Client, parameters: GetApprovals): Promise<Page<Approval>> {
+export async function getApprovals(
+  client: Client,
+  parameters: GetApprovals,
+  options?: RequestOptions,
+): Promise<Page<Approval>> {
   const config: SendRequestOptions<Page<Approval>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/approval`,
     method: 'GET',
@@ -170,6 +223,7 @@ export async function getApprovals(client: Client, parameters: GetApprovals): Pr
       limit: parameters.limit,
     },
     schema: PagedApprovalSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -181,11 +235,16 @@ export async function getApprovals(client: Client, parameters: GetApprovals): Pr
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the customer request.
  */
-export async function getApprovalById(client: Client, parameters: GetApprovalById): Promise<Approval> {
+export async function getApprovalById(
+  client: Client,
+  parameters: GetApprovalById,
+  options?: RequestOptions,
+): Promise<Approval> {
   const config: SendRequestOptions<Approval> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/approval/${parameters.approvalId}`,
     method: 'GET',
     schema: ApprovalSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -198,7 +257,11 @@ export async function getApprovalById(client: Client, parameters: GetApprovalByI
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: User is
  * assigned to the approval request.
  */
-export async function answerApproval(client: Client, parameters: AnswerApproval): Promise<Approval> {
+export async function answerApproval(
+  client: Client,
+  parameters: AnswerApproval,
+  options?: RequestOptions,
+): Promise<Approval> {
   const config: SendRequestOptions<Approval> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/approval/${parameters.approvalId}`,
     method: 'POST',
@@ -206,6 +269,7 @@ export async function answerApproval(client: Client, parameters: AnswerApproval)
       decision: parameters.decision,
     },
     schema: ApprovalSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -222,6 +286,7 @@ export async function answerApproval(client: Client, parameters: AnswerApproval)
 export async function getAttachmentsForRequest(
   client: Client,
   parameters: GetAttachmentsForRequest,
+  options?: RequestOptions,
 ): Promise<Page<Attachment>> {
   const config: SendRequestOptions<Page<Attachment>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/attachment`,
@@ -231,6 +296,7 @@ export async function getAttachmentsForRequest(
       limit: parameters.limit,
     },
     schema: PagedAttachmentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -242,9 +308,9 @@ export async function getAttachmentsForRequest(
  * with the visibility set by `public`. See
  *
  * - GET
- *   [servicedeskapi/request/{issueIdOrKey}/attachment](./#api-rest-servicedeskapi-request-issueidorkey-attachment-get)
+ *   [servicedeskapi/request/{issueIdOrKey}/attachment](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#api-rest-servicedeskapi-request-issueidorkey-attachment-get)
  * - GET
- *   [servicedeskapi/request/{issueIdOrKey}/comment/{commentId}/attachment](./#api-rest-servicedeskapi-request-issueidorkey-comment-commentid-attachment-get)
+ *   [servicedeskapi/request/{issueIdOrKey}/comment/{commentId}/attachment](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#api-rest-servicedeskapi-request-issueidorkey-comment-commentid-attachment-get)
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to add an attachment.
@@ -254,6 +320,7 @@ export async function getAttachmentsForRequest(
 export async function createCommentWithAttachment(
   client: Client,
   parameters: CreateCommentWithAttachment,
+  options?: RequestOptions,
 ): Promise<AttachmentCreateResult> {
   const config: SendRequestOptions<AttachmentCreateResult> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/attachment`,
@@ -264,6 +331,7 @@ export async function createCommentWithAttachment(
       temporaryAttachmentIds: parameters.temporaryAttachmentIds,
     },
     schema: AttachmentCreateResultSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -273,7 +341,7 @@ export async function createCommentWithAttachment(
  * Returns the contents of an attachment.
  *
  * To return a thumbnail of the attachment, use
- * [servicedeskapi/request/{issueIdOrKey}/attachment/{attachmentId}/thumbnail](./#api-rest-servicedeskapi-request-issueidorkey-attachment-attachmentid-thumbnail-get).
+ * [servicedeskapi/request/{issueIdOrKey}/attachment/{attachmentId}/thumbnail](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#api-rest-servicedeskapi-request-issueidorkey-attachment-attachmentid-thumbnail-get).
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required:** For the
  * issue containing the attachment:
@@ -283,11 +351,16 @@ export async function createCommentWithAttachment(
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function getAttachmentContent(client: Client, parameters: GetAttachmentContent): Promise<Buffer> {
+export async function getAttachmentContent(
+  client: Client,
+  parameters: GetAttachmentContent,
+  options?: RequestOptions,
+): Promise<Buffer> {
   const config: SendRequestOptions<Buffer> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/attachment/${parameters.attachmentId}`,
     method: 'GET',
     schema: BufferSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -307,11 +380,16 @@ export async function getAttachmentContent(client: Client, parameters: GetAttach
  * - If [issue-level security](https://confluence.atlassian.com/x/J4lKLg) is configured, issue-level security permission
  *   to view the issue.
  */
-export async function getAttachmentThumbnail(client: Client, parameters: GetAttachmentThumbnail): Promise<Buffer> {
+export async function getAttachmentThumbnail(
+  client: Client,
+  parameters: GetAttachmentThumbnail,
+  options?: RequestOptions,
+): Promise<Buffer> {
   const config: SendRequestOptions<Buffer> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/attachment/${parameters.attachmentId}/thumbnail`,
     method: 'GET',
     schema: BufferSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -326,7 +404,11 @@ export async function getAttachmentThumbnail(client: Client, parameters: GetAtta
  *
  * **Response limitations**: Customers are returned public comments only.
  */
-export async function getRequestComments(client: Client, parameters: GetRequestComments): Promise<Page<Comment>> {
+export async function getRequestComments(
+  client: Client,
+  parameters: GetRequestComments,
+  options?: RequestOptions,
+): Promise<Page<Comment>> {
   const config: SendRequestOptions<Page<Comment>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/comment`,
     method: 'GET',
@@ -338,6 +420,7 @@ export async function getRequestComments(client: Client, parameters: GetRequestC
       limit: parameters.limit,
     },
     schema: PagedCommentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -352,7 +435,11 @@ export async function getRequestComments(client: Client, parameters: GetRequestC
  *
  * **Request limitations**: Customers can set comments to public visibility only.
  */
-export async function createRequestComment(client: Client, parameters: CreateRequestComment): Promise<Comment> {
+export async function createRequestComment(
+  client: Client,
+  parameters: CreateRequestComment,
+  options?: RequestOptions,
+): Promise<Comment> {
   const config: SendRequestOptions<Comment> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/comment`,
     method: 'POST',
@@ -361,6 +448,7 @@ export async function createRequestComment(client: Client, parameters: CreateReq
       public: parameters.public,
     },
     schema: CommentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -375,7 +463,11 @@ export async function createRequestComment(client: Client, parameters: CreateReq
  * **Response limitations**: Customers can only view public comments on requests where they are the reporter or a
  * participant whereas agents can see both internal and public comments.
  */
-export async function getRequestCommentById(client: Client, parameters: GetRequestCommentById): Promise<Comment> {
+export async function getRequestCommentById(
+  client: Client,
+  parameters: GetRequestCommentById,
+  options?: RequestOptions,
+): Promise<Comment> {
   const config: SendRequestOptions<Comment> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/comment/${parameters.commentId}`,
     method: 'GET',
@@ -383,6 +475,7 @@ export async function getRequestCommentById(client: Client, parameters: GetReque
       expand: parameters.expand,
     },
     schema: CommentSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -398,11 +491,13 @@ export async function getRequestCommentById(client: Client, parameters: GetReque
 export async function getSubscriptionStatus(
   client: Client,
   parameters: GetSubscriptionStatus,
+  options?: RequestOptions,
 ): Promise<RequestNotificationSubscription> {
   const config: SendRequestOptions<RequestNotificationSubscription> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/notification`,
     method: 'GET',
     schema: RequestNotificationSubscriptionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -414,10 +509,11 @@ export async function getSubscriptionStatus(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the customer request.
  */
-export async function subscribe(client: Client, parameters: Subscribe): Promise<void> {
+export async function subscribe(client: Client, parameters: Subscribe, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/notification`,
     method: 'PUT',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -429,10 +525,11 @@ export async function subscribe(client: Client, parameters: Subscribe): Promise<
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the customer request.
  */
-export async function unsubscribe(client: Client, parameters: Unsubscribe): Promise<void> {
+export async function unsubscribe(client: Client, parameters: Unsubscribe, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/notification`,
     method: 'DELETE',
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -444,7 +541,11 @@ export async function unsubscribe(client: Client, parameters: Unsubscribe): Prom
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to view the customer request.
  */
-export async function getRequestParticipants(client: Client, parameters: GetRequestParticipants): Promise<Page<User>> {
+export async function getRequestParticipants(
+  client: Client,
+  parameters: GetRequestParticipants,
+  options?: RequestOptions,
+): Promise<Page<User>> {
   const config: SendRequestOptions<Page<User>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/participant`,
     method: 'GET',
@@ -453,6 +554,7 @@ export async function getRequestParticipants(client: Client, parameters: GetRequ
       limit: parameters.limit,
     },
     schema: PagedUserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -468,7 +570,11 @@ export async function getRequestParticipants(client: Client, parameters: GetRequ
  * [request](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#api-request-post) resource, by defining
  * the participants in the `requestParticipants` field.
  */
-export async function addRequestParticipants(client: Client, parameters: AddRequestParticipants): Promise<Page<User>> {
+export async function addRequestParticipants(
+  client: Client,
+  parameters: AddRequestParticipants,
+  options?: RequestOptions,
+): Promise<Page<User>> {
   const config: SendRequestOptions<Page<User>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/participant`,
     method: 'POST',
@@ -477,6 +583,7 @@ export async function addRequestParticipants(client: Client, parameters: AddRequ
       usernames: parameters.usernames,
     },
     schema: PagedUserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -491,6 +598,7 @@ export async function addRequestParticipants(client: Client, parameters: AddRequ
 export async function removeRequestParticipants(
   client: Client,
   parameters: RemoveRequestParticipants,
+  options?: RequestOptions,
 ): Promise<Page<User>> {
   const config: SendRequestOptions<Page<User>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/participant`,
@@ -500,6 +608,7 @@ export async function removeRequestParticipants(
       usernames: parameters.usernames,
     },
     schema: PagedUserSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -516,7 +625,11 @@ export async function removeRequestParticipants(
  * - Browse Projects permission on the project containing the customer request, including any restrictions imposed by
  *   issue security schemes or custom permission schemes on the specific issue.
  */
-export async function getSlaInformation(client: Client, parameters: GetSlaInformation): Promise<Page<SlaInformation>> {
+export async function getSlaInformation(
+  client: Client,
+  parameters: GetSlaInformation,
+  options?: RequestOptions,
+): Promise<Page<SlaInformation>> {
   const config: SendRequestOptions<Page<SlaInformation>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/sla`,
     method: 'GET',
@@ -525,6 +638,7 @@ export async function getSlaInformation(client: Client, parameters: GetSlaInform
       limit: parameters.limit,
     },
     schema: PagedSlaInformationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -542,11 +656,13 @@ export async function getSlaInformation(client: Client, parameters: GetSlaInform
 export async function getSlaInformationById(
   client: Client,
   parameters: GetSlaInformationById,
+  options?: RequestOptions,
 ): Promise<SlaInformation> {
   const config: SendRequestOptions<SlaInformation> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/sla/${parameters.slaMetricId}`,
     method: 'GET',
     schema: SlaInformationSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -563,6 +679,7 @@ export async function getSlaInformationById(
 export async function getCustomerRequestStatus(
   client: Client,
   parameters: GetCustomerRequestStatus,
+  options?: RequestOptions,
 ): Promise<Page<CustomerRequestStatus>> {
   const config: SendRequestOptions<Page<CustomerRequestStatus>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/status`,
@@ -572,6 +689,7 @@ export async function getCustomerRequestStatus(
       limit: parameters.limit,
     },
     schema: PagedCustomerRequestStatusSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -588,6 +706,7 @@ export async function getCustomerRequestStatus(
 export async function getCustomerTransitions(
   client: Client,
   parameters: GetCustomerTransitions,
+  options?: RequestOptions,
 ): Promise<Page<CustomerTransition>> {
   const config: SendRequestOptions<Page<CustomerTransition>> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/transition`,
@@ -597,6 +716,7 @@ export async function getCustomerTransitions(
       limit: parameters.limit,
     },
     schema: PagedCustomerTransitionSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -610,7 +730,11 @@ export async function getCustomerTransitions(
  * must be able to view the request and have the Transition Issues permission. If a comment is passed the user must have
  * the Add Comments permission.
  */
-export async function performCustomerTransition(client: Client, parameters: PerformCustomerTransition): Promise<void> {
+export async function performCustomerTransition(
+  client: Client,
+  parameters: PerformCustomerTransition,
+  options?: RequestOptions,
+): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/request/${parameters.issueIdOrKey}/transition`,
     method: 'POST',
@@ -618,6 +742,7 @@ export async function performCustomerTransition(client: Client, parameters: Perf
       additionalComment: parameters.additionalComment,
       id: parameters.id,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/serviceDesk/api/servicedesk.ts
+++ b/src/serviceDesk/api/servicedesk.ts
@@ -26,7 +26,7 @@ import type { GetRequestTypes } from '../parameters/getRequestTypes';
 import type { GetRequestTypeById } from '../parameters/getRequestTypeById';
 import type { GetRequestTypeFields } from '../parameters/getRequestTypeFields';
 import type { GetRequestTypeGroups } from '../parameters/getRequestTypeGroups';
-import type { Client, SendRequestOptions } from '#/core';
+import type { Client, RequestOptions, SendRequestOptions } from '#/core';
 
 /**
  * This method returns all the service desks in the Jira Service Management instance that the user has permission to
@@ -34,12 +34,16 @@ import type { Client, SendRequestOptions } from '#/core';
  *
  * **Note:** This method will be slow if the instance has hundreds of service desks. If you want to fetch a single
  * service desk by its ID, use
- * [/rest/servicedeskapi/servicedesk/{serviceDeskId}](./#api-rest-servicedeskapi-servicedesk-servicedeskid-get)
+ * [/rest/servicedeskapi/servicedesk/{serviceDeskId}](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#api-rest-servicedeskapi-servicedesk-servicedeskid-get)
  * instead.
  *
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Any
  */
-export async function getServiceDesks(client: Client, parameters?: GetServiceDesks): Promise<Page<ServiceDesk>> {
+export async function getServiceDesks(
+  client: Client,
+  parameters?: GetServiceDesks,
+  options?: RequestOptions,
+): Promise<Page<ServiceDesk>> {
   const config: SendRequestOptions<Page<ServiceDesk>> = {
     url: '/rest/servicedeskapi/servicedesk',
     method: 'GET',
@@ -48,6 +52,7 @@ export async function getServiceDesks(client: Client, parameters?: GetServiceDes
       limit: parameters?.limit,
     },
     schema: PagedServiceDeskSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -61,11 +66,16 @@ export async function getServiceDesks(client: Client, parameters?: GetServiceDes
  * Permission to access the Service Desk. For example, being the Service Desk's Administrator or one of its Agents or
  * Users.
  */
-export async function getServiceDeskById(client: Client, parameters: GetServiceDeskById): Promise<ServiceDesk> {
+export async function getServiceDeskById(
+  client: Client,
+  parameters: GetServiceDeskById,
+  options?: RequestOptions,
+): Promise<ServiceDesk> {
   const config: SendRequestOptions<ServiceDesk> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}`,
     method: 'GET',
     schema: ServiceDeskSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -99,12 +109,14 @@ export async function getServiceDeskById(client: Client, parameters: GetServiceD
 export async function attachTemporaryFile(
   client: Client,
   parameters: AttachTemporaryFileParameters,
+  options?: RequestOptions,
 ): Promise<AttachTemporaryFile> {
   const config: SendRequestOptions<AttachTemporaryFile> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/attachTemporaryFile`,
     method: 'POST',
     body: parameters.body,
     schema: AttachTemporaryFileSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -117,7 +129,7 @@ export async function attachTemporaryFile(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk administrator
  */
-export async function addCustomers(client: Client, parameters: AddCustomers): Promise<void> {
+export async function addCustomers(client: Client, parameters: AddCustomers, options?: RequestOptions): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/customer`,
     method: 'POST',
@@ -125,6 +137,7 @@ export async function addCustomers(client: Client, parameters: AddCustomers): Pr
       accountIds: parameters.accountIds,
       usernames: parameters.usernames,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -146,6 +159,7 @@ export async function addCustomers(client: Client, parameters: AddCustomers): Pr
 export async function addCustomersSkippingPermissionCheck(
   client: Client,
   parameters: AddCustomersSkippingPermissionCheck,
+  options?: RequestOptions,
 ): Promise<void> {
   const config: SendRequestOptions<void> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/customer/skip-permission-check`,
@@ -154,6 +168,7 @@ export async function addCustomersSkippingPermissionCheck(
       accountIds: parameters.accountIds,
       usernames: parameters.usernames,
     },
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -168,6 +183,7 @@ export async function addCustomersSkippingPermissionCheck(
 export async function getServiceDeskArticles(
   client: Client,
   parameters: GetServiceDeskArticles,
+  options?: RequestOptions,
 ): Promise<Page<Article>> {
   const config: SendRequestOptions<Page<Article>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/knowledgebase/article`,
@@ -181,6 +197,7 @@ export async function getServiceDeskArticles(
       prev: parameters.prev,
     },
     schema: PagedArticleSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -193,7 +210,7 @@ export async function getServiceDeskArticles(
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: service
  * desk's Agent.
  */
-export async function getQueues(client: Client, parameters: GetQueues): Promise<Page<Queue>> {
+export async function getQueues(client: Client, parameters: GetQueues, options?: RequestOptions): Promise<Page<Queue>> {
   const config: SendRequestOptions<Page<Queue>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/queue`,
     method: 'GET',
@@ -203,6 +220,7 @@ export async function getQueues(client: Client, parameters: GetQueues): Promise<
       limit: parameters.limit,
     },
     schema: PagedQueueSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -215,7 +233,7 @@ export async function getQueues(client: Client, parameters: GetQueues): Promise<
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: service
  * desk's Agent.
  */
-export async function getQueue(client: Client, parameters: GetQueue): Promise<Queue> {
+export async function getQueue(client: Client, parameters: GetQueue, options?: RequestOptions): Promise<Queue> {
   const config: SendRequestOptions<Queue> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/queue/${parameters.queueId}`,
     method: 'GET',
@@ -223,6 +241,7 @@ export async function getQueue(client: Client, parameters: GetQueue): Promise<Qu
       includeCount: parameters.includeCount,
     },
     schema: QueueSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -236,7 +255,11 @@ export async function getQueue(client: Client, parameters: GetQueue): Promise<Qu
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**: Service
  * desk's agent.
  */
-export async function getIssuesInQueue(client: Client, parameters: GetIssuesInQueue): Promise<Page<Issue>> {
+export async function getIssuesInQueue(
+  client: Client,
+  parameters: GetIssuesInQueue,
+  options?: RequestOptions,
+): Promise<Page<Issue>> {
   const config: SendRequestOptions<Page<Issue>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/queue/${parameters.queueId}/issue`,
     method: 'GET',
@@ -245,6 +268,7 @@ export async function getIssuesInQueue(client: Client, parameters: GetIssuesInQu
       limit: parameters.limit,
     },
     schema: PagedIssueSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -266,7 +290,11 @@ export async function getIssuesInQueue(client: Client, parameters: GetIssuesInQu
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to access the service desk.
  */
-export async function getRequestTypes(client: Client, parameters: GetRequestTypes): Promise<Page<RequestType>> {
+export async function getRequestTypes(
+  client: Client,
+  parameters: GetRequestTypes,
+  options?: RequestOptions,
+): Promise<Page<RequestType>> {
   const config: SendRequestOptions<Page<RequestType>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/requesttype`,
     method: 'GET',
@@ -280,6 +308,7 @@ export async function getRequestTypes(client: Client, parameters: GetRequestType
       restrictionStatus: parameters.restrictionStatus,
     },
     schema: PagedRequestTypeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -293,7 +322,11 @@ export async function getRequestTypes(client: Client, parameters: GetRequestType
  * **[Permissions](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#permissions) required**:
  * Permission to access the service desk.
  */
-export async function getRequestTypeById(client: Client, parameters: GetRequestTypeById): Promise<RequestType> {
+export async function getRequestTypeById(
+  client: Client,
+  parameters: GetRequestTypeById,
+  options?: RequestOptions,
+): Promise<RequestType> {
   const config: SendRequestOptions<RequestType> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/requesttype/${parameters.requestTypeId}`,
     method: 'GET',
@@ -301,6 +334,7 @@ export async function getRequestTypeById(client: Client, parameters: GetRequestT
       expand: parameters.expand,
     },
     schema: RequestTypeSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -322,6 +356,7 @@ export async function getRequestTypeById(client: Client, parameters: GetRequestT
 export async function getRequestTypeFields(
   client: Client,
   parameters: GetRequestTypeFields,
+  options?: RequestOptions,
 ): Promise<CustomerRequestCreateMeta> {
   const config: SendRequestOptions<CustomerRequestCreateMeta> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/requesttype/${parameters.requestTypeId}/field`,
@@ -330,6 +365,7 @@ export async function getRequestTypeFields(
       expand: parameters.expand,
     },
     schema: CustomerRequestCreateMetaSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);
@@ -346,6 +382,7 @@ export async function getRequestTypeFields(
 export async function getRequestTypeGroups(
   client: Client,
   parameters: GetRequestTypeGroups,
+  options?: RequestOptions,
 ): Promise<Page<RequestTypeGroup>> {
   const config: SendRequestOptions<Page<RequestTypeGroup>> = {
     url: `/rest/servicedeskapi/servicedesk/${parameters.serviceDeskId}/requesttypegroup`,
@@ -355,6 +392,7 @@ export async function getRequestTypeGroups(
       limit: parameters.limit,
     },
     schema: PagedRequestTypeGroupSchema,
+    signal: options?.signal,
   };
 
   return await client.sendRequest(config);

--- a/src/serviceDesk/createServiceDeskClient.ts
+++ b/src/serviceDesk/createServiceDeskClient.ts
@@ -1,4 +1,4 @@
-import { type ClientConfig, type Client, createClient, type Buffer } from '#/core';
+import { type ClientConfig, type Client, type RequestOptions, createClient, type Buffer } from '#/core';
 import * as assets from './api/assets';
 import * as customer from './api/customer';
 import * as info from './api/info';
@@ -30,6 +30,7 @@ import type {
   RemoveOrganization,
   GetCustomerRequests,
   CreateCustomerRequest,
+  ValidateCustomerRequest,
   GetCustomerRequestByIdOrKey,
   GetApprovals,
   GetApprovalById,
@@ -77,6 +78,7 @@ import type {
   PropertyKeys,
   EntityProperty,
   CustomerRequest,
+  RequestValidationResult,
   Approval,
   Attachment,
   AttachmentCreateResult,
@@ -99,120 +101,173 @@ export function createServiceDeskClient(clientConfig: ClientConfig | Client) {
 
   return {
     assets: {
-      getAssetsWorkspaces: (parameters?: GetAssetsWorkspaces): Promise<Page<AssetsWorkspace>> =>
-        assets.getAssetsWorkspaces(client, parameters),
-      getInsightWorkspaces: (parameters?: GetInsightWorkspaces): Promise<Page<InsightWorkspace>> =>
-        assets.getInsightWorkspaces(client, parameters),
+      getAssetsWorkspaces: (
+        parameters?: GetAssetsWorkspaces,
+        options?: RequestOptions,
+      ): Promise<Page<AssetsWorkspace>> => assets.getAssetsWorkspaces(client, parameters, options),
+      getInsightWorkspaces: (
+        parameters?: GetInsightWorkspaces,
+        options?: RequestOptions,
+      ): Promise<Page<InsightWorkspace>> => assets.getInsightWorkspaces(client, parameters, options),
     },
     customer: {
-      createCustomer: (parameters: CreateCustomer): Promise<User> => customer.createCustomer(client, parameters),
-      createCustomerSkippingPermissionCheck: (parameters: CreateCustomerSkippingPermissionCheck): Promise<User> =>
-        customer.createCustomerSkippingPermissionCheck(client, parameters),
-      revokePortalOnlyAccessForUser: (parameters: RevokePortalOnlyAccessForUser): Promise<void> =>
-        customer.revokePortalOnlyAccessForUser(client, parameters),
+      createCustomer: (parameters: CreateCustomer, options?: RequestOptions): Promise<User> =>
+        customer.createCustomer(client, parameters, options),
+      createCustomerSkippingPermissionCheck: (
+        parameters: CreateCustomerSkippingPermissionCheck,
+        options?: RequestOptions,
+      ): Promise<User> => customer.createCustomerSkippingPermissionCheck(client, parameters, options),
+      revokePortalOnlyAccessForUser: (
+        parameters: RevokePortalOnlyAccessForUser,
+        options?: RequestOptions,
+      ): Promise<void> => customer.revokePortalOnlyAccessForUser(client, parameters, options),
     },
     info: {
-      getInfo: (): Promise<SoftwareInfo> => info.getInfo(client),
+      getInfo: (options?: RequestOptions): Promise<SoftwareInfo> => info.getInfo(client, options),
     },
     knowledgebase: {
-      getArticles: (parameters: GetArticles): Promise<Page<Article>> => knowledgebase.getArticles(client, parameters),
-      viewArticle: (parameters: ViewArticle): Promise<string> => knowledgebase.viewArticle(client, parameters),
+      getArticles: (parameters: GetArticles, options?: RequestOptions): Promise<Page<Article>> =>
+        knowledgebase.getArticles(client, parameters, options),
+      viewArticle: (parameters: ViewArticle, options?: RequestOptions): Promise<string> =>
+        knowledgebase.viewArticle(client, parameters, options),
     },
     organization: {
-      getOrganizations: (parameters?: GetOrganizations): Promise<Page<Organization>> =>
-        organization.getOrganizations(client, parameters),
-      createOrganization: (parameters: CreateOrganization): Promise<Organization> =>
-        organization.createOrganization(client, parameters),
-      getOrganization: (parameters: GetOrganization): Promise<Organization> =>
-        organization.getOrganization(client, parameters),
-      deleteOrganization: (parameters: DeleteOrganization): Promise<void> =>
-        organization.deleteOrganization(client, parameters),
-      getPropertiesKeys: (parameters: GetPropertiesKeys): Promise<PropertyKeys> =>
-        organization.getPropertiesKeys(client, parameters),
-      getProperty: (parameters: GetProperty): Promise<EntityProperty> => organization.getProperty(client, parameters),
-      setProperty: (parameters: SetProperty): Promise<void> => organization.setProperty(client, parameters),
-      deleteProperty: (parameters: DeleteProperty): Promise<void> => organization.deleteProperty(client, parameters),
-      getUsersInOrganization: (parameters: GetUsersInOrganization): Promise<Page<User>> =>
-        organization.getUsersInOrganization(client, parameters),
-      addUsersToOrganization: (parameters: AddUsersToOrganization): Promise<void> =>
-        organization.addUsersToOrganization(client, parameters),
-      removeUsersFromOrganization: (parameters: RemoveUsersFromOrganization): Promise<void> =>
-        organization.removeUsersFromOrganization(client, parameters),
-      getServiceDeskOrganizations: (parameters: GetServiceDeskOrganizations): Promise<Page<Organization>> =>
-        organization.getServiceDeskOrganizations(client, parameters),
-      addOrganization: (parameters: AddOrganization): Promise<void> => organization.addOrganization(client, parameters),
-      removeOrganization: (parameters: RemoveOrganization): Promise<void> =>
-        organization.removeOrganization(client, parameters),
+      getOrganizations: (parameters?: GetOrganizations, options?: RequestOptions): Promise<Page<Organization>> =>
+        organization.getOrganizations(client, parameters, options),
+      createOrganization: (parameters: CreateOrganization, options?: RequestOptions): Promise<Organization> =>
+        organization.createOrganization(client, parameters, options),
+      getOrganization: (parameters: GetOrganization, options?: RequestOptions): Promise<Organization> =>
+        organization.getOrganization(client, parameters, options),
+      deleteOrganization: (parameters: DeleteOrganization, options?: RequestOptions): Promise<void> =>
+        organization.deleteOrganization(client, parameters, options),
+      getPropertiesKeys: (parameters: GetPropertiesKeys, options?: RequestOptions): Promise<PropertyKeys> =>
+        organization.getPropertiesKeys(client, parameters, options),
+      getProperty: (parameters: GetProperty, options?: RequestOptions): Promise<EntityProperty> =>
+        organization.getProperty(client, parameters, options),
+      setProperty: (parameters: SetProperty, options?: RequestOptions): Promise<void> =>
+        organization.setProperty(client, parameters, options),
+      deleteProperty: (parameters: DeleteProperty, options?: RequestOptions): Promise<void> =>
+        organization.deleteProperty(client, parameters, options),
+      getUsersInOrganization: (parameters: GetUsersInOrganization, options?: RequestOptions): Promise<Page<User>> =>
+        organization.getUsersInOrganization(client, parameters, options),
+      addUsersToOrganization: (parameters: AddUsersToOrganization, options?: RequestOptions): Promise<void> =>
+        organization.addUsersToOrganization(client, parameters, options),
+      removeUsersFromOrganization: (parameters: RemoveUsersFromOrganization, options?: RequestOptions): Promise<void> =>
+        organization.removeUsersFromOrganization(client, parameters, options),
+      getServiceDeskOrganizations: (
+        parameters: GetServiceDeskOrganizations,
+        options?: RequestOptions,
+      ): Promise<Page<Organization>> => organization.getServiceDeskOrganizations(client, parameters, options),
+      addOrganization: (parameters: AddOrganization, options?: RequestOptions): Promise<void> =>
+        organization.addOrganization(client, parameters, options),
+      removeOrganization: (parameters: RemoveOrganization, options?: RequestOptions): Promise<void> =>
+        organization.removeOrganization(client, parameters, options),
     },
     request: {
-      getCustomerRequests: (parameters?: GetCustomerRequests): Promise<Page<CustomerRequest>> =>
-        request.getCustomerRequests(client, parameters),
-      createCustomerRequest: (parameters: CreateCustomerRequest): Promise<CustomerRequest> =>
-        request.createCustomerRequest(client, parameters),
-      getCustomerRequestByIdOrKey: (parameters: GetCustomerRequestByIdOrKey): Promise<CustomerRequest> =>
-        request.getCustomerRequestByIdOrKey(client, parameters),
-      getApprovals: (parameters: GetApprovals): Promise<Page<Approval>> => request.getApprovals(client, parameters),
-      getApprovalById: (parameters: GetApprovalById): Promise<Approval> => request.getApprovalById(client, parameters),
-      answerApproval: (parameters: AnswerApproval): Promise<Approval> => request.answerApproval(client, parameters),
-      getAttachmentsForRequest: (parameters: GetAttachmentsForRequest): Promise<Page<Attachment>> =>
-        request.getAttachmentsForRequest(client, parameters),
-      createCommentWithAttachment: (parameters: CreateCommentWithAttachment): Promise<AttachmentCreateResult> =>
-        request.createCommentWithAttachment(client, parameters),
-      getAttachmentContent: (parameters: GetAttachmentContent): Promise<Buffer> =>
-        request.getAttachmentContent(client, parameters),
-      getAttachmentThumbnail: (parameters: GetAttachmentThumbnail): Promise<Buffer> =>
-        request.getAttachmentThumbnail(client, parameters),
-      getRequestComments: (parameters: GetRequestComments): Promise<Page<Comment>> =>
-        request.getRequestComments(client, parameters),
-      createRequestComment: (parameters: CreateRequestComment): Promise<Comment> =>
-        request.createRequestComment(client, parameters),
-      getRequestCommentById: (parameters: GetRequestCommentById): Promise<Comment> =>
-        request.getRequestCommentById(client, parameters),
-      getSubscriptionStatus: (parameters: GetSubscriptionStatus): Promise<RequestNotificationSubscription> =>
-        request.getSubscriptionStatus(client, parameters),
-      subscribe: (parameters: Subscribe): Promise<void> => request.subscribe(client, parameters),
-      unsubscribe: (parameters: Unsubscribe): Promise<void> => request.unsubscribe(client, parameters),
-      getRequestParticipants: (parameters: GetRequestParticipants): Promise<Page<User>> =>
-        request.getRequestParticipants(client, parameters),
-      addRequestParticipants: (parameters: AddRequestParticipants): Promise<Page<User>> =>
-        request.addRequestParticipants(client, parameters),
-      removeRequestParticipants: (parameters: RemoveRequestParticipants): Promise<Page<User>> =>
-        request.removeRequestParticipants(client, parameters),
-      getSlaInformation: (parameters: GetSlaInformation): Promise<Page<SlaInformation>> =>
-        request.getSlaInformation(client, parameters),
-      getSlaInformationById: (parameters: GetSlaInformationById): Promise<SlaInformation> =>
-        request.getSlaInformationById(client, parameters),
-      getCustomerRequestStatus: (parameters: GetCustomerRequestStatus): Promise<Page<CustomerRequestStatus>> =>
-        request.getCustomerRequestStatus(client, parameters),
-      getCustomerTransitions: (parameters: GetCustomerTransitions): Promise<Page<CustomerTransition>> =>
-        request.getCustomerTransitions(client, parameters),
-      performCustomerTransition: (parameters: PerformCustomerTransition): Promise<void> =>
-        request.performCustomerTransition(client, parameters),
+      getCustomerRequests: (
+        parameters?: GetCustomerRequests,
+        options?: RequestOptions,
+      ): Promise<Page<CustomerRequest>> => request.getCustomerRequests(client, parameters, options),
+      createCustomerRequest: (parameters: CreateCustomerRequest, options?: RequestOptions): Promise<CustomerRequest> =>
+        request.createCustomerRequest(client, parameters, options),
+      validateCustomerRequest: (
+        parameters: ValidateCustomerRequest,
+        options?: RequestOptions,
+      ): Promise<RequestValidationResult> => request.validateCustomerRequest(client, parameters, options),
+      getCustomerRequestByIdOrKey: (
+        parameters: GetCustomerRequestByIdOrKey,
+        options?: RequestOptions,
+      ): Promise<CustomerRequest> => request.getCustomerRequestByIdOrKey(client, parameters, options),
+      getApprovals: (parameters: GetApprovals, options?: RequestOptions): Promise<Page<Approval>> =>
+        request.getApprovals(client, parameters, options),
+      getApprovalById: (parameters: GetApprovalById, options?: RequestOptions): Promise<Approval> =>
+        request.getApprovalById(client, parameters, options),
+      answerApproval: (parameters: AnswerApproval, options?: RequestOptions): Promise<Approval> =>
+        request.answerApproval(client, parameters, options),
+      getAttachmentsForRequest: (
+        parameters: GetAttachmentsForRequest,
+        options?: RequestOptions,
+      ): Promise<Page<Attachment>> => request.getAttachmentsForRequest(client, parameters, options),
+      createCommentWithAttachment: (
+        parameters: CreateCommentWithAttachment,
+        options?: RequestOptions,
+      ): Promise<AttachmentCreateResult> => request.createCommentWithAttachment(client, parameters, options),
+      getAttachmentContent: (parameters: GetAttachmentContent, options?: RequestOptions): Promise<Buffer> =>
+        request.getAttachmentContent(client, parameters, options),
+      getAttachmentThumbnail: (parameters: GetAttachmentThumbnail, options?: RequestOptions): Promise<Buffer> =>
+        request.getAttachmentThumbnail(client, parameters, options),
+      getRequestComments: (parameters: GetRequestComments, options?: RequestOptions): Promise<Page<Comment>> =>
+        request.getRequestComments(client, parameters, options),
+      createRequestComment: (parameters: CreateRequestComment, options?: RequestOptions): Promise<Comment> =>
+        request.createRequestComment(client, parameters, options),
+      getRequestCommentById: (parameters: GetRequestCommentById, options?: RequestOptions): Promise<Comment> =>
+        request.getRequestCommentById(client, parameters, options),
+      getSubscriptionStatus: (
+        parameters: GetSubscriptionStatus,
+        options?: RequestOptions,
+      ): Promise<RequestNotificationSubscription> => request.getSubscriptionStatus(client, parameters, options),
+      subscribe: (parameters: Subscribe, options?: RequestOptions): Promise<void> =>
+        request.subscribe(client, parameters, options),
+      unsubscribe: (parameters: Unsubscribe, options?: RequestOptions): Promise<void> =>
+        request.unsubscribe(client, parameters, options),
+      getRequestParticipants: (parameters: GetRequestParticipants, options?: RequestOptions): Promise<Page<User>> =>
+        request.getRequestParticipants(client, parameters, options),
+      addRequestParticipants: (parameters: AddRequestParticipants, options?: RequestOptions): Promise<Page<User>> =>
+        request.addRequestParticipants(client, parameters, options),
+      removeRequestParticipants: (
+        parameters: RemoveRequestParticipants,
+        options?: RequestOptions,
+      ): Promise<Page<User>> => request.removeRequestParticipants(client, parameters, options),
+      getSlaInformation: (parameters: GetSlaInformation, options?: RequestOptions): Promise<Page<SlaInformation>> =>
+        request.getSlaInformation(client, parameters, options),
+      getSlaInformationById: (parameters: GetSlaInformationById, options?: RequestOptions): Promise<SlaInformation> =>
+        request.getSlaInformationById(client, parameters, options),
+      getCustomerRequestStatus: (
+        parameters: GetCustomerRequestStatus,
+        options?: RequestOptions,
+      ): Promise<Page<CustomerRequestStatus>> => request.getCustomerRequestStatus(client, parameters, options),
+      getCustomerTransitions: (
+        parameters: GetCustomerTransitions,
+        options?: RequestOptions,
+      ): Promise<Page<CustomerTransition>> => request.getCustomerTransitions(client, parameters, options),
+      performCustomerTransition: (parameters: PerformCustomerTransition, options?: RequestOptions): Promise<void> =>
+        request.performCustomerTransition(client, parameters, options),
     },
     servicedesk: {
-      getServiceDesks: (parameters?: GetServiceDesks): Promise<Page<ServiceDesk>> =>
-        servicedesk.getServiceDesks(client, parameters),
-      getServiceDeskById: (parameters: GetServiceDeskById): Promise<ServiceDesk> =>
-        servicedesk.getServiceDeskById(client, parameters),
-      attachTemporaryFile: (parameters: AttachTemporaryFile): Promise<AttachTemporaryFileModel> =>
-        servicedesk.attachTemporaryFile(client, parameters),
-      addCustomers: (parameters: AddCustomers): Promise<void> => servicedesk.addCustomers(client, parameters),
-      addCustomersSkippingPermissionCheck: (parameters: AddCustomersSkippingPermissionCheck): Promise<void> =>
-        servicedesk.addCustomersSkippingPermissionCheck(client, parameters),
-      getServiceDeskArticles: (parameters: GetServiceDeskArticles): Promise<Page<Article>> =>
-        servicedesk.getServiceDeskArticles(client, parameters),
-      getQueues: (parameters: GetQueues): Promise<Page<Queue>> => servicedesk.getQueues(client, parameters),
-      getQueue: (parameters: GetQueue): Promise<Queue> => servicedesk.getQueue(client, parameters),
-      getIssuesInQueue: (parameters: GetIssuesInQueue): Promise<Page<Issue>> =>
-        servicedesk.getIssuesInQueue(client, parameters),
-      getRequestTypes: (parameters: GetRequestTypes): Promise<Page<RequestType>> =>
-        servicedesk.getRequestTypes(client, parameters),
-      getRequestTypeById: (parameters: GetRequestTypeById): Promise<RequestType> =>
-        servicedesk.getRequestTypeById(client, parameters),
-      getRequestTypeFields: (parameters: GetRequestTypeFields): Promise<CustomerRequestCreateMeta> =>
-        servicedesk.getRequestTypeFields(client, parameters),
-      getRequestTypeGroups: (parameters: GetRequestTypeGroups): Promise<Page<RequestTypeGroup>> =>
-        servicedesk.getRequestTypeGroups(client, parameters),
+      getServiceDesks: (parameters?: GetServiceDesks, options?: RequestOptions): Promise<Page<ServiceDesk>> =>
+        servicedesk.getServiceDesks(client, parameters, options),
+      getServiceDeskById: (parameters: GetServiceDeskById, options?: RequestOptions): Promise<ServiceDesk> =>
+        servicedesk.getServiceDeskById(client, parameters, options),
+      attachTemporaryFile: (
+        parameters: AttachTemporaryFile,
+        options?: RequestOptions,
+      ): Promise<AttachTemporaryFileModel> => servicedesk.attachTemporaryFile(client, parameters, options),
+      addCustomers: (parameters: AddCustomers, options?: RequestOptions): Promise<void> =>
+        servicedesk.addCustomers(client, parameters, options),
+      addCustomersSkippingPermissionCheck: (
+        parameters: AddCustomersSkippingPermissionCheck,
+        options?: RequestOptions,
+      ): Promise<void> => servicedesk.addCustomersSkippingPermissionCheck(client, parameters, options),
+      getServiceDeskArticles: (parameters: GetServiceDeskArticles, options?: RequestOptions): Promise<Page<Article>> =>
+        servicedesk.getServiceDeskArticles(client, parameters, options),
+      getQueues: (parameters: GetQueues, options?: RequestOptions): Promise<Page<Queue>> =>
+        servicedesk.getQueues(client, parameters, options),
+      getQueue: (parameters: GetQueue, options?: RequestOptions): Promise<Queue> =>
+        servicedesk.getQueue(client, parameters, options),
+      getIssuesInQueue: (parameters: GetIssuesInQueue, options?: RequestOptions): Promise<Page<Issue>> =>
+        servicedesk.getIssuesInQueue(client, parameters, options),
+      getRequestTypes: (parameters: GetRequestTypes, options?: RequestOptions): Promise<Page<RequestType>> =>
+        servicedesk.getRequestTypes(client, parameters, options),
+      getRequestTypeById: (parameters: GetRequestTypeById, options?: RequestOptions): Promise<RequestType> =>
+        servicedesk.getRequestTypeById(client, parameters, options),
+      getRequestTypeFields: (
+        parameters: GetRequestTypeFields,
+        options?: RequestOptions,
+      ): Promise<CustomerRequestCreateMeta> => servicedesk.getRequestTypeFields(client, parameters, options),
+      getRequestTypeGroups: (
+        parameters: GetRequestTypeGroups,
+        options?: RequestOptions,
+      ): Promise<Page<RequestTypeGroup>> => servicedesk.getRequestTypeGroups(client, parameters, options),
     },
   };
 }

--- a/src/serviceDesk/models/index.ts
+++ b/src/serviceDesk/models/index.ts
@@ -172,6 +172,8 @@ export * from './renderedValue';
 
 export * from './requestCreate';
 
+export * from './requestFieldValidationError';
+
 export * from './requestNotificationSubscription';
 
 export * from './requestParticipantUpdate';
@@ -193,6 +195,8 @@ export * from './requestTypeIconLink';
 export * from './requestTypePermissionCheckRequest';
 
 export * from './requestTypePermissionCheckResponse';
+
+export * from './requestValidationResult';
 
 export * from './resource';
 

--- a/src/serviceDesk/models/requestFieldValidationError.ts
+++ b/src/serviceDesk/models/requestFieldValidationError.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { apiObject } from '#/core';
+
+export const RequestFieldValidationErrorSchema = apiObject({
+  /** The id of the request field that failed validation (matches a key in 'requestFieldValues'). */
+  field: z.string().optional(),
+  /** A human-readable explanation of why this field failed validation. */
+  message: z.string().optional(),
+});
+
+export type RequestFieldValidationError = z.infer<typeof RequestFieldValidationErrorSchema>;

--- a/src/serviceDesk/models/requestValidationResult.ts
+++ b/src/serviceDesk/models/requestValidationResult.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { apiObject } from '#/core';
+import { RequestFieldValidationErrorSchema } from './requestFieldValidationError';
+import { FormValidationErrorSchema } from './formValidationError';
+
+export const RequestValidationResultSchema = apiObject({
+  /** A single, human-readable summary describing why validation failed. Null when valid. */
+  errorMessage: z.string().optional(),
+  /** General validation errors that are not attributable to a single field. Empty when valid. */
+  errorMessages: z.array(z.string()).optional(),
+  /** Field-level validation errors, keyed by the failing request field id. Empty when valid. */
+  fieldErrors: z.array(RequestFieldValidationErrorSchema).optional(),
+  /** ProForma form validation errors, if a form was supplied. Empty when valid or no form was present. */
+  formErrors: z.array(FormValidationErrorSchema).optional(),
+  /** A machine-readable reason key categorising the overall failure. Null when valid. */
+  reasonKey: z.string().optional(),
+  /** True when the payload is both structurally and semantically valid and safe to create. */
+  valid: z.boolean().optional(),
+});
+
+export type RequestValidationResult = z.infer<typeof RequestValidationResultSchema>;

--- a/src/serviceDesk/parameters/attachTemporaryFile.ts
+++ b/src/serviceDesk/parameters/attachTemporaryFile.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MultipartFileSchema } from '../models';
 
 export const AttachTemporaryFileSchema = z.object({
   /**
@@ -6,7 +7,7 @@ export const AttachTemporaryFileSchema = z.object({
    * identifier.](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro#project-identifiers)
    */
   serviceDeskId: z.string(),
-  body: z.record(z.string(), z.any()),
+  body: z.array(MultipartFileSchema),
 });
 
 export type AttachTemporaryFile = z.input<typeof AttachTemporaryFileSchema>;

--- a/src/serviceDesk/parameters/index.ts
+++ b/src/serviceDesk/parameters/index.ts
@@ -112,4 +112,6 @@ export * from './subscribe';
 
 export * from './unsubscribe';
 
+export * from './validateCustomerRequest';
+
 export * from './viewArticle';

--- a/src/serviceDesk/parameters/validateCustomerRequest.ts
+++ b/src/serviceDesk/parameters/validateCustomerRequest.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { RequestCreateSchema } from '../models';
+
+export const ValidateCustomerRequestSchema = z.object(RequestCreateSchema.shape);
+
+export type ValidateCustomerRequest = z.input<typeof ValidateCustomerRequestSchema>;

--- a/tests/live/cloud/abort.test.ts
+++ b/tests/live/cloud/abort.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Cancellation, against a real request rather than a stubbed one.
+ *
+ * A unit test can prove the signal reaches `fetch`; only a real request proves it reaches the socket, and that the
+ * rejection arrives promptly rather than after the response would have.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { CloudClient } from '#/cloud/createCloudClient';
+import { isAuthError, isNetworkError } from '#/core';
+import { getCloudClient } from '../setup/client';
+
+describe('Jira Cloud — cancellation (live)', () => {
+  let client: CloudClient;
+
+  beforeAll(() => {
+    client = getCloudClient();
+  });
+
+  it('aborts an in-flight request and rethrows the reason unwrapped', async () => {
+    const controller = new AbortController();
+    const reason = new Error('caller changed their mind');
+
+    const pending = client.projects.searchProjects({ maxResults: 50 }, { signal: controller.signal });
+
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+  });
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const started = Date.now();
+    const error = await client.projects
+      .searchProjects({ maxResults: 1 }, { signal: AbortSignal.abort() })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(isNetworkError(error)).toBe(false);
+    expect(isAuthError(error)).toBe(false);
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it('lets a request finish when the signal is never aborted', async () => {
+    const controller = new AbortController();
+
+    await expect(
+      client.projects.searchProjects({ maxResults: 1 }, { signal: controller.signal }),
+    ).resolves.toHaveProperty('values');
+  });
+});

--- a/tests/live/cloud/appMigration.test.ts
+++ b/tests/live/cloud/appMigration.test.ts
@@ -1,0 +1,51 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { CloudClient } from '#/cloud/createCloudClient';
+import { getCloudClient } from '../setup/client';
+
+/**
+ * Live suite for the `appMigration` API (`updateEntityPropertiesValue`, `updateIssueFields`).
+ *
+ * These sit on `/rest/atlassian-connect/1/migration`, addressed with a JWT a Connect app mints while moving customer
+ * data from server to cloud. A user token has no claim to that identity at all, so — like the `appProperties` family —
+ * the failure is about *who is asking* rather than about permission, and no credential this suite can hold will ever
+ * reach them.
+ *
+ * They are also writes into an app's migrated data, which is reason enough not to succeed at one. So what is worth
+ * pinning is the refusal: it has to arrive as a typed error carrying its status, rather than as a bare rejection or as
+ * a quietly successful no-op.
+ *
+ * The body shape these declare is checked where it can be — `tests/unit/nonObjectBodies.test.ts` asserts the property
+ * list leaves the client as a top-level array, which a live run that never reaches the endpoint cannot show.
+ */
+describe('Jira Cloud — app migration (live)', () => {
+  let client: CloudClient;
+
+  beforeAll(() => {
+    client = getCloudClient();
+  });
+
+  it('refuses the property-value update typed, and writes nothing', async () => {
+    const error = await client.appMigration
+      .updateEntityPropertiesValue({
+        'Atlassian-Transfer-Id': 'jira-js-live-test-no-such-transfer',
+        entityType: 'IssueProperty',
+        body: [{ entityId: 99999999, key: 'jira.js.livetest', value: 'never-written' }],
+      })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { status?: number }).status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('refuses the issue-field update typed as well, whose body is wrapped rather than bare', async () => {
+    const error = await client.appMigration
+      .updateIssueFields({
+        'Atlassian-Transfer-Id': 'jira-js-live-test-no-such-transfer',
+        updateValueList: [{ _type: 'StringIssueField', issueID: 99999999, fieldID: 99999999, string: 'never-written' }],
+      })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { status?: number }).status).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/tests/live/cloud/auth.test.ts
+++ b/tests/live/cloud/auth.test.ts
@@ -1,0 +1,62 @@
+/**
+ * A refused credential is an error, whatever status Jira dresses it in.
+ *
+ * The reason this suite exists rather than a unit test alone: the behaviour it pins is Jira's, not ours. Roughly a
+ * quarter of the platform's operations can be reached anonymously, and on those a dead API token does not fail the
+ * request — Jira serves it as the anonymous user and reports the refusal only in `X-Seraph-LoginReason`. Both halves
+ * of that sentence are checked here against the real site, so a change on Atlassian's side surfaces as a red test
+ * rather than as a silently empty result in someone's integration.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createCloudClient, type CloudClient } from '#/cloud/createCloudClient';
+import { isAuthError, type ApiError } from '#/core';
+import { requireLiveEnv } from '../setup/env';
+import { getCloudClient, rawRequest } from '../setup/client';
+
+const DEAD_TOKEN = 'this-api-token-was-never-valid';
+
+describe('Jira Cloud — refused credentials (live)', () => {
+  let valid: CloudClient;
+  let dead: CloudClient;
+
+  beforeAll(() => {
+    const { host, email } = requireLiveEnv();
+
+    valid = getCloudClient();
+    dead = createCloudClient({ host, auth: { type: 'basic', email, apiToken: DEAD_TOKEN } });
+  });
+
+  it('answers an anonymous-accessible endpoint with 2xx and the refusal header', async () => {
+    const { email } = requireLiveEnv();
+    const credentials = Buffer.from(`${email}:${DEAD_TOKEN}`).toString('base64');
+    const { host } = requireLiveEnv();
+
+    const response = await fetch(`${host}/rest/api/3/project/search?maxResults=1`, {
+      headers: { authorization: `Basic ${credentials}`, accept: 'application/json' },
+    });
+
+    expect(response.headers.get('x-seraph-loginreason')).toBe('AUTHENTICATED_FAILED');
+    expect(response.ok).toBe(true);
+  });
+
+  it('throws instead of handing back the anonymous result', async () => {
+    const error = await dead.projects.searchProjects({ maxResults: 1 }).catch((e: unknown) => e);
+
+    expect(isAuthError(error)).toBe(true);
+    expect((error as ApiError).message).toContain('x-seraph-loginreason');
+  });
+
+  it('throws on an endpoint that refuses anonymous access too', async () => {
+    const error = await dead.myself.getCurrentUser().catch((e: unknown) => e);
+
+    expect(isAuthError(error)).toBe(true);
+  });
+
+  it('leaves a working token alone — no header, no error', async () => {
+    const response = await rawRequest('/rest/api/3/project/search?maxResults=1');
+
+    expect(response.headers.get('x-seraph-loginreason')).toBeNull();
+
+    await expect(valid.projects.searchProjects({ maxResults: 1 })).resolves.toHaveProperty('values');
+  });
+});

--- a/tests/live/cloud/issueWatchers.test.ts
+++ b/tests/live/cloud/issueWatchers.test.ts
@@ -20,14 +20,6 @@ import { createTestIssue, TEST_PROJECT_KEY, type TestIssue } from '../setup/fixt
  * Strings are JSON-encoded now, so the endpoint works through the client and this suite exercises it directly.
  */
 
-/**
- * The parameter type still declares an object where the endpoint wants a lone string — a specification quirk the cast
- * records rather than hides. What changed is the transport underneath it, not this declaration.
- */
-function accountIdBody(accountId: string): Record<string, unknown> {
-  return accountId as unknown as Record<string, unknown>;
-}
-
 describe('Jira Cloud — issueWatchers (live)', () => {
   const tracker = new ResourceTracker();
   let client: CloudClient;
@@ -53,7 +45,7 @@ describe('Jira Cloud — issueWatchers (live)', () => {
   });
 
   it('adds the calling account as a watcher, observable on the next read', async () => {
-    await client.issueWatchers.addWatcher({ issueIdOrKey: issue.key, body: accountIdBody(accountId) });
+    await client.issueWatchers.addWatcher({ issueIdOrKey: issue.key, body: accountId });
 
     const watchers = await client.issueWatchers.getIssueWatchers({ issueIdOrKey: issue.key });
 
@@ -64,7 +56,7 @@ describe('Jira Cloud — issueWatchers (live)', () => {
   it('treats a repeated add as idempotent rather than cumulative', async () => {
     const before = await client.issueWatchers.getIssueWatchers({ issueIdOrKey: issue.key });
 
-    await client.issueWatchers.addWatcher({ issueIdOrKey: issue.key, body: accountIdBody(accountId) });
+    await client.issueWatchers.addWatcher({ issueIdOrKey: issue.key, body: accountId });
 
     const after = await client.issueWatchers.getIssueWatchers({ issueIdOrKey: issue.key });
 
@@ -88,7 +80,7 @@ describe('Jira Cloud — issueWatchers (live)', () => {
 
   it('rejects an unknown account id rather than silently ignoring it', async () => {
     const error = await client.issueWatchers
-      .addWatcher({ issueIdOrKey: issue.key, body: accountIdBody('no-such-account-id') })
+      .addWatcher({ issueIdOrKey: issue.key, body: 'no-such-account-id' })
       .catch((e: unknown) => e);
 
     expect(error).toBeInstanceOf(Error);

--- a/tests/live/cloud/myself.test.ts
+++ b/tests/live/cloud/myself.test.ts
@@ -14,16 +14,6 @@ import { getCloudClient } from '../setup/client';
 /** Namespaced so a failed run can never clobber a real user preference. */
 const PREFERENCE_KEY = 'jira.js.livetest.preference';
 
-/**
- * `setPreference` declares its body as an object, but the endpoint is plain text: it stores whatever bytes it is given
- * and `getPreference` hands them straight back (verified live — a raw `raw-text-value` body reads back verbatim, and
- * the response schema is `z.string()` precisely because of that). The declared parameter type is wrong, inherited from
- * the specification; the cast records the mismatch here rather than papering over it, and the fix belongs upstream.
- */
-function preferenceBody(value: string): Record<string, unknown> {
-  return value as unknown as Record<string, unknown>;
-}
-
 describe('Jira Cloud — myself.getCurrentUser (live)', () => {
   let client: CloudClient;
 
@@ -80,7 +70,7 @@ describe('Jira Cloud — myself preferences (live, round trip)', () => {
   });
 
   it('stores a preference and reads back exactly what was written', async () => {
-    await client.myself.setPreference({ key: PREFERENCE_KEY, body: preferenceBody('stored-by-live-test') });
+    await client.myself.setPreference({ key: PREFERENCE_KEY, body: 'stored-by-live-test' });
 
     const value = await client.myself.getPreference({ key: PREFERENCE_KEY });
 
@@ -88,13 +78,13 @@ describe('Jira Cloud — myself preferences (live, round trip)', () => {
   });
 
   it('overwrites rather than appending on a second write', async () => {
-    await client.myself.setPreference({ key: PREFERENCE_KEY, body: preferenceBody('second') });
+    await client.myself.setPreference({ key: PREFERENCE_KEY, body: 'second' });
 
     expect(await client.myself.getPreference({ key: PREFERENCE_KEY })).toBe('second');
   });
 
   it('makes the preference unreadable once removed', async () => {
-    await client.myself.setPreference({ key: PREFERENCE_KEY, body: preferenceBody('transient') });
+    await client.myself.setPreference({ key: PREFERENCE_KEY, body: 'transient' });
     await client.myself.removePreference({ key: PREFERENCE_KEY });
 
     const error = await client.myself.getPreference({ key: PREFERENCE_KEY }).catch((e: unknown) => e);

--- a/tests/live/serviceDesk/info.test.ts
+++ b/tests/live/serviceDesk/info.test.ts
@@ -5,7 +5,7 @@ import { getClient } from '../setup/client';
 
 /**
  * Live suite for the Service Management `info` and `servicedesk` APIs (`getInfo`, `getServiceDesks`,
- * `getServiceDeskById`, `getQueues`, `getRequestTypes`).
+ * `getServiceDeskById`, `getQueues`, `getRequestTypes`, `attachTemporaryFile`).
  *
  * The third surface, and the one whose availability is not a single yes or no. On this tenant the product *is*
  * installed — `getInfo` answers with a version — while every service-desk endpoint refuses with 403, because the
@@ -85,6 +85,18 @@ describe('Jira Service Management — info and service desks (live)', () => {
     const requestTypes = await serviceDesk.servicedesk.getRequestTypes({ serviceDeskId: String(first.id) });
 
     expect(Array.isArray(requestTypes.values)).toBe(true);
+  });
+
+  it('never uploads a temporary attachment, and fails typed on the attempt', async () => {
+    const error = await serviceDesk.servicedesk
+      .attachTemporaryFile({
+        serviceDeskId: '99999999',
+        body: [{ name: 'file', originalFilename: 'jira-js-live-test.txt', contentType: 'text/plain', size: 0 }],
+      })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { status?: number }).status).toBeGreaterThanOrEqual(400);
   });
 
   it('surfaces an unknown service desk as a typed error', async () => {

--- a/tests/unit/core/createClient.test.ts
+++ b/tests/unit/core/createClient.test.ts
@@ -5,9 +5,12 @@ import {
   BlobSchema,
   BufferSchema,
   createClient,
+  isAuthError,
+  isForbiddenError,
   isNetworkError,
   isSchemaMismatchError,
   resetSchemaMismatchReporting,
+  type AuthError,
   type NetworkError,
   type SchemaMismatchError,
   type SchemaMismatchReport,
@@ -58,6 +61,24 @@ describe('auth headers', () => {
     const expected = `Basic ${Buffer.from('a@b.co:secret').toString('base64')}`;
 
     expect((calls[0].init.headers as Record<string, string>).Authorization).toBe(expected);
+  });
+
+  it('base64-encodes username and password for Data Center basic auth', async () => {
+    const calls = mockFetch([json({})]);
+
+    await createClient({ host: HOST, auth: { type: 'basic', username: 'jdoe', password: 'hunter2' } })
+      .sendRequest({ url: '/x', method: 'GET' });
+
+    const expected = `Basic ${Buffer.from('jdoe:hunter2').toString('base64')}`;
+
+    expect((calls[0].init.headers as Record<string, string>).Authorization).toBe(expected);
+  });
+
+  it('rejects a basic credential that mixes the two forms', async () => {
+    mockFetch([json({})]);
+
+    expect(() => createClient({ host: HOST, auth: { email: 'a@b.co', password: 'hunter2' } as never }))
+      .toThrow();
   });
 
   it('sends a static bearer token', async () => {
@@ -421,5 +442,210 @@ describe('headers and body', () => {
       .sendRequest({ url: '/x', method: 'GET', headers: { 'X-Trace': 'request' } });
 
     expect((calls[0].init.headers as Record<string, string>)['X-Trace']).toBe('request');
+  });
+
+  it('drops a header the caller left out instead of sending the word undefined', async () => {
+    const calls = mockFetch([json({})]);
+
+    await createClient({ host: HOST }).sendRequest({ url: '/x', method: 'GET', headers: { 'If-Match': undefined } });
+
+    expect(calls[0].init.headers as Record<string, string>).not.toHaveProperty('If-Match');
+  });
+
+  it('does not let an omitted header parameter shadow a client-wide one', async () => {
+    const calls = mockFetch([json({})]);
+
+    await createClient({ host: HOST, headers: { 'X-Trace': 'client' } })
+      .sendRequest({ url: '/x', method: 'GET', headers: { 'X-Trace': undefined } });
+
+    expect((calls[0].init.headers as Record<string, string>)['X-Trace']).toBe('client');
+  });
+});
+
+describe('credentials refused behind a status that says otherwise', () => {
+  const basic = { type: 'basic', email: 'a@b.co', apiToken: 'expired' } as const;
+
+  /** What Jira answers an anonymous-accessible endpoint with when the token is dead. */
+  function anonymous(reason = 'AUTHENTICATED_FAILED', status = 200): Response {
+    return new Response(JSON.stringify({ total: 0, isLast: true, values: [] }), {
+      status,
+      headers: { 'content-type': 'application/json', 'x-seraph-loginreason': reason },
+    });
+  }
+
+  it('throws rather than handing back the anonymous body', async () => {
+    mockFetch([anonymous()]);
+
+    const error = await createClient({ host: HOST, auth: basic })
+      .sendRequest({ url: '/rest/api/3/project/search', method: 'GET' })
+      .catch((e: unknown) => e);
+
+    expect(isAuthError(error)).toBe(true);
+    expect((error as AuthError).message).toContain('x-seraph-loginreason: AUTHENTICATED_FAILED');
+  });
+
+  it('reports the status that was actually on the wire, not 401', async () => {
+    mockFetch([anonymous()]);
+
+    const error = await createClient({ host: HOST, auth: basic })
+      .sendRequest({ url: '/x', method: 'GET' })
+      .catch((e: unknown) => e);
+
+    expect((error as AuthError).status).toBe(200);
+    expect((error as AuthError).statusText).toBe('');
+  });
+
+  it('fires on a 4xx too, where the status alone would blame the request', async () => {
+    mockFetch([anonymous('AUTHENTICATED_FAILED', 400)]);
+
+    const error = await createClient({ host: HOST, auth: basic })
+      .sendRequest({ url: '/x', method: 'POST' })
+      .catch((e: unknown) => e);
+
+    expect(isAuthError(error)).toBe(true);
+    expect((error as AuthError).status).toBe(400);
+  });
+
+  it('counts a login the instance refused outright', async () => {
+    mockFetch([anonymous('AUTHENTICATION_DENIED')]);
+
+    const error = await createClient({ host: HOST, auth: basic })
+      .sendRequest({ url: '/x', method: 'GET' })
+      .catch((e: unknown) => e);
+
+    expect(isAuthError(error)).toBe(true);
+  });
+
+  it.each(['AUTHORISATION_FAILED', 'OUT', 'OK'])('leaves %s alone — it is not a refused credential', async reason => {
+    mockFetch([anonymous(reason)]);
+
+    await expect(
+      createClient({ host: HOST, auth: basic }).sendRequest({ url: '/x', method: 'GET' }),
+    ).resolves.toEqual({ total: 0, isLast: true, values: [] });
+  });
+
+  it('leaves a client with no credentials alone', async () => {
+    mockFetch([anonymous()]);
+
+    await expect(createClient({ host: HOST }).sendRequest({ url: '/x', method: 'GET' })).resolves.toEqual({
+      total: 0,
+      isLast: true,
+      values: [],
+    });
+  });
+
+  it('does not reclassify a permission denial that carries the header', async () => {
+    mockFetch([
+      new Response('{"errorMessages":["nope"]}', {
+        status: 403,
+        headers: { 'content-type': 'application/json', 'x-seraph-loginreason': 'AUTHORISATION_FAILED' },
+      }),
+    ]);
+
+    const error = await createClient({ host: HOST, auth: basic })
+      .sendRequest({ url: '/x', method: 'GET' })
+      .catch((e: unknown) => e);
+
+    expect(isForbiddenError(error)).toBe(true);
+    expect(isAuthError(error)).toBe(false);
+  });
+
+  it('gives getAuthOn401 the same single attempt a 401 would', async () => {
+    const calls = mockFetch([anonymous(), json({ ok: true })]);
+    const getAuthOn401 = vi.fn(async () => ({ type: 'basic', email: 'a@b.co', apiToken: 'fresh' }) as const);
+
+    await expect(
+      createClient({ host: HOST, auth: basic, getAuthOn401 }).sendRequest({ url: '/x', method: 'GET' }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(getAuthOn401).toHaveBeenCalledOnce();
+    expect(calls).toHaveLength(2);
+    expect((calls[1].init.headers as Record<string, string>).Authorization).toContain(
+      Buffer.from('a@b.co:fresh').toString('base64'),
+    );
+  });
+
+  it('does not loop when the fresh credentials are refused as well', async () => {
+    const calls = mockFetch([anonymous(), anonymous()]);
+    const getAuthOn401 = vi.fn(async () => ({ type: 'basic', email: 'a@b.co', apiToken: 'also-dead' }) as const);
+
+    await expect(
+      createClient({ host: HOST, auth: basic, getAuthOn401 }).sendRequest({ url: '/x', method: 'GET' }),
+    ).rejects.toSatisfy(isAuthError);
+
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe('cancellation', () => {
+  it('hands the signal to fetch', async () => {
+    const calls = mockFetch([json({})]);
+    const controller = new AbortController();
+
+    await createClient({ host: HOST }).sendRequest({ url: '/x', method: 'GET', signal: controller.signal });
+
+    expect(calls[0].init.signal).toBe(controller.signal);
+  });
+
+  it('rethrows the reason the caller supplied, unwrapped', async () => {
+    const reason = new Error('gave up waiting');
+
+    mockFetch([reason]);
+
+    const controller = new AbortController();
+
+    controller.abort(reason);
+
+    const error = await createClient({ host: HOST })
+      .sendRequest({ url: '/x', method: 'GET', signal: controller.signal })
+      .catch((e: unknown) => e);
+
+    expect(error).toBe(reason);
+    expect(isNetworkError(error)).toBe(false);
+  });
+
+  it('cuts the retry back-off short instead of waiting it out', async () => {
+    const calls = mockFetch([networkError('ECONNRESET')]);
+    const controller = new AbortController();
+    const started = Date.now();
+
+    setTimeout(() => controller.abort(), 5);
+
+    const error = await createClient({ host: HOST, retry: { maxAttempts: 3, initialDelayMs: 30_000 } })
+      .sendRequest({ url: '/x', method: 'GET', signal: controller.signal })
+      .catch((e: unknown) => e);
+
+    expect(error).toBe(controller.signal.reason);
+    expect(calls).toHaveLength(1);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+});
+
+describe('a fetch of your own', () => {
+  it('is used in place of the global one', async () => {
+    mockFetch([json({ from: 'global' })]);
+
+    const own = vi.fn(async (_url: string, _init: RequestInit) => json({ from: 'own' }));
+
+    await expect(
+      createClient({ host: HOST, fetch: own }).sendRequest({ url: '/x', method: 'GET' }),
+    ).resolves.toEqual({ from: 'own' });
+
+    expect(own).toHaveBeenCalledOnce();
+    expect(own.mock.calls[0][0]).toBe(`${HOST}/x`);
+  });
+
+  it('sees the headers the client built', async () => {
+    const own = vi.fn(async (_url: string, _init: RequestInit) => json({}));
+
+    await createClient({
+      host: HOST,
+      auth: { type: 'bearer', token: 'pat' },
+      fetch: own,
+    }).sendRequest({ url: '/x', method: 'GET' });
+
+    const init = own.mock.calls[0][1];
+
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer pat');
   });
 });

--- a/tests/unit/core/oauth/oauth2Manager.test.ts
+++ b/tests/unit/core/oauth/oauth2Manager.test.ts
@@ -198,14 +198,14 @@ describe('cloud id resolution', () => {
     mockFetch([json(SITES)]);
     const manager = createOAuth2Manager({ accessToken: 'access' });
 
-    await expect(manager.getBaseUrl()).rejects.toThrow(/Multiple accessible Confluence resources/);
+    await expect(manager.getBaseUrl()).rejects.toThrow(/Multiple accessible resources/);
   });
 
   it('explains an empty resource list', async () => {
     mockFetch([json([])]);
     const manager = createOAuth2Manager({ accessToken: 'access' });
 
-    await expect(manager.getBaseUrl()).rejects.toThrow(/No accessible Confluence resources/);
+    await expect(manager.getBaseUrl()).rejects.toThrow(/No accessible resources/);
   });
 
   it('reports which sites were available when siteUrl matches none', async () => {

--- a/tests/unit/core/oauthServer/serverOAuth2.test.ts
+++ b/tests/unit/core/oauthServer/serverOAuth2.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createClient,
+  exchangeServerAuthorizationCode,
+  generateServerAuthorizationUrl,
+  refreshServerOAuth2Token,
+} from '#/core';
+
+interface Call {
+  url: string;
+  init: RequestInit;
+}
+
+function mockFetch(responses: Response[]): Call[] {
+  const calls: Call[] = [];
+  let index = 0;
+
+  vi.stubGlobal('fetch', (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+
+    const next = responses[Math.min(index, responses.length - 1)];
+
+    index += 1;
+
+    return Promise.resolve(next.clone());
+  });
+
+  return calls;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function tokens(accessToken: string, refreshToken?: string): Response {
+  return json({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    expires_in: 3600,
+    scope: 'READ WRITE',
+    token_type: 'bearer',
+  });
+}
+
+const HOST = 'https://jira.acme.internal';
+
+const CREDENTIALS = {
+  clientId: 'client',
+  clientSecret: 'secret',
+  refreshToken: 'r1',
+  redirectUri: 'https://app.acme.internal/callback',
+} as const;
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('Data Center authorization URL', () => {
+  it('is built on the instance, not on auth.atlassian.com', () => {
+    const url = new URL(
+      generateServerAuthorizationUrl({
+        host: HOST,
+        clientId: 'client',
+        scopes: ['READ', 'WRITE'],
+        redirectUri: 'https://app.acme.internal/callback',
+        state: 'nonce',
+      }),
+    );
+
+    expect(url.origin).toBe(HOST);
+    expect(url.pathname).toBe('/rest/oauth2/latest/authorize');
+    expect(url.searchParams.get('scope')).toBe('READ WRITE');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('state')).toBe('nonce');
+  });
+
+  it('does not double the slash when the host carries a trailing one', () => {
+    const url = generateServerAuthorizationUrl({
+      host: `${HOST}/`,
+      clientId: 'client',
+      scopes: ['READ'],
+      redirectUri: 'https://app.acme.internal/callback',
+      state: 'nonce',
+    });
+
+    expect(url.startsWith(`${HOST}/rest/oauth2/latest/authorize?`)).toBe(true);
+  });
+});
+
+describe('Data Center token endpoint', () => {
+  it('posts the code exchange form-encoded to the instance', async () => {
+    const calls = mockFetch([tokens('access')]);
+
+    const result = await exchangeServerAuthorizationCode({
+      host: HOST,
+      clientId: 'client',
+      clientSecret: 'secret',
+      code: 'auth-code',
+      redirectUri: 'https://app.acme.internal/callback',
+    });
+
+    expect(calls[0].url).toBe(`${HOST}/rest/oauth2/latest/token`);
+    expect((calls[0].init.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/x-www-form-urlencoded',
+    );
+
+    const form = new URLSearchParams(calls[0].init.body as string);
+
+    expect(form.get('grant_type')).toBe('authorization_code');
+    expect(form.get('code')).toBe('auth-code');
+    expect(result.accessToken).toBe('access');
+  });
+
+  it('sends redirect_uri on the refresh grant, which Data Center validates there too', async () => {
+    const calls = mockFetch([tokens('access', 'r2')]);
+
+    await refreshServerOAuth2Token({ host: HOST, ...CREDENTIALS });
+
+    const form = new URLSearchParams(calls[0].init.body as string);
+
+    expect(form.get('grant_type')).toBe('refresh_token');
+    expect(form.get('redirect_uri')).toBe(CREDENTIALS.redirectUri);
+  });
+
+  it('turns a non-2xx into an OAuthError carrying the body', async () => {
+    mockFetch([json({ error: 'invalid_grant' }, 400)]);
+
+    await expect(refreshServerOAuth2Token({ host: HOST, ...CREDENTIALS })).rejects.toMatchObject({
+      status: 400,
+      body: { error: 'invalid_grant' },
+    });
+  });
+});
+
+describe('a client authenticated against Data Center', () => {
+  it('keeps talking to the instance — there is no gateway to route through', async () => {
+    const calls = mockFetch([json({})]);
+
+    await createClient({
+      host: HOST,
+      auth: { type: 'oauth2Server', accessToken: 'access' },
+    }).sendRequest({ url: '/rest/api/2/myself', method: 'GET' });
+
+    expect(calls[0].url).toBe(`${HOST}/rest/api/2/myself`);
+    expect((calls[0].init.headers as Record<string, string>).Authorization).toBe('Bearer access');
+  });
+
+  it('refreshes an expired token before the request, and reports the rotated one', async () => {
+    const calls = mockFetch([tokens('fresh', 'r2'), json({})]);
+    const rotated: string[] = [];
+
+    await createClient({
+      host: HOST,
+      auth: {
+        type: 'oauth2Server',
+        accessToken: 'stale',
+        expiresAt: Date.now() - 1,
+        ...CREDENTIALS,
+        onTokenRefresh: event => void rotated.push(event.refreshToken!),
+      },
+    }).sendRequest({ url: '/rest/api/2/myself', method: 'GET' });
+
+    expect(calls[0].url).toBe(`${HOST}/rest/oauth2/latest/token`);
+    expect((calls[1].init.headers as Record<string, string>).Authorization).toBe('Bearer fresh');
+    expect(rotated).toEqual(['r2']);
+  });
+
+  it('refreshes once and retries when the instance answers 401', async () => {
+    const calls = mockFetch([json({ message: 'no' }, 401), tokens('fresh'), json({})]);
+
+    await createClient({
+      host: HOST,
+      auth: { type: 'oauth2Server', accessToken: 'stale', ...CREDENTIALS },
+    }).sendRequest({ url: '/rest/api/2/myself', method: 'GET' });
+
+    expect(calls.map(call => call.url)).toEqual([
+      `${HOST}/rest/api/2/myself`,
+      `${HOST}/rest/oauth2/latest/token`,
+      `${HOST}/rest/api/2/myself`,
+    ]);
+  });
+
+  it('refuses a half-filled refresh credential set', () => {
+    expect(() =>
+      createClient({
+        host: HOST,
+        auth: { type: 'oauth2Server', refreshToken: 'r1', clientId: 'client', clientSecret: 'secret' },
+      }),
+    ).toThrow();
+  });
+});

--- a/tests/unit/nonObjectBodies.test.ts
+++ b/tests/unit/nonObjectBodies.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createCloudClient } from '#/cloud/createCloudClient';
+import { createServiceDeskClient } from '#/serviceDesk/createServiceDeskClient';
+
+/**
+ * Four operations declare a request body that is not an object, and every one of them used to declare
+ * `Record<string, any>` instead — a shape the endpoint never accepted. Passing the right value meant casting past the
+ * declaration, so the live suite carried helpers whose only job was to launder a string into an object.
+ *
+ * A live run can only reach two of the four. `updateEntityPropertiesValue` is a Connect app-migration endpoint reached
+ * with a JWT the test tenant has no way to mint, and `attachTemporaryFile` needs an agent licence it does not hold, so
+ * neither can prove what leaves the client. That is what these pin instead: the declared shape reaches the wire whole
+ * and unwrapped, rather than being nested under a key or flattened into an object.
+ */
+
+interface Call {
+  url: string;
+  method: string;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+function mockFetch(response: unknown = {}): Call[] {
+  const calls: Call[] = [];
+
+  vi.stubGlobal('fetch', (url: string, init: RequestInit) => {
+    calls.push({
+      url,
+      method: init.method ?? 'GET',
+      body: typeof init.body === 'string' ? JSON.parse(init.body) : init.body,
+      headers: init.headers as Record<string, string>,
+    });
+
+    return Promise.resolve(
+      new Response(JSON.stringify(response), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+  });
+
+  return calls;
+}
+
+const cloud = () =>
+  createCloudClient({
+    host: 'https://acme.atlassian.net',
+    auth: { type: 'basic', email: 'a@b.co', apiToken: 'token' },
+  });
+
+const serviceDesk = () =>
+  createServiceDeskClient({
+    host: 'https://acme.atlassian.net',
+    auth: { type: 'basic', email: 'a@b.co', apiToken: 'token' },
+  });
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('an operation whose body is a lone string sends the string', () => {
+  it('addWatcher sends the account id as a JSON string, not as an object', async () => {
+    const calls = mockFetch();
+
+    await cloud().issueWatchers.addWatcher({ issueIdOrKey: 'TEST-1', body: '5b10ac8d82e05b22cc7d4ef5' });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('/rest/api/3/issue/TEST-1/watchers');
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].body).toBe('5b10ac8d82e05b22cc7d4ef5');
+  });
+
+  it('setPreference sends the value the caller gave, verbatim', async () => {
+    const calls = mockFetch();
+
+    await cloud().myself.setPreference({ key: 'jira.js.preference', body: 'stored' });
+
+    expect(calls[0].url).toContain('/rest/api/3/mypreferences');
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].body).toBe('stored');
+  });
+});
+
+describe('an operation whose body is an array sends the array', () => {
+  it('updateEntityPropertiesValue sends the properties as a top-level array', async () => {
+    const calls = mockFetch();
+
+    await cloud().appMigration.updateEntityPropertiesValue({
+      'Atlassian-Transfer-Id': 'transfer-1',
+      entityType: 'IssueProperty',
+      body: [{ entityId: 10001, key: 'app.state', value: 'migrated' }],
+    });
+
+    expect(calls[0].url).toContain('/rest/atlassian-connect/1/migration/properties/IssueProperty');
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].headers['Atlassian-Transfer-Id']).toBe('transfer-1');
+    expect(calls[0].body).toEqual([{ entityId: 10001, key: 'app.state', value: 'migrated' }]);
+  });
+
+  it('attachTemporaryFile sends the files as a top-level array', async () => {
+    const calls = mockFetch({ temporaryAttachments: [{ temporaryAttachmentId: 'temp-1', fileName: 'report.txt' }] });
+
+    const result = await serviceDesk().servicedesk.attachTemporaryFile({
+      serviceDeskId: '10',
+      body: [{ name: 'file', originalFilename: 'report.txt', contentType: 'text/plain', size: 5 }],
+    });
+
+    expect(calls[0].url).toContain('/rest/servicedeskapi/servicedesk/10/attachTemporaryFile');
+    expect(calls[0].method).toBe('POST');
+    expect(Array.isArray(calls[0].body)).toBe(true);
+    expect(calls[0].body).toEqual([
+      { name: 'file', originalFilename: 'report.txt', contentType: 'text/plain', size: 5 },
+    ]);
+    expect(result.temporaryAttachments?.[0].temporaryAttachmentId).toBe('temp-1');
+  });
+});


### PR DESCRIPTION
Second of eight, splitting #443. Base is `chore/foundation` (#445) — GitHub retargets this to `master` once that
merges, and the diff shown here is the increment alone.

Closes #406, closes #404, closes #418.

## Three requests older than 6.0

The client had no seam. `fetch` was reached as a global, a request could not be cancelled, and a response's headers
were read for one thing and thrown away.

* **Every call takes an `AbortSignal`** as an optional last argument — an operation with no parameters takes it in
  their place. It reaches `fetch` and cuts short a retry back-off that had no bound on total wall time. The abort
  reason is rethrown untouched, so `error.name === 'AbortError'` and `error === signal.reason` both hold. Nothing that
  compiled before stops compiling: the argument is optional and last. **#406**
* **The `fetch` the client calls is yours to replace.** The OAuth 2.0 token and cloud-id calls go through it too, so a
  proxy covers the whole flow rather than working until the first refresh an hour later — and a wrapper that logs
  bodies will see `client_secret`. **#404**
* **An expired API token is an error rather than an empty result. This changes behaviour.** A quarter of Jira's
  operations can be reached anonymously, and there a dead token does not fail: Jira answers as the anonymous user and
  reports the refusal only in `X-Seraph-LoginReason`. Measured on a live site, `GET /rest/api/3/project/search` with a
  dead token answers `200` and `{"total":0,"isLast":true,"values":[]}`. Code that treated that as normal now throws —
  it was reading anonymous data and calling it yours. **#418**

## Four request body types change, and that is a break

The regeneration carries specification drift that has nothing to do with the transport, and one part of it is
breaking. Four operations declared their body as `Record<string, any>` — the generator's fallback for a request body
that is not an object — and now declare what the endpoint actually reads:

| Operation | Body was | Body is |
| --- | --- | --- |
| `issueWatchers.addWatcher` | `Record<string, any>` | `string` |
| `myself.setPreference` | `Record<string, any>` | `string` |
| `appMigration.updateEntityPropertiesValue` | `Record<string, any>` | `EntityPropertyDetails[]` |
| `servicedesk.attachTemporaryFile` (Service Desk) | `Record<string, any>` | `MultipartFile[]` |

None of the four could be called correctly through the old declaration. The proof is in this repository: the live
suite carried two helpers whose only purpose was to cast a `string` into a `Record<string, unknown>`, each with a
comment saying the declaration was wrong and the fix belonged upstream. It landed upstream, and this pull request
deletes both helpers. That is also the break — a caller who was calling these correctly was casting, and the cast is
what stops compiling.

The two array bodies break more quietly, since an array satisfies `Record<string, any>`: a caller already passing the
right thing is untouched. Documented in the changelog under a new **Types** heading, matching how 6.2.0 recorded the
same class of change.

`updateEntityPropertiesValue` and `attachTemporaryFile` had no coverage of any kind, and a live run cannot give them
much — the first is addressed with a Connect app's JWT, the second needs an agent licence this tenant does not hold.
Both now have a live test pinning the typed refusal, and all four have unit coverage in
`tests/unit/nonObjectBodies.test.ts` asserting what leaves the client. That last one earns its keep: the neighbouring
`updateIssueFields` in the same generated file *does* wrap its body under a key, so "bare array, not wrapped" is a
distinction a regression could plausibly erase.

## A documentation regression this branch was carrying, fixed in the generator

The same regeneration was quietly destroying doc comments. `htmlDescriptionsToMarkdown` strips leftover HTML from
descriptions, and its catch-all was `/<\/?[a-z][^>]*>/gi` — which cannot tell a tag from a placeholder, since
`<project ID or key>` reads as an element named `project` carrying three boolean attributes.

Master is correct; this branch was not. It turned `IssueBulkMovePayload`'s format string into "The format is `,,`" and
emptied the API token out of three curl examples, leaving `-u 'email@example.com:'`. Measured across the six
specification documents, the catch-all removed 85 substrings of prose to remove 4 of markup.

Fixed in `apis-code-gen` (`fix: a description is prose, and prose is full of angle brackets`) by two conditions, since
neither is sufficient alone: only names of real HTML elements are recognised, and no replacement reaches inside a code
span. On the current documents that is exact — 4 removals, all markup, nothing else touched — and six new tests pin
it. Regenerating with the fix changes exactly four files in this tree, all of them restorations, so the branch no
longer regresses master.

## Two things worth flagging in review

**Data Center authentication ships here, ahead of its surface.** `basic` gains a `username`/`password` branch and
`oauth2Server` arrives with `src/core/oauthServer/`. They belong to the Data Center pull request further up this
stack, and they are here anyway: `src/core` is generated whole, and `createClient` branches on the auth strategy, so
lifting them out would mean hand-writing a core state the generator does not produce — which CONTRIBUTING says
disappears on the next regeneration. Taking a subset of the generated tree is safe; inventing an intermediate one is
not. Nothing in this pull request answers to either strategy yet, and the changelog says so.

**`getTenantContext` was lifted out**, because there it *was* a clean subset: one file, one export line, no other
reference in `src/core`. It arrives with Teams, which is what needs it.

## Verified

`typecheck`, `lint`, `test` (236 passing, up from 203), `build`, `check:browser`, `check:consumers` all pass locally.

`docs:api` now builds **with no warnings at all** — the pre-existing one flagged in #445, a Service Management
description linking `./#api-…`, is corrected by this regeneration as predicted. 4377 pages.

Live coverage for the new behaviour: `tests/live/cloud/abort.test.ts` and `tests/live/cloud/auth.test.ts`, plus 29 new
unit tests across `createClient` and the server OAuth 2.0 manager.

